### PR TITLE
Add obstacle support to construction

### DIFF
--- a/Assets/Content/Items/Functional/Tools/Generic/Crowbar.cs
+++ b/Assets/Content/Items/Functional/Tools/Generic/Crowbar.cs
@@ -14,6 +14,7 @@ namespace SS3D.Content.Items.Functional.Tools.Generic
         public Turf WallToConstruct;
         public Turf FloorToConstruct;
         public float Delay;
+        public LayerMask ObstacleMask;
 
         public Sprite constructIcon;
      
@@ -26,7 +27,8 @@ namespace SS3D.Content.Items.Functional.Tools.Generic
                 FloorToConstruct = FloorToConstruct,
                 Delay = Delay,
                 LoadingBarPrefab = LoadingBarPrefab,
-                icon = constructIcon
+                icon = constructIcon,
+                ObstacleMask = ObstacleMask
             };
             interactions.Insert(0, new InteractionEntry(targets[0], wallConstructionInteraction));
         }

--- a/Assets/Content/Items/Functional/Tools/Generic/Wrench.cs
+++ b/Assets/Content/Items/Functional/Tools/Generic/Wrench.cs
@@ -13,6 +13,7 @@ namespace SS3D.Content.Items.Functional.Tools.Generic
         public GameObject LoadingBarPrefab;
         public Fixture TableToConstruct;
         public float Delay;
+        public LayerMask ObstacleMask;
 
         public Sprite constructIcon;
 
@@ -23,7 +24,8 @@ namespace SS3D.Content.Items.Functional.Tools.Generic
             {       TableToConstruct = TableToConstruct, 
                 Delay = Delay, 
                 LoadingBarPrefab = LoadingBarPrefab,
-                icon = constructIcon
+                icon = constructIcon,
+                ObstacleMask = ObstacleMask
             }));
         }
     }

--- a/Assets/Content/Items/Functional/Tools/Generic/crowbar.prefab
+++ b/Assets/Content/Items/Functional/Tools/Generic/crowbar.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 926100782}
   - component: {fileID: 769153401460545782}
   - component: {fileID: 7755032100304685975}
+  - component: {fileID: 5629774943137491972}
   - component: {fileID: -1366249567310261295}
   m_Layer: 16
   m_Name: crowbar
@@ -50,9 +51,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
   m_AssetId: 
-  m_SceneId: 0
+  hasSpawned: 0
 --- !u!33 &5851963053719667412
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -145,6 +147,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   ItemId: 
+  Name: Crowbar
   container: {fileID: 0}
   itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
@@ -155,7 +158,24 @@ MonoBehaviour:
   WallToConstruct: {fileID: 11400000, guid: cede127f2ecc46345ab2c1fad9cbd507, type: 2}
   FloorToConstruct: {fileID: 11400000, guid: 9dda7bed5d66999498b68b9b7517499d, type: 2}
   Delay: 1.5
+  ObstacleMask:
+    serializedVersion: 2
+    m_Bits: 32768
   constructIcon: {fileID: 21300000, guid: e1b5b9fab3120ad4c91ea3deb5197a7b, type: 3}
+--- !u!114 &5629774943137491972
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888703706215615217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59d174b721ba45d285a8f164a519c314, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Text: Used to construct and destroy walls.
+  MaxDistance: 0
 --- !u!114 &-1366249567310261295
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -170,8 +190,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  compressRotation: 1
   clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!1 &2468349444349537438
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Functional/Tools/Generic/wrench.prefab
+++ b/Assets/Content/Items/Functional/Tools/Generic/wrench.prefab
@@ -45,6 +45,7 @@ GameObject:
   - component: {fileID: 2715522631516638477}
   - component: {fileID: 7817880274887278369}
   - component: {fileID: 1022902389129981048}
+  - component: {fileID: 5794515216983496791}
   - component: {fileID: -3512790196692281400}
   m_Layer: 16
   m_Name: wrench
@@ -80,9 +81,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
   m_AssetId: 
-  m_SceneId: 0
+  hasSpawned: 0
 --- !u!33 &9196258322038297090
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -174,6 +176,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   ItemId: 
+  Name: Wrench
   container: {fileID: 0}
   itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
@@ -183,7 +186,24 @@ MonoBehaviour:
     type: 3}
   TableToConstruct: {fileID: 11400000, guid: e361c0d934015604fa13db8b86d73f4b, type: 2}
   Delay: 1
+  ObstacleMask:
+    serializedVersion: 2
+    m_Bits: 32768
   constructIcon: {fileID: 21300000, guid: e1b5b9fab3120ad4c91ea3deb5197a7b, type: 3}
+--- !u!114 &5794515216983496791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3792017003477948967}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59d174b721ba45d285a8f164a519c314, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Text: Used to construct and destroy tables.
+  MaxDistance: 0
 --- !u!114 &-3512790196692281400
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -198,5 +218,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  compressRotation: 1
   clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01

--- a/Assets/Content/Systems/Interactions/ConstructionInteraction.cs
+++ b/Assets/Content/Systems/Interactions/ConstructionInteraction.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using SS3D.Engine.Interactions;
+using SS3D.Engine.Tiles;
+using UnityEngine;
+
+public abstract class ConstructionInteraction : DelayedInteraction
+{
+    /// <summary>
+    /// A layer mask for objects which block building
+    /// </summary>
+    public LayerMask ObstacleMask { get; set; }
+    /// <summary>
+    /// The space required for this construction
+    /// </summary>
+    public Vector3 BuildDimensions { get; set; } = Vector3.one;
+    /// <summary>
+    /// The target tile of this construction
+    /// </summary>
+    protected TileObject TargetTile { get; private set; }
+
+    public override bool CanInteract(InteractionEvent interactionEvent)
+    {
+        if (interactionEvent.Target is IGameObjectProvider targetBehaviour)
+        {
+            // Get target tile
+            TargetTile = targetBehaviour.GameObject.GetComponentInParent<TileObject>();
+            if (TargetTile == null)
+            {
+                return false;
+            }
+            
+            // Ready if no obstacles
+            if (ObstacleMask == 0)
+            {
+                return true;
+            }
+
+            // Check for obstacle
+            Vector3 center = TargetTile.gameObject.transform.position;
+            bool obstacle = Physics.CheckBox(center, BuildDimensions / 2, Quaternion.identity, ObstacleMask, QueryTriggerInteraction.Ignore);
+            return !obstacle;
+        }
+
+        return false;
+       
+        
+        
+    }
+}

--- a/Assets/Content/Systems/Interactions/ConstructionInteraction.cs.meta
+++ b/Assets/Content/Systems/Interactions/ConstructionInteraction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7795dd4c0c03312419b0a27284d7e39a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/Systems/Interactions/TableConstructionInteraction.cs
+++ b/Assets/Content/Systems/Interactions/TableConstructionInteraction.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace SS3D.Content.Systems.Interactions
 {
-    public class TableConstructionInteraction : DelayedInteraction
+    public class TableConstructionInteraction : ConstructionInteraction
     {
         public Fixture TableToConstruct { get; set; }
 
@@ -22,28 +22,17 @@ namespace SS3D.Content.Systems.Interactions
 
         public override bool CanInteract(InteractionEvent interactionEvent)
         {
-            if (interactionEvent.Target is IGameObjectProvider targetBehaviour)
+            if (!base.CanInteract(interactionEvent))
             {
-                TileObject targetTile = targetBehaviour.GameObject.GetComponentInParent<TileObject>();
-                if (targetTile == null)
-                {
-                    return false;
-                }
-
-                if (!InteractionExtensions.RangeCheck(interactionEvent))
-                {
-                    return false;
-                }
-
-                if (targetTile.Tile.turf?.isWall == true)
-                {
-                    return false;
-                }
-
-                return true;
+                return false;
             }
             
-            return false;
+            if (!InteractionExtensions.RangeCheck(interactionEvent))
+            {
+                return false;
+            }
+            
+            return TargetTile.Tile.turf?.isWall != true;
         }
 
         public override void Cancel(InteractionEvent interactionEvent, InteractionReference reference)

--- a/Assets/Content/Systems/Interactions/WallConstructionInteraction.cs
+++ b/Assets/Content/Systems/Interactions/WallConstructionInteraction.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace SS3D.Content.Systems.Interactions
 {
-    public class WallConstructionInteraction : DelayedInteraction
+    public class WallConstructionInteraction : ConstructionInteraction
     {
         public Turf WallToConstruct { get; set; }
         public Turf FloorToConstruct { get; set; }
@@ -23,28 +23,17 @@ namespace SS3D.Content.Systems.Interactions
 
         public override bool CanInteract(InteractionEvent interactionEvent)
         {
-            if (!InteractionExtensions.RangeCheck(interactionEvent))
+            if (!base.CanInteract(interactionEvent))
             {
                 return false;
             }
             
-            if (interactionEvent.Target is IGameObjectProvider targetBehaviour)
+            if (!InteractionExtensions.RangeCheck(interactionEvent))
             {
-                TileObject targetTile = targetBehaviour.GameObject.GetComponentInParent<TileObject>();
-                if (targetTile == null)
-                {
-                    return false;
-                }
-
-                if (targetTile.Tile.GetFixtureAtLayer(FixtureLayers.Furniture) != null)
-                {
-                    return false;
-                }
-
-                return true;
+                return false;
             }
-            
-            return false;
+
+            return TargetTile.Tile.GetFixtureAtLayer(FixtureLayers.Furniture) == null;
         }
 
         public override void Cancel(InteractionEvent interactionEvent, InteractionReference reference)


### PR DESCRIPTION
### Summary

Prevents the player from building on a tile a player is on.
Can also be used to check for other layers.

## Technical Notes

Adds a new abstract class ConstructionInteraction for constructions, which implements the obstacle check.

## Fixes

Fixes #366
