### PR TITLE
Fix interaction player raycast

### DIFF
--- a/Assets/Content/Creatures/Human/Human.prefab
+++ b/Assets/Content/Creatures/Human/Human.prefab
@@ -350,7 +350,7 @@ MonoBehaviour:
   syncInterval: 0.1
   selectionMask:
     serializedVersion: 2
-    m_Bits: 1148723
+    m_Bits: 1115955
   menuPrefab: {fileID: 6380575431912782132, guid: 69782ec738cf5ad40809cf5f548be89a,
     type: 3}
 --- !u!114 &666907628477534858


### PR DESCRIPTION
### Summary

Makes the interaction raycast ignore the player movement collider.

## Pictures/Videos

![image](https://user-images.githubusercontent.com/26800509/85801383-09016680-b743-11ea-961f-58e1bc0030b7.png)

## Fixes

Fixes #352
