### PR TITLE
Remove left-over meta files from recent asset retraction

### DIFF
--- a/Assets/Art/Animations/World.meta
+++ b/Assets/Art/Animations/World.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 8edc9c72d92e3a3418cda926ea60a401
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Art/Models/VFX.meta
+++ b/Assets/Art/Models/VFX.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: fba6f643188f48e4f920ff11237ba812
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Art/Models/VFX/Generic.meta
+++ b/Assets/Art/Models/VFX/Generic.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 9775242adc550704ab71f82760b9cdbe
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Art/Shaders/VFX.meta
+++ b/Assets/Art/Shaders/VFX.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 4c04ec1691d2fa646898adce5745a935
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Art/Shaders/World.meta
+++ b/Assets/Art/Shaders/World.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: ac123e185314fed4683a4d3328b1d2ec
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Content/World/VFX/Water.meta
+++ b/Assets/Content/World/VFX/Water.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 05eee7003d53864439b1c03f613c2dfb
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Content/World/VFX/Weapons.meta
+++ b/Assets/Content/World/VFX/Weapons.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 09b7d6374a10e85478ce528b8420d510
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
This PR removes some left-over .meta files from the recent asset retraction.