### PR TITLE
Fix inconsistent interaction range

### DIFF
--- a/Assets/Content/Creatures/Human/Human.prefab
+++ b/Assets/Content/Creatures/Human/Human.prefab
@@ -285,7 +285,10 @@ MonoBehaviour:
   syncInterval: 0.1
   handContainer: {fileID: 593928988720118032}
   handRange: 5
-  Range: 1.5
+  range:
+    horizontal: 1.5
+    vertical: 1
+  interactionOrigin: {fileID: 2233422433550402390}
   pickupIcon: {fileID: 21300000, guid: d1f34343e08a14e48a856e409c355f32, type: 3}
 --- !u!114 &-4112737952016829400
 MonoBehaviour:

--- a/Assets/Content/Systems/Interactions/ToggleInteraction.cs
+++ b/Assets/Content/Systems/Interactions/ToggleInteraction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using SS3D.Engine.Interactions;
+using SS3D.Engine.Interactions.Extensions;
 using UnityEngine;
 
 namespace SS3D.Content.Systems.Interactions
@@ -31,6 +32,11 @@ namespace SS3D.Content.Systems.Interactions
         /// The name for the interaction when state is false
         /// </summary>
         public string OffName { get; set; } = "Turn on";
+
+        /// <summary>
+        /// If the interaction should be range limited
+        /// </summary>
+        public bool RangeCheck { get; set; } = true;
         
         public IClientInteraction CreateClient(InteractionEvent interactionEvent)
         {
@@ -59,6 +65,10 @@ namespace SS3D.Content.Systems.Interactions
 
         public bool CanInteract(InteractionEvent interactionEvent)
         {
+            if (RangeCheck && !InteractionExtensions.RangeCheck(interactionEvent))
+            {
+                return false;
+            }
             return CanInteractCallback.Invoke(interactionEvent);
         }
 

--- a/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
+++ b/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
@@ -6,16 +6,21 @@ namespace SS3D.Engine.Interactions.Extensions
     {
         public static bool RangeCheck(InteractionEvent interactionEvent)
         {
+            Vector3 point = interactionEvent.Point;
+            
             // Ignore range when there is no point
-            if (interactionEvent.Point.sqrMagnitude < 0.001)
+            if (point.sqrMagnitude < 0.001)
             {
                 return true;
             }
             
             if (interactionEvent.Source is IGameObjectProvider provider)
             {
-                return Vector3.Distance(provider.GameObject.transform.position, interactionEvent.Point) <
-                       interactionEvent.Source.GetRange();
+                float range = interactionEvent.Source.GetRange();
+                Vector3 sourcePosition = provider.GameObject.transform.position;
+                // Check range, ignoring height
+                return (new Vector2(point.x, point.z) - new Vector2(sourcePosition.x, sourcePosition.z)).sqrMagnitude <
+                       range * range;
             }
 
             return true;

--- a/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
+++ b/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
@@ -7,23 +7,38 @@ namespace SS3D.Engine.Interactions.Extensions
         public static bool RangeCheck(InteractionEvent interactionEvent)
         {
             Vector3 point = interactionEvent.Point;
-            
+
             // Ignore range when there is no point
             if (point.sqrMagnitude < 0.001)
             {
                 return true;
             }
-            
-            if (interactionEvent.Source is IGameObjectProvider provider)
+
+            Vector3 sourcePosition;
+
+            if (interactionEvent.Source is IInteractionOriginProvider origin)
             {
-                float range = interactionEvent.Source.GetRange();
-                Vector3 sourcePosition = provider.GameObject.transform.position;
-                // Check range, ignoring height
-                return (new Vector2(point.x, point.z) - new Vector2(sourcePosition.x, sourcePosition.z)).sqrMagnitude <
-                       range * range;
+                // Object has a custom interaction origin
+                sourcePosition = origin.InteractionOrigin;
+            }
+            else if (interactionEvent.Source is IGameObjectProvider provider)
+            {
+                // Use default game object origin
+                sourcePosition = provider.GameObject.transform.position;
+            }
+            else
+            {
+                // No origin
+                return true;
             }
 
-            return true;
+
+            RangeLimit range = interactionEvent.Source.GetRange();
+            float horizontal = range.horizontal;
+            // Check horizontal and vertical range
+            return Mathf.Abs(point.y - sourcePosition.y) < range.vertical &&
+                   (new Vector2(point.x, point.z) - new Vector2(sourcePosition.x, sourcePosition.z)).sqrMagnitude <
+                   horizontal * horizontal;
         }
     }
 }

--- a/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
+++ b/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
@@ -14,22 +14,23 @@ namespace SS3D.Engine.Interactions.Extensions
                 return true;
             }
 
+            var interactionRangeLimit = interactionEvent.Source.GetComponentInTree<IInteractionRangeLimit>(out IGameObjectProvider provider);
+            if (interactionRangeLimit == null)
+            {
+                // No range limit
+                return true;
+            }
+            
             Vector3 sourcePosition;
-
-            if (interactionEvent.Source is IInteractionOriginProvider origin)
+            if (provider is IInteractionOriginProvider origin)
             {
                 // Object has a custom interaction origin
                 sourcePosition = origin.InteractionOrigin;
             }
-            else if (interactionEvent.Source is IGameObjectProvider provider)
+            else
             {
                 // Use default game object origin
                 sourcePosition = provider.GameObject.transform.position;
-            }
-            else
-            {
-                // No origin
-                return true;
             }
 
 

--- a/Assets/Engine/Interactions/Extensions/InteractionSourceExtension.cs
+++ b/Assets/Engine/Interactions/Extensions/InteractionSourceExtension.cs
@@ -1,4 +1,5 @@
 ﻿using SS3D.Engine.Inventory.Extensions;
+using UnityEngine;
 
 namespace SS3D.Engine.Interactions.Extensions
 {
@@ -17,20 +18,27 @@ namespace SS3D.Engine.Interactions.Extensions
         
         public static T GetComponentInTree<T>(this IInteractionSource source) where T: class
         {
+            return GetComponentInTree<T>(source, out IGameObjectProvider _);
+        }
+        
+        public static T GetComponentInTree<T>(this IInteractionSource source, out IGameObjectProvider provider) where T: class
+        {
             IInteractionSource current = source;
             while (current != null)
             {
-                if (current is IGameObjectProvider provider)
+                if (current is IGameObjectProvider gameObjectProvider)
                 {
-                    T component = provider.GameObject.GetComponent<T>();
+                    T component = gameObjectProvider.GameObject.GetComponent<T>();
                     if (component != null)
                     {
+                        provider = gameObjectProvider;
                         return component;
                     }
                 }
                 current = current.Parent;
             }
 
+            provider = null;
             return null;
         }
 

--- a/Assets/Engine/Interactions/Extensions/InteractionSourceExtension.cs
+++ b/Assets/Engine/Interactions/Extensions/InteractionSourceExtension.cs
@@ -34,10 +34,10 @@ namespace SS3D.Engine.Interactions.Extensions
             return null;
         }
 
-        public static float GetRange(this IInteractionSource source)
+        public static RangeLimit GetRange(this IInteractionSource source)
         {
             IInteractionRangeLimit limit = source.GetComponentInTree<IInteractionRangeLimit>();
-            return limit?.GetInteractionRange() ?? float.MaxValue;
+            return limit?.GetInteractionRange() ?? RangeLimit.Max;
         }
 
         public static Hands GetHands(this IInteractionSource source)

--- a/Assets/Engine/Interactions/IInteractionOriginProvider.cs
+++ b/Assets/Engine/Interactions/IInteractionOriginProvider.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace SS3D.Engine.Interactions
+{
+    public interface IInteractionOriginProvider
+    {
+        Vector3 InteractionOrigin { get; }
+    }
+}

--- a/Assets/Engine/Interactions/IInteractionOriginProvider.cs.meta
+++ b/Assets/Engine/Interactions/IInteractionOriginProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c6d9836e888443f6a83f65a4bd2d93b1
+timeCreated: 1593642966

--- a/Assets/Engine/Interactions/IInteractionRangeLimit.cs
+++ b/Assets/Engine/Interactions/IInteractionRangeLimit.cs
@@ -2,6 +2,6 @@
 {
     public interface IInteractionRangeLimit
     {
-        float GetInteractionRange();
+        RangeLimit GetInteractionRange();
     }
 }

--- a/Assets/Engine/Interactions/RangeLimit.cs
+++ b/Assets/Engine/Interactions/RangeLimit.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using UnityEngine.Serialization;
+
+namespace SS3D.Engine.Interactions
+{
+    [Serializable]
+    public struct RangeLimit
+    {
+        public float horizontal;
+        public float vertical;
+
+        public RangeLimit(float horizontal, float vertical)
+        {
+            this.horizontal = horizontal;
+            this.vertical = vertical;
+        }
+
+        public static readonly RangeLimit Max = new RangeLimit {horizontal = float.MaxValue, vertical = float.MaxValue};
+    }
+}

--- a/Assets/Engine/Interactions/RangeLimit.cs.meta
+++ b/Assets/Engine/Interactions/RangeLimit.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6521d8a863bd425bb6b9a0f0097128c6
+timeCreated: 1593642233

--- a/Assets/Engine/Inventory/Extensions/Hands.cs
+++ b/Assets/Engine/Inventory/Extensions/Hands.cs
@@ -4,18 +4,20 @@ using System.Linq;
 using Mirror;
 using UnityEngine;
 using SS3D.Engine.Interactions;
+using UnityEngine.Serialization;
 
 namespace SS3D.Engine.Inventory.Extensions
 {
     [RequireComponent(typeof(Inventory))]
-    public class Hands : InteractionSourceNetworkBehaviour, IToolHolder, IInteractionRangeLimit
+    public class Hands : InteractionSourceNetworkBehaviour, IToolHolder, IInteractionRangeLimit, IInteractionOriginProvider
     {
         [SerializeField] private Container handContainer = null;
         [SerializeField] private float handRange = 0f;
 
         public event Action<int> onHandChange;
         public int SelectedHand { get; private set; } = 0;
-        public float Range = 1.5f;
+        public RangeLimit range = new RangeLimit(1.5f, 1);
+        public Transform interactionOrigin;
 
         public Sprite pickupIcon;
 
@@ -178,9 +180,11 @@ namespace SS3D.Engine.Inventory.Extensions
             }
             return interactionSource;
         }
-        public float GetInteractionRange()
+        public RangeLimit GetInteractionRange()
         {
-            return Range;
+            return range;
         }
+
+        public Vector3 InteractionOrigin => interactionOrigin.position;
     }
 }


### PR DESCRIPTION
### Summary

The range code now checks horizontal and vertical distance separately, making interacting feel more consistent.
The origin of the distance check is now consistent, even when holding items.

## Technical Notes

IInteractionRangeLimit now returns a new RangeLimit struct instead of a simple float value.
IInteractionOriginProvider can be used to give an source a custom origin.
The range check origin object is now the first object in the tree with a range limit component and not the first source.

## Fixes

Fixes #474
Fixes #381