### PR TITLE
Build Distance & Build Related Bug Fixes

### DIFF
--- a/Assets/Content/Items/Functional/Tools/TableConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/TableConstructer.cs
@@ -24,7 +24,36 @@ namespace SS3D.Content.Items.Functional.Tools
         {
             targetTile = Event.target.GetComponentInParent<TileObject>();
 
-            return Event.tool == gameObject && targetTile != null && targetTile.Tile.turf?.isWall == false;
+            // Note: I didn't write the failure conditions over here, just rewrote in a different way.
+            // Not quite sure what the second one does.
+
+            // If target tile exists.
+            if (targetTile == null)
+            {
+                return false;
+            }
+
+            if (Event.tool != gameObject)
+            {
+                return false;
+            }
+
+            // Make sure there's not a wall on the turf.
+            if (targetTile.Tile.turf?.isWall == true)
+            {
+                return false;
+            }
+
+            var player = transform.root;
+            if (player != gameObject)
+            {
+                if (Vector3.Distance(player.transform.position, targetTile.transform.position) > buildDistance)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public void Interact()
@@ -33,15 +62,6 @@ namespace SS3D.Content.Items.Functional.Tools
             var tileManager = FindObjectOfType<TileManager>();
 
             var tile = targetTile.Tile;
-
-            // The player using this item.
-            var player = transform.root;
-
-            // Cancel interaction if the target tile is outside the build range.
-            if (Vector3.Distance(player.transform.position, targetTile.transform.position) > buildDistance)
-            {
-                return;
-            }
 
             if (tile.fixture != null) // If there is a fixture on the place
             {

--- a/Assets/Content/Items/Functional/Tools/TableConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/TableConstructer.cs
@@ -18,7 +18,7 @@ namespace SS3D.Content.Items.Functional.Tools
         public string Name => ShouldDeconstruct ? "Deconstruct Table" : "Construct Table";
 
         // The distance in which to allow constructing tables.
-        public float buildDistance = 3f;
+        public float buildDistance = 1.5f;
 
         public bool CanInteract()
         {
@@ -33,7 +33,14 @@ namespace SS3D.Content.Items.Functional.Tools
                 return false;
             }
 
+            // Dont construct if picking up the item.
             if (Event.tool != gameObject)
+            {
+                return false;
+            }
+
+            // Range check
+            if (Vector3.Distance(Event.Player.transform.position, Event.target.transform.position) > 3f)
             {
                 return false;
             }
@@ -42,15 +49,6 @@ namespace SS3D.Content.Items.Functional.Tools
             if (targetTile.Tile.turf?.isWall == true)
             {
                 return false;
-            }
-
-            var player = transform.root;
-            if (player != gameObject)
-            {
-                if (Vector3.Distance(player.transform.position, targetTile.transform.position) > buildDistance)
-                {
-                    return false;
-                }
             }
 
             return true;

--- a/Assets/Content/Items/Functional/Tools/TableConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/TableConstructer.cs
@@ -31,10 +31,17 @@ namespace SS3D.Content.Items.Functional.Tools
 
             var tile = targetTile.Tile;
 
-            if (tile.fixture == tableToConstruct) // Deconstruct
-                tile.fixture = null;
-            else // Construct
-                tile.fixture = tableToConstruct;
+            if (tile.fixture != null) // If there is a fixture on the place
+            {
+                if (tile.fixture == tableToConstruct) // If the fixture is a table
+                {
+                    tile.fixture = null; // Deconstruct
+                }
+            }
+            else // If there is no fixture on place
+            {
+                tile.fixture = tableToConstruct; // Construct
+            }
 
             // TODO: Make an easier way of doing this.
             tile.subStates = new object[2];

--- a/Assets/Content/Items/Functional/Tools/TableConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/TableConstructer.cs
@@ -17,6 +17,9 @@ namespace SS3D.Content.Items.Functional.Tools
         public InteractionEvent Event { get; set; }
         public string Name => ShouldDeconstruct ? "Deconstruct Table" : "Construct Table";
 
+        // The distance in which to allow constructing tables.
+        public float buildDistance = 3f;
+
         public bool CanInteract()
         {
             targetTile = Event.target.GetComponentInParent<TileObject>();
@@ -30,6 +33,15 @@ namespace SS3D.Content.Items.Functional.Tools
             var tileManager = FindObjectOfType<TileManager>();
 
             var tile = targetTile.Tile;
+
+            // The player using this item.
+            var player = transform.root;
+
+            // Cancel interaction if the target tile is outside the build range.
+            if (Vector3.Distance(player.transform.position, targetTile.transform.position) > buildDistance)
+            {
+                return;
+            }
 
             if (tile.fixture != null) // If there is a fixture on the place
             {

--- a/Assets/Content/Items/Functional/Tools/TableConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/TableConstructer.cs
@@ -40,7 +40,7 @@ namespace SS3D.Content.Items.Functional.Tools
             }
 
             // Range check
-            if (Vector3.Distance(Event.Player.transform.position, Event.target.transform.position) > 3f)
+            if (Vector3.Distance(Event.Player.transform.position, Event.target.transform.position) > 1.5f)
             {
                 return false;
             }

--- a/Assets/Content/Items/Functional/Tools/WallConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/WallConstructer.cs
@@ -32,6 +32,12 @@ namespace SS3D.Content.Items.Functional.Tools
             var tileManager = FindObjectOfType<TileManager>();
 
             var tile = targetTile.Tile;
+
+            if (tile.fixture != null) // Prevent construction if the tile is occupied by a fixture. 
+            {
+                return;
+            }
+
             if (tile.turf?.isWall == true) // Deconstruct
                 tile.turf = floorToConstruct;
             else // Construct

--- a/Assets/Content/Items/Functional/Tools/WallConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/WallConstructer.cs
@@ -19,6 +19,9 @@ namespace SS3D.Content.Items.Functional.Tools
         public InteractionEvent Event { get; set; }
         public string Name => ShouldDeconstruct ? "Deconstruct Wall" : "Construct Wall";
 
+        // The distance in which to allow constructing walls
+        public float buildDistance = 3f;
+
         public bool CanInteract()
         {
             targetTile = Event.target.GetComponentInParent<TileObject>();
@@ -32,6 +35,15 @@ namespace SS3D.Content.Items.Functional.Tools
             var tileManager = FindObjectOfType<TileManager>();
 
             var tile = targetTile.Tile;
+
+            // The player using this item.
+            var player = transform.root;
+
+            // Cancel interaction if the target tile is outside the build range.
+            if (Vector3.Distance(player.transform.position, targetTile.transform.position) > buildDistance)
+            {
+                return;
+            }
 
             if (tile.fixture != null) // Prevent construction if the tile is occupied by a fixture. 
             {

--- a/Assets/Content/Items/Functional/Tools/WallConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/WallConstructer.cs
@@ -39,7 +39,7 @@ namespace SS3D.Content.Items.Functional.Tools
             }
 
             // Range check
-            if (Vector3.Distance(Event.Player.transform.position, Event.target.transform.position) > 3f)
+            if (Vector3.Distance(Event.Player.transform.position, Event.target.transform.position) > 1.5f)
             {
                 return false;
             }

--- a/Assets/Content/Items/Functional/Tools/WallConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/WallConstructer.cs
@@ -26,7 +26,41 @@ namespace SS3D.Content.Items.Functional.Tools
         {
             targetTile = Event.target.GetComponentInParent<TileObject>();
 
-            return Event.tool == gameObject && targetTile != null;
+            // Note: I didn't write the failure conditions over here, just rewrote in a different way.
+            // Not quite sure what the second one does.
+
+            // If target tile exists.
+            if (targetTile == null)
+            {
+                return false;
+            }
+
+            if (Event.tool != gameObject)
+            {
+                return false;
+            }
+
+            var tile = targetTile.Tile;
+
+            if (tile.fixture != null) // Prevent construction if the tile is occupied by a fixture. 
+            {
+                return false;
+            }
+
+
+            // The player using this item.
+            var player = transform.root;
+            if (player != gameObject) // Check if there even is a player.
+            {
+                // Cancel interaction if the target tile is outside the build range.
+                if (Vector3.Distance(player.transform.position, targetTile.transform.position) > buildDistance)
+                {
+                    return false;
+                }
+            }
+
+
+            return true;
         }
 
         public void Interact()
@@ -35,20 +69,6 @@ namespace SS3D.Content.Items.Functional.Tools
             var tileManager = FindObjectOfType<TileManager>();
 
             var tile = targetTile.Tile;
-
-            // The player using this item.
-            var player = transform.root;
-
-            // Cancel interaction if the target tile is outside the build range.
-            if (Vector3.Distance(player.transform.position, targetTile.transform.position) > buildDistance)
-            {
-                return;
-            }
-
-            if (tile.fixture != null) // Prevent construction if the tile is occupied by a fixture. 
-            {
-                return;
-            }
 
             if (tile.turf?.isWall == true) // Deconstruct
                 tile.turf = floorToConstruct;

--- a/Assets/Content/Items/Functional/Tools/WallConstructer.cs
+++ b/Assets/Content/Items/Functional/Tools/WallConstructer.cs
@@ -20,14 +20,11 @@ namespace SS3D.Content.Items.Functional.Tools
         public string Name => ShouldDeconstruct ? "Deconstruct Wall" : "Construct Wall";
 
         // The distance in which to allow constructing walls
-        public float buildDistance = 3f;
+        public float buildDistance = 1.5f;
 
         public bool CanInteract()
         {
             targetTile = Event.target.GetComponentInParent<TileObject>();
-
-            // Note: I didn't write the failure conditions over here, just rewrote in a different way.
-            // Not quite sure what the second one does.
 
             // If target tile exists.
             if (targetTile == null)
@@ -35,30 +32,27 @@ namespace SS3D.Content.Items.Functional.Tools
                 return false;
             }
 
+            //Dont construct if picking up the item.
             if (Event.tool != gameObject)
             {
                 return false;
             }
 
-            var tile = targetTile.Tile;
-
-            if (tile.fixture != null) // Prevent construction if the tile is occupied by a fixture. 
+            // Range check
+            if (Vector3.Distance(Event.Player.transform.position, Event.target.transform.position) > 3f)
             {
                 return false;
             }
 
 
-            // The player using this item.
-            var player = transform.root;
-            if (player != gameObject) // Check if there even is a player.
-            {
-                // Cancel interaction if the target tile is outside the build range.
-                if (Vector3.Distance(player.transform.position, targetTile.transform.position) > buildDistance)
-                {
-                    return false;
-                }
-            }
+            //The target tile's.... Tile.
+            var tile = targetTile.Tile;
 
+            // Prevent construction if the tile is occupied by a fixture. 
+            if (tile.fixture != null) 
+            {
+                return false;
+            }
 
             return true;
         }

--- a/Assets/Content/Items/Functional/Tools/crowbar.prefab
+++ b/Assets/Content/Items/Functional/Tools/crowbar.prefab
@@ -50,7 +50,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   serverOnly: 0
-  m_AssetId: 7becfab153276864f9fc7636a839d837
+  m_AssetId: 
   m_SceneId: 0
 --- !u!33 &5851963053719667412
 MeshFilter:
@@ -74,6 +74,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -140,9 +141,9 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 3
+  serializedVersion: 4
   m_Convex: 1
-  m_CookingOptions: 14
+  m_CookingOptions: 30
   m_Mesh: {fileID: 8918077550557095614, guid: 8f2f2c0dc3e66ab4fafad982b8bea8ab, type: 3}
 --- !u!114 &7861503108559545368
 MonoBehaviour:
@@ -158,3 +159,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   wallToConstruct: {fileID: 11400000, guid: cede127f2ecc46345ab2c1fad9cbd507, type: 2}
   floorToConstruct: {fileID: 11400000, guid: 9dda7bed5d66999498b68b9b7517499d, type: 2}
+  buildDistance: 3

--- a/Assets/Content/Systems/Interactions/Drops.cs
+++ b/Assets/Content/Systems/Interactions/Drops.cs
@@ -17,6 +17,8 @@ namespace SS3D.Content.Systems.Interactions
     {
         public override string Name => "Drop";
 
+        public float dropDistance = 1.5f;
+
         public override bool CanInteract()
         {
             // An item can be dropped on a floor or any fixture attached to a floor.
@@ -26,7 +28,23 @@ namespace SS3D.Content.Systems.Interactions
 
             hands = Event.Player.GetComponent<Hands>();
 
-            return hands.GetItemInHand() != null && isFloor;
+            if (hands.GetItemInHand() == null)
+            {
+                return false;
+            }
+
+            if (!isFloor)
+            {
+                return false;
+            }
+
+            // Range check
+            if (Vector3.Distance(Event.Player.transform.position, Event.target.transform.position) > dropDistance)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public override void Interact()

--- a/Assets/Content/Systems/Interactions/Pickup.cs
+++ b/Assets/Content/Systems/Interactions/Pickup.cs
@@ -17,11 +17,28 @@ namespace SS3D.Content.Systems.Interactions
     {
         public override string Name => "Pick Up";
 
+        public float pickupDistance = 1.5f;
+
         public override bool CanInteract()
         {
-            // TODO: Should also be within certain range.
-            return Event.target.GetComponent<Item>() != null
-                && Event.Player.GetComponent<Hands>().GetItemInHand() == null;
+            // Below are some failure conditions for interactions:
+
+            if (Event.target.GetComponent<Item>() == null)
+            {
+                return false;
+            }
+
+            if (Event.Player.GetComponent<Hands>().GetItemInHand() != null)
+            {
+                return false;
+            }
+
+            if (Vector3.Distance(Event.Player.transform.position, Event.target.transform.position) > pickupDistance)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public override void Interact()


### PR DESCRIPTION
## Summary

Add a build distance to the Crowbar and Wrench so they can only be used under the distance specified in the inspector, which defaults to 1.5f.

Fix a bug where you could place walls over floor fixtures. (Fixes #170 )
Fix a bug where you could place tables over doors, and essentially delete them.

## Changes to Files

WallConstructer.cs and TableConstructer.cs recieved some more checks before interacting
crowbar.prefab changed because unity decided to change it. Basicly it adds the new inspector value for the crowbar just in case it doesn't default to 3f (Which happened during my playtesting)

## Technical Notes

Both WallConstructer.cs and TableConstructer.cs recieved new checks before defining a new tile.
The inspector should default the buildrange to 3f. If you use buildrange 0 it will be a useless item.