### PR TITLE
Modify build to use offical unity arguments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .github/Unity_v2019.x.ulf || exit 0
 
       - name: Build Windows Player
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -accept-apiupdate -logFile -projectPath . -buildTarget StandaloneWindows64 -customBuildTarget StandaloneWindows64 -customBuildPath ./dist/win64/ -customBuildName RESS3D.exe
+        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -accept-apiupdate -logFile -projectPath . -buildTarget Win64 -buildWindows64Player ./dist/win64/RESS3D.exe
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
### Summary

Current unity build arguments seem to use a custom build script that is not included in the project.
This pr changes it to use arguments from the Unity documentation.
