### PR TITLE
Fix interaction keys

### DIFF
--- a/Assets/Engine/Interactions/InteractionHandler.cs
+++ b/Assets/Engine/Interactions/InteractionHandler.cs
@@ -56,23 +56,37 @@ namespace SS3D.Engine.Interactions
                     Destroy(activeMenu.gameObject);
                 }
 
-                var ray = Camera.main.ScreenPointToRay(Input.mousePosition);
-                var viableInteractions = GetViableInteractions(ray, out InteractionEvent interactionEvent);
-                if (viableInteractions.Select(x => x.Interaction).ToList().Count > 0)
+                if (Input.GetButton("Alternate"))
                 {
-                    //Debug.LogError(viableInteractions.Count);
-                    // Create a menu that will run the given action when clicked
-                    var obj = Instantiate(menuPrefab, transform.root.transform);
-                    activeMenu = obj.GetComponentInChildren<UI.RadialInteractionMenuUI>();
-
-                    activeMenu.Position = Input.mousePosition;
-                    activeMenu.Event = interactionEvent;
-                    activeMenu.Interactions = viableInteractions.Select(x => x.Interaction).ToList();
-                    activeMenu.onSelect = interaction =>
+                    Hands hands = GetComponent<Hands>();
+                    if (hands != null )
                     {
-                        CmdRunInteraction(ray, viableInteractions.FindIndex(x => x.Interaction == interaction),
+                        Item item = hands.Container.GetItem(hands.HeldSlot);
+                        if (item != null)
+                        {
+                            InteractInHand(item.gameObject, gameObject, true);
+                        }
+                    }
+                }
+                else
+                {
+                    var ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+                    var viableInteractions = GetViableInteractions(ray, out InteractionEvent interactionEvent);
+                    if (viableInteractions.Select(x => x.Interaction).ToList().Count > 0)
+                    {
+                        // Create a menu that will run the given action when clicked
+                        var obj = Instantiate(menuPrefab, transform.root.transform);
+                        activeMenu = obj.GetComponentInChildren<UI.RadialInteractionMenuUI>();
+
+                        activeMenu.Position = Input.mousePosition;
+                        activeMenu.Event = interactionEvent;
+                        activeMenu.Interactions = viableInteractions.Select(x => x.Interaction).ToList();
+                        activeMenu.onSelect = interaction =>
+                        {
+                            CmdRunInteraction(ray, viableInteractions.FindIndex(x => x.Interaction == interaction),
                                 interaction.GetName(interactionEvent));
-                    };
+                        };
+                    }
                 }
             }
 
@@ -116,7 +130,6 @@ namespace SS3D.Engine.Interactions
             interactionEvent.Target = entries[0].Target;
             if (showMenu && entries.Select(x => x.Interaction).ToList().Count > 0)
             {
-                //Debug.LogError(entries[0]);
                 var obj = Instantiate(menuPrefab, transform.root.transform);
                 activeMenu = obj.GetComponentInChildren<UI.RadialInteractionMenuUI>();
 

--- a/Assets/Engine/Interactions/InteractionHandler.cs
+++ b/Assets/Engine/Interactions/InteractionHandler.cs
@@ -133,7 +133,9 @@ namespace SS3D.Engine.Interactions
                 var obj = Instantiate(menuPrefab, transform.root.transform);
                 activeMenu = obj.GetComponentInChildren<UI.RadialInteractionMenuUI>();
 
-                activeMenu.Position = Input.mousePosition;
+                Vector3 mousePosition = Input.mousePosition;
+                mousePosition.y = Mathf.Max(obj.transform.GetChild(0).GetComponent<RectTransform>().rect.height, mousePosition.y);
+                activeMenu.Position = mousePosition;
                 activeMenu.Event = interactionEvent;
                 activeMenu.Interactions = entries.Select(x => x.Interaction).ToList();
                 activeMenu.onSelect = interaction =>

--- a/Assets/Engine/Interactions/UI/RadialMenuInteraction/PetalsManager.cs
+++ b/Assets/Engine/Interactions/UI/RadialMenuInteraction/PetalsManager.cs
@@ -111,7 +111,7 @@ public class PetalsManager : MonoBehaviour
         Petal newPetal = Instantiate(petalPrefab, petalParent.transform).GetComponent<Petal>();
         newPetal.iconImage.texture = icon.texture;
         newPetal.name = name;
-        newPetal.transform.parent = petalParent.transform;
+        newPetal.transform.SetParent(petalParent.transform, false);
         folder.AddPetal(newPetal);
         folder.isDirty = true;
         return (newPetal);

--- a/Assets/Engine/Inventory/UI/UIGroupedContainers.cs
+++ b/Assets/Engine/Inventory/UI/UIGroupedContainers.cs
@@ -96,7 +96,7 @@ namespace SS3D.Engine.Inventory.UI
 
             if (handler != null && hands != null && hands.GetActiveTool() != null && item != null && (slotType == Container.SlotType.LeftHand || slotType == Container.SlotType.RightHand))
             {
-                handler.InteractInHand(item, playerObject);
+                handler.InteractInHand(item, playerObject, button == PointerEventData.InputButton.Right);
                 return;
             }
 

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -490,9 +490,25 @@ InputManager:
     descriptiveName: Activate Item
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: left alt
+    positiveButton: 
     altNegativeButton: 
     altPositiveButton: z
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 5
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Alternate
+    descriptiveName: Alternate action
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: left alt
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 1000
     dead: 0.001
     sensitivity: 1000


### PR DESCRIPTION
### Summary

Fixes the radial menu shortcuts. Alt no longer executes the first interaction, making it possible to use the alt + right click menu. It is also possible to right click an item in hand.
Executing the first interaction on the selected item is Z.

## Fixes

Fixes #355 
