### PR TITLE
Update to upload artifact-v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,10 @@ jobs:
         run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -accept-apiupdate -logFile -projectPath . -buildTarget StandaloneWindows64 -customBuildTarget StandaloneWindows64 -customBuildPath ./dist/win64/ -customBuildName RESS3D.exe
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: RESS3D_WIN
-          path: ./dist/win64
+          path: ./dist/win64/
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

Updates the upload artifact to version 2.
This fixes a bug in the original upload artifact, where the action runs on the host VM even when a container is specified.
This leads to missing files because the docker container is not mapped to the same location on the host.

See actions/upload-artifact#13
