### PR TITLE
Removes interaction opacity when not selected

### DIFF
--- a/Assets/Content/Graphics/UI/Interaction/RadialMenuUI/Classic/RadialMenuList.prefab
+++ b/Assets/Content/Graphics/UI/Interaction/RadialMenuUI/Classic/RadialMenuList.prefab
@@ -58,7 +58,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.6901961, g: 0.6901961, b: 0.6901961, a: 0.27058825}
+  m_Color: {r: 0.6901961, g: 0.6901961, b: 0.6901961, a: 0}
   m_RaycastTarget: 1
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/Engine/Interactions/UI/RadialInteractionMenuUI.cs
+++ b/Assets/Engine/Interactions/UI/RadialInteractionMenuUI.cs
@@ -34,6 +34,10 @@ namespace SS3D.Engine.Interactions.UI
         public float mouseDistance;
         public Sprite missingIcon;
 
+        private Image indicatorImage;
+        private Color indicatorBaseColor;
+        private Color indicatorOffColor;
+
         // Current selected object
         GameObject obj = null;
 
@@ -83,6 +87,10 @@ namespace SS3D.Engine.Interactions.UI
             else
                 contextMenuManagerInstance = this;
             parentCanvas = GetComponentInParent<Canvas>();
+
+            indicatorImage = indicator.GetComponent<Image>();
+            indicatorOffColor = indicatorImage.color;
+            indicatorBaseColor = new Color(indicatorOffColor.r, indicatorOffColor.g, indicatorOffColor.b, .69f);
         }
         private void Update()
         {
@@ -137,6 +145,8 @@ namespace SS3D.Engine.Interactions.UI
                 interactionName.text = null;
                 objectName.text = null;
             }
+
+            indicatorImage.color = (selectedPetal == null) ? indicatorOffColor : indicatorBaseColor;
         }
 
         private void UpdateInteractions()


### PR DESCRIPTION
When there is no interaction selected, the selection wheel will not appear

## Fixes
Fixes #362 
