### PR TITLE
Tone and color

### DIFF
--- a/Assets/Content/World/PostProcessing/MKI.asset
+++ b/Assets/Content/World/PostProcessing/MKI.asset
@@ -119,22 +119,22 @@ MonoBehaviour:
     value: {fileID: 0}
     defaultState: 1
   tonemapper:
-    overrideState: 0
-    value: 0
+    overrideState: 1
+    value: 3
   toneCurveToeStrength:
-    overrideState: 0
-    value: 0
+    overrideState: 1
+    value: 0.031
   toneCurveToeLength:
-    overrideState: 0
-    value: 0.5
+    overrideState: 1
+    value: 1
   toneCurveShoulderStrength:
-    overrideState: 0
-    value: 0
+    overrideState: 1
+    value: 0.901
   toneCurveShoulderLength:
-    overrideState: 0
-    value: 0.5
+    overrideState: 1
+    value: 1.31
   toneCurveShoulderAngle:
-    overrideState: 0
+    overrideState: 1
     value: 0
   toneCurveGamma:
     overrideState: 0
@@ -147,11 +147,11 @@ MonoBehaviour:
     overrideState: 0
     value: 1
   temperature:
-    overrideState: 0
-    value: 0
+    overrideState: 1
+    value: -5
   tint:
-    overrideState: 0
-    value: 0
+    overrideState: 1
+    value: 5
   colorFilter:
     overrideState: 0
     value: {r: 1, g: 1, b: 1, a: 1}
@@ -201,11 +201,11 @@ MonoBehaviour:
     overrideState: 0
     value: {x: 1, y: 1, z: 1, w: 0}
   gamma:
-    overrideState: 0
-    value: {x: 1, y: 1, z: 1, w: 0}
+    overrideState: 1
+    value: {x: 1, y: 1, z: 1, w: -0.0153374225}
   gain:
-    overrideState: 0
-    value: {x: 1, y: 1, z: 1, w: 0}
+    overrideState: 1
+    value: {x: 1, y: 1, z: 1, w: 0.39877293}
   masterCurve:
     overrideState: 0
     value:


### PR DESCRIPTION
### Summary

Fixes tone-mapping and color-grading, which weren't properly applied during the lighting update.
Makes the game feel more like classic tgstation.

<!-- Follow with a more concise explanation of the change here. -->

<!-- What features does this change include/not include? -->

## Pictures
No tone and color (old):
![current2](https://user-images.githubusercontent.com/38957910/82254359-530f5500-9918-11ea-9425-7b2ea741c5e3.PNG)

With tone and color (this PR):
![cool2](https://user-images.githubusercontent.com/38957910/82254414-691d1580-9918-11ea-9aea-66668b5075e4.PNG)
:
