### PR TITLE
Change ragdoll to a time based system

### DIFF
--- a/Assets/Content/Creatures/Human/HumanRagdoll.cs
+++ b/Assets/Content/Creatures/Human/HumanRagdoll.cs
@@ -1,4 +1,5 @@
-﻿using Mirror;
+﻿using System;
+using Mirror;
 using SS3D.Content.Systems.Player;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -15,64 +16,162 @@ namespace SS3D.Content.Creatures.Human
         /// </summary>
         public bool BodyEnabled
         {
-            get => bodyEnabled;
-            set => SetEnabled(value);
+            get;
+            private set;
         }
-
-        private bool bodyEnabled = false;
+        
+        // The parent object of the armature
         private Transform character;
+        // The center of the body
         private Transform center;
-    
+        // When the knockdown will expire
+        private float knockdownEnd;
+        // Will the ragdoll get up by itself?
+        private bool isKnockedDown;
+        private HumanoidMovementController movementController;
+        private CharacterController characterController;
+
         void Start()
         {
             Assert.IsNotNull(ArmatureRoot);
-            SetEnabled(BodyEnabled);
+            SetEnabledInternal(false);
             character = ArmatureRoot.parent;
             center = ArmatureRoot.GetChild(0);
         }
 
         void Update()
         {
-            if (bodyEnabled && character != null && center != null)
+            if (BodyEnabled)
             {
-                character.position = center.position;
-                center.localPosition = Vector3.zero;
+                if (character != null && center != null)
+                {
+                    // Make character follow center of body
+                    character.position = center.position;
+                    center.localPosition = Vector3.zero;
+                }
+
+                if (isKnockedDown && knockdownEnd < Time.time)
+                {
+                    // Knockdown expired
+                    Recover();
+                }
             }
         }
 
+        /// <summary>
+        /// Knocks this ragdoll down for the specific amount of time
+        /// </summary>
+        /// <param name="duration">How long the knockdown lasts</param>
+        /// <param name="extend">If this extends any existing knockdown that is longer</param>
+        public void KnockDown(float duration, bool extend = false)
+        {
+            if (duration < 0)
+            {
+                throw new ArgumentException("Can not knock down for a negative duration, use the Recover method", nameof(duration));
+            }
+
+            if (isKnockedDown)
+            {
+                float time = Time.time;
+                float remainingTime = Mathf.Max(0, knockdownEnd - time);
+                // Extend or fill up remaining time
+                knockdownEnd = time + (extend ? remainingTime + duration : Mathf.Max(remainingTime, duration));
+            }
+            else
+            {
+                // Can't knockdown a body that has been manually disabled
+                if (BodyEnabled)
+                {
+                    return;
+                }
+                
+                isKnockedDown = true;
+                knockdownEnd = Time.time + duration;
+                SetEnabledInternal(true);
+            }
+        }
+
+        /// <summary>
+        /// Decreases knockdown by a specific amount
+        /// </summary>
+        /// <param name="time">How much faster the ragdoll recovers</param>
+        public void Recover(float time)
+        {
+            if (!isKnockedDown)
+            {
+                return;
+            }
+            
+            knockdownEnd -= time;
+            if (knockdownEnd < Time.time)
+            {
+                Recover();
+            }
+        }
+        
+        /// <summary>
+        /// Completely recovers from any knockdown
+        /// </summary>
+        public void Recover()
+        {
+            if (isKnockedDown)
+            {
+                isKnockedDown = false;
+                SetEnabledInternal(false);
+            }
+        }
+
+        /// <summary>
+        /// Enables or disables the body until this method is called again
+        /// </summary>
+        /// <param name="enabled">If the body should be enabled or disabled</param>
         public void SetEnabled(bool enabled)
         {
-            bodyEnabled = enabled;
+            isKnockedDown = false;
+            SetEnabledInternal(enabled);
+        }
+        
+        private void SetEnabledInternal(bool enabled)
+        {
+            BodyEnabled = enabled;
 
-            HumanoidMovementController movementController = GetComponent<HumanoidMovementController>();
+            // Get absolute character movement
+            movementController = movementController != null ? movementController : GetComponent<HumanoidMovementController>();
             Vector3 movement = Vector3.zero;
             if (movementController != null)
             {
                 movement = movementController.absoluteMovement;
             }
             
+            // For each rigid body in the ragdoll
             foreach (Rigidbody body in ArmatureRoot.GetComponentsInChildren<Rigidbody>())
             {
+                // Set physics simulation
                 body.isKinematic = !enabled;
                 if (enabled)
                 {
+                    // Apply movement force to preserve momentum
                     body.AddForce(movement, ForceMode.VelocityChange);
                 }
             }
 
+            // Enable/disable animator
             GetComponent<Animator>().enabled = !enabled;
             
-            CharacterController characterController = GetComponent<CharacterController>();
+            // Enable/disable character controller
+            characterController = characterController != null ? characterController : GetComponent<CharacterController>();
             if (characterController != null)
             {
                 characterController.enabled = !enabled;
             }
             
+            // Enable/disable movement controller
             if (movementController != null)
             {
                 movementController.enabled = !enabled;
             }
 
+            // Replicate changes on client
             if (isServer)
             {
                 RpcSetEnabled(enabled);

--- a/Assets/Content/Creatures/Human/RigidBodyInspector.cs
+++ b/Assets/Content/Creatures/Human/RigidBodyInspector.cs
@@ -13,7 +13,7 @@ namespace SS3D.Content.Creatures.Human
             DrawDefaultInspector();
             if (GUILayout.Button(ragdoll.BodyEnabled ? "Disable body" : "Enable body"))
             {
-                ragdoll.BodyEnabled = !ragdoll.BodyEnabled;
+                ragdoll.SetEnabled(!ragdoll.BodyEnabled);
             }
         }
     }

--- a/Assets/Content/Items/Slippery.cs
+++ b/Assets/Content/Items/Slippery.cs
@@ -9,6 +9,16 @@ namespace SS3D.Content.Items
 {
     public class Slippery : NetworkBehaviour
     {
+        /// <summary>
+        /// How long a character is knocked down
+        /// </summary>
+        public float knockdownDuration = 3;
+        /// <summary>
+        /// How long before a character can get slipped again
+        /// </summary>
+        public float knockdownPause = 1;
+        
+        // Keeps track of who was recently slipped
         private Dictionary<HumanRagdoll, float> slippedBodies;
 
         private void Start()
@@ -29,9 +39,8 @@ namespace SS3D.Content.Items
                 CleanBodyDictionary();
                 if (!slippedBodies.ContainsKey(humanRagdoll))
                 {
-                    humanRagdoll.BodyEnabled = true;
+                    humanRagdoll.KnockDown(knockdownDuration);
                     slippedBodies.Add(humanRagdoll, Time.time);
-                    StartCoroutine(DisableBodyCoroutine(humanRagdoll));
                 }
             }
             
@@ -44,12 +53,6 @@ namespace SS3D.Content.Items
             {
                 slippedBodies.Remove(pair.Key);
             }
-        }
-
-        private IEnumerator DisableBodyCoroutine(HumanRagdoll body)
-        {
-            yield return new WaitForSeconds(3);
-            body.BodyEnabled = false;
         }
     }
 }

--- a/Assets/Engine/Atmospherics/AtmosRagdoll.cs
+++ b/Assets/Engine/Atmospherics/AtmosRagdoll.cs
@@ -13,7 +13,6 @@ namespace SS3D.Engine.Atmospherics
         public float knockdownTime = 3;
         public float checkInterval = 0.2f;
         
-        private float knockdownStart = -1;
         private HumanRagdoll ragdoll;
         private int lastX;
         private int lastY;
@@ -42,7 +41,7 @@ namespace SS3D.Engine.Atmospherics
                 Vector3 position = transform.position;
                 int x = Mathf.FloorToInt(position.x);
                 int y = Mathf.FloorToInt(position.z);
-                
+
                 // Update atmos object if tile changed
                 if (x != lastX || y != lastY)
                 {
@@ -62,31 +61,13 @@ namespace SS3D.Engine.Atmospherics
                 }
             }
         }
-        
+
         private void ApplyVelocity(Vector2 velocity)
         {
             if (velocity.sqrMagnitude > minVelocity * minVelocity)
             {
-                bool alreadyKnocked = knockdownStart >= 0;
-                knockdownStart = Time.time;
-                
-                if (!alreadyKnocked)
-                {
-                    ragdoll.BodyEnabled = true;
-                    StartCoroutine(GetUp());
-                }
+                ragdoll.KnockDown(knockdownTime);
             }
-        }
-
-        private IEnumerator GetUp()
-        {
-            while (knockdownStart + knockdownTime > Time.time)
-            {
-                yield return new WaitForSeconds(knockdownStart + knockdownTime - Time.time);
-            }
-
-            ragdoll.BodyEnabled = false;
-            knockdownStart = -1;
         }
     }
 }


### PR DESCRIPTION
### Summary

Currently certain events enabled and disable the ragdoll. This is done using co-routines, disabling the ragdoll after a specified time.
This leads to 2 main problems:

1. Disabling a game object (taking items) stops the co-routine and the player stays stuck
2. If two sources enable the ragdoll, one might disable the ragdoll while it is still supposed to be enabled

This is solved by implementing a simple knock down system, where external scripts knock down the player for a specified amount of time. If multiple knockdowns are triggered, the longer persists. This also gets rid of the faulty co-routines.

## Fixes 

Fixes #460
