### PR TITLE
Fix X connections on advanced scripts

### DIFF
--- a/Assets/Engine/Tile/Connections/AdvancedAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/Connections/AdvancedAdjacencyConnector.cs
@@ -204,23 +204,23 @@ namespace SS3D.Engine.Tiles.Connections
                         break;
                     case 1:
                         mesh = xSingle;
-                        rotation = DirectionHelper.AngleBetween(Direction.North, diagonals.GetOnlyPositive());
+                        rotation = DirectionHelper.AngleBetween(Direction.South, diagonals.GetOnlyPositive());
                         break;
                     case 2:
                         if (diagonals.north == diagonals.south)
                         {
                             mesh = xOpposite;
-                            rotation = OrientationHelper.AngleBetween(Orientation.Horizontal, diagonals.GetFirstOrientation());
+                            rotation = OrientationHelper.AngleBetween(Orientation.Vertical, diagonals.GetFirstOrientation());
                         }
                         else
                         {
                             mesh = xSide;
-                            rotation = DirectionHelper.AngleBetween(Direction.NorthWest, diagonals.GetCornerDirection());
+                            rotation = DirectionHelper.AngleBetween(Direction.SouthEast, diagonals.GetCornerDirection());
                         }
                         break;
                     case 3:
                         mesh = xTriple;
-                        rotation = DirectionHelper.AngleBetween(Direction.South, diagonals.GetOnlyNegative());
+                        rotation = DirectionHelper.AngleBetween(Direction.North, diagonals.GetOnlyNegative());
                         break;
                     default:
                         mesh = xQuad;

--- a/Assets/Engine/Tile/Connections/TieredAdvancedAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/Connections/TieredAdvancedAdjacencyConnector.cs
@@ -197,23 +197,23 @@ namespace SS3D.Engine.Tiles.Connections
                         break;
                     case 1:
                         mesh = xSingle;
-                        rotation = DirectionHelper.AngleBetween(Direction.North, diagonals.GetOnlyPositive());
+                        rotation = DirectionHelper.AngleBetween(Direction.South, diagonals.GetOnlyPositive());
                         break;
                     case 2:
                         if (diagonals.north == diagonals.south)
                         {
                             mesh = xOpposite;
-                            rotation = OrientationHelper.AngleBetween(Orientation.Horizontal, diagonals.GetFirstOrientation());
+                            rotation = OrientationHelper.AngleBetween(Orientation.Vertical, diagonals.GetFirstOrientation());
                         }
                         else
                         {
                             mesh = xSide;
-                            rotation = DirectionHelper.AngleBetween(Direction.NorthWest, diagonals.GetCornerDirection());
+                            rotation = DirectionHelper.AngleBetween(Direction.SouthEast, diagonals.GetCornerDirection());
                         }
                         break;
                     case 3:
                         mesh = xTriple;
-                        rotation = DirectionHelper.AngleBetween(Direction.South, diagonals.GetOnlyNegative());
+                        rotation = DirectionHelper.AngleBetween(Direction.North, diagonals.GetOnlyNegative());
                         break;
                     default:
                         mesh = xQuad;


### PR DESCRIPTION
<!-- Text within these arrows are notes for you and should be deleted. -->

### Summary

I don't know why but, the connections got messed up on the advanced scripts at some point (all connection scripts based of the simple script shouldn't be affected by this).
 This fixes the X connection errors on tables, walls, windows.

BEFORE

![Unity_p31NxYvtuf](https://user-images.githubusercontent.com/41941008/85913308-986d4f00-b801-11ea-835e-105122d017d2.png)

AFTER

![Unity_0jQ8iK1jE0](https://user-images.githubusercontent.com/41941008/85913309-9dca9980-b801-11ea-90a1-c1ab76667872.png)

## Known issues (optional)

T & L connections still seem to be messed up, but only on the TieredAdvancedAdjacencyConnector (used on windows), but I'm not sure why, as comparing them to the AdvancedAdjacencyConnector, they seem fine. So I'm not sure why T& L are broken for windows still... I even checked the .fbx and didn't see anything out of place.