### PR TITLE
Ensure items get placed in same rotation as pickup

### DIFF
--- a/Assets/Content/Systems/Interactions/Drops.cs
+++ b/Assets/Content/Systems/Interactions/Drops.cs
@@ -50,9 +50,7 @@ namespace SS3D.Content.Systems.Interactions
         public override void Interact()
         {
             hands.PlaceHeldItem(
-                Event.at.point + Event.at.normal * 0.1f,
-                // Item is rotated to point in direction of interaction from player
-                Quaternion.LookRotation(Event.Player.transform.up, Event.at.point - Event.Player.transform.position)
+                Event.at.point + Event.at.normal * 0.1f
             );
         }
 

--- a/Assets/Engine/Inventory/Extensions/Hands.cs
+++ b/Assets/Engine/Inventory/Extensions/Hands.cs
@@ -41,10 +41,10 @@ namespace SS3D.Engine.Inventory.Extensions
             if (GetItemInHand() == null) return;
 
             var transform = GetItemInHand().transform;
-            inventory.PlaceItem(ContainerObject, HeldSlot, transform.position, transform.rotation);
+            inventory.PlaceItem(ContainerObject, HeldSlot, transform.position);
         }
         [Server]
-        public void PlaceHeldItem(Vector3 position, Quaternion rotation) => inventory.PlaceItem(ContainerObject, HeldSlot, position, rotation);
+        public void PlaceHeldItem(Vector3 position) => inventory.PlaceItem(ContainerObject, HeldSlot, position);
         [Server]
         public void DestroyHeldItem() => inventory.DestroyItem(ContainerObject, HeldSlot);
 

--- a/Assets/Engine/Inventory/Extensions/WearableContainer.cs
+++ b/Assets/Engine/Inventory/Extensions/WearableContainer.cs
@@ -10,6 +10,15 @@ namespace SS3D.Engine.Inventory.Extensions
     public class WearableContainer : Container
     {
         public GameObject[] displays;
+        private Quaternion[] originalRotations;
+
+        public void Start()
+        {
+            if (displays != null)
+            {
+                originalRotations = new Quaternion[displays.Length];
+            }
+        }
 
         // Override add item so any changes refresh the interaction system's tool
         public override void AddItem(int index, GameObject item)
@@ -63,6 +72,13 @@ namespace SS3D.Engine.Inventory.Extensions
             if (item.GetComponent<NetworkTransform>())
                 item.GetComponent<NetworkTransform>().enabled = false;
 
+            // Back up old rotation
+            if (originalRotations != null)
+            {
+                originalRotations[index] = item.transform.rotation;
+            }
+            
+            
             item.transform.SetParent(displays[index].transform, false);
             item.transform.localPosition = new Vector3();
             item.transform.localRotation = new Quaternion();
@@ -92,6 +108,12 @@ namespace SS3D.Engine.Inventory.Extensions
                 item.GetComponent<NetworkTransform>().enabled = true;
 
             item.transform.SetParent(null);
+            
+            // Restore old rotation
+            if (originalRotations != null)
+            {
+                item.transform.rotation = originalRotations[index];
+            }
 
             if (isServer)
                 RpcUnplaceItem(index, item);

--- a/Assets/Engine/Inventory/Inventory.cs
+++ b/Assets/Engine/Inventory/Inventory.cs
@@ -215,6 +215,11 @@ namespace SS3D.Engine.Inventory
         private void Spawn(GameObject item, Vector3 position)
         {
             item.transform.position = position;
+            item.transform.LookAt(transform);
+            Vector3 transformRotation = item.transform.rotation.eulerAngles;
+            transformRotation.x = 0f;
+            transformRotation.z = 0f;
+            item.transform.rotation = Quaternion.Euler(transformRotation);
             item.SetActive(true);
 
             if (isServer)

--- a/Assets/Engine/Inventory/Inventory.cs
+++ b/Assets/Engine/Inventory/Inventory.cs
@@ -91,10 +91,10 @@ namespace SS3D.Engine.Inventory
          * Place an item from a container into the world.
          */
         [Server]
-        public void PlaceItem(GameObject fromContainer, int fromIndex, Vector3 location, Quaternion rotation)
+        public void PlaceItem(GameObject fromContainer, int fromIndex, Vector3 location)
         {
             GameObject item = fromContainer.GetComponent<Container>().RemoveItem(fromIndex);
-            Spawn(item, location, rotation);
+            Spawn(item, location);
         }
 
         /**
@@ -150,7 +150,7 @@ namespace SS3D.Engine.Inventory
         [Command]
         public void CmdAddItemToDefault(GameObject item, GameObject toContainer) => AddItem(item, toContainer);
         [Command]
-        public void CmdPlaceItem(GameObject fromContainer, int fromIndex, Vector3 location, Quaternion rotation) => PlaceItem(fromContainer, fromIndex, location, rotation);
+        public void CmdPlaceItem(GameObject fromContainer, int fromIndex, Vector3 location) => PlaceItem(fromContainer, fromIndex, location);
         [Command]
         public void CmdMoveItem(GameObject fromContainer, int fromIndex, GameObject toContainer, int toIndex) => MoveItem(fromContainer, fromIndex, toContainer, toIndex);
         [Command]
@@ -195,8 +195,6 @@ namespace SS3D.Engine.Inventory
          */
         private void Despawn(GameObject item)
         {
-            // If on server we can do things to the transform
-            item.transform.SetPositionAndRotation(new Vector3(), new Quaternion());
             item.SetActive(false);
 
             if (isServer)
@@ -214,20 +212,20 @@ namespace SS3D.Engine.Inventory
          * Graphically adds the item back into the world (for server and all clients).
          * Must be called from server initially
          */
-        private void Spawn(GameObject item, Vector3 position, Quaternion rotation = new Quaternion())
+        private void Spawn(GameObject item, Vector3 position)
         {
-            item.transform.SetPositionAndRotation(position, rotation);
+            item.transform.position = position;
             item.SetActive(true);
 
             if (isServer)
-                RpcSpawn(item, position, rotation);
+                RpcSpawn(item, position);
         }
 
         [ClientRpc]
-        private void RpcSpawn(GameObject item, Vector3 position, Quaternion rotation)
+        private void RpcSpawn(GameObject item, Vector3 position)
         {
             if (!isServer) // Silly thing to prevent looping when server and client are one
-                Spawn(item, position, rotation);
+                Spawn(item, position);
         }
 
         // All objects containing containers usable by this player

--- a/Assets/Engine/Inventory/UI/UIInventory.cs
+++ b/Assets/Engine/Inventory/UI/UIInventory.cs
@@ -92,7 +92,7 @@ namespace SS3D.Engine.Inventory.UI
             if(!found)
                 return;
         
-            inventory.CmdPlaceItem(from.gameObject, fromSlot, hit.point + hit.normal * 0.2f, new Quaternion());
+            inventory.CmdPlaceItem(from.gameObject, fromSlot, hit.point + hit.normal * 0.2f);
         }
 
         private void OnInventoryChange()


### PR DESCRIPTION
### Summary

Placed items have the same rotation as when they were picked up.

## Fixes

Fixes #231 