### PR TITLE
Camera restart fix

### DIFF
--- a/Assets/Content/Systems/Player/CameraRegister.cs
+++ b/Assets/Content/Systems/Player/CameraRegister.cs
@@ -9,14 +9,12 @@ namespace SS3D.Content.Systems.Player
     {
         void Start()
         {
-            Debug.Log(isLocalPlayer);
-            if(!isLocalPlayer)
+            if(isLocalPlayer)
             {
-                return;
+                CameraFollow cameraFollow = Camera.main.GetComponent<CameraFollow>();
+                cameraFollow.SetTarget(gameObject);
+                cameraFollow.enabled = true;
             }
-            CameraFollow cameraFollow = Camera.main.GetComponent<CameraFollow>();
-            cameraFollow.SetTarget(gameObject);
-            cameraFollow.enabled = true;
         }
     }
 }

--- a/Assets/Content/Systems/Player/CameraRegister.cs
+++ b/Assets/Content/Systems/Player/CameraRegister.cs
@@ -7,8 +7,13 @@ namespace SS3D.Content.Systems.Player
 {
     public class CameraRegister : NetworkBehaviour
     {
-        public override void OnStartLocalPlayer()
+        void Start()
         {
+            Debug.Log(isLocalPlayer);
+            if(!isLocalPlayer)
+            {
+                return;
+            }
             CameraFollow cameraFollow = Camera.main.GetComponent<CameraFollow>();
             cameraFollow.SetTarget(gameObject);
             cameraFollow.enabled = true;


### PR DESCRIPTION
Fixes camera desync on restart
### Summary
OnStartLocalPlayer() gets called when first connecting to the server, but not on scene change or on disable/enable of the player. This uses Start() instead and an isLocalPlayer check to get around that.
### Fixes
Fixes #276.