### PR TITLE
Add Tilelayer restrictions

### DIFF
--- a/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister_Air.prefab
+++ b/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister_Air.prefab
@@ -105,7 +105,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gas: 0
   valvePressure: 0.1
-  valveOpen: 1
+  valveOpen: 0
   content: 500
   maxContent: 500
   menuUIPrefab: {fileID: 5132141291517980175, guid: 7c93c05ad2f5fa14489b94e1db0cc85c,

--- a/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister_Oxygen.prefab
+++ b/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister_Oxygen.prefab
@@ -105,7 +105,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gas: 0
   valvePressure: 0.1
-  valveOpen: 1
+  valveOpen: 0
   content: 500
   maxContent: 500
   menuUIPrefab: {fileID: 5132141291517980175, guid: 7c93c05ad2f5fa14489b94e1db0cc85c,

--- a/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister_Plasma.prefab
+++ b/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister_Plasma.prefab
@@ -105,7 +105,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gas: 3
   valvePressure: 0.1
-  valveOpen: 1
+  valveOpen: 0
   content: 500
   maxContent: 500
   menuUIPrefab: {fileID: 5132141291517980175, guid: 7c93c05ad2f5fa14489b94e1db0cc85c,

--- a/Assets/Content/Structures/Walls/Girder.asset
+++ b/Assets/Content/Structures/Walls/Girder.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp:TileMap:Turf
   id: girder
   genericType: wall
-  isWall: 1
+  isWall: 0
   prefab: {fileID: 5989834269598487349, guid: 60695978170ac0c48af8fd7ac2c0a43c, type: 3}

--- a/Assets/Editor/TileMapSettings.asset
+++ b/Assets/Editor/TileMapSettings.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
     turf: {fileID: 0}
     fixtures:
       tileFixtureDefinition:
-        plenumCap: {fileID: 0}
         wire: {fileID: 0}
         disposal: {fileID: 0}
         pipe1: {fileID: 0}
@@ -33,13 +32,13 @@ MonoBehaviour:
         lowWallSouth: {fileID: 0}
         lowWallWest: {fileID: 0}
       floorFixtureDefinition:
-        furniture: {fileID: 0}
+        pipeUpper: {fileID: 0}
         overlay1: {fileID: 0}
         overlay2: {fileID: 0}
         overlay3: {fileID: 0}
-        tableMachine1: {fileID: 0}
-        tableMachine2: {fileID: 0}
-        tableMachine3: {fileID: 0}
-        tableMachine4: {fileID: 0}
-        tableMachine5: {fileID: 0}
+        furnitureMain: {fileID: 0}
+        furniture2: {fileID: 0}
+        furniture3: {fileID: 0}
+        furniture4: {fileID: 0}
+        furniture5: {fileID: 0}
     atmos: {fileID: 0}

--- a/Assets/Engine/Tile/Fixtures/FixturesContainer.cs
+++ b/Assets/Engine/Tile/Fixtures/FixturesContainer.cs
@@ -361,7 +361,7 @@ namespace SS3D.Engine.Tiles
 
             if (altered)
             {
-                EditorUtility.DisplayDialog("Fixture combination", "You chose an invalid combination of fixtures. Definition has been reset", "ok");
+                EditorUtility.DisplayDialog("Fixture combination", "You chose an invalid combination of fixtures. Definition has been reset.", "ok");
             }
 
             return tileDefinition;

--- a/Assets/Engine/Tile/Fixtures/FixturesContainer.cs
+++ b/Assets/Engine/Tile/Fixtures/FixturesContainer.cs
@@ -358,11 +358,12 @@ namespace SS3D.Engine.Tiles
                 tileDefinition.fixtures.SetTileFixtureAtLayer(null, TileFixtureLayers.Pipe3);
             }
 
-
+#if UNITY_EDITOR
             if (altered)
             {
                 EditorUtility.DisplayDialog("Fixture combination", "You chose an invalid combination of fixtures. Definition has been reset.", "ok");
             }
+#endif
 
             return tileDefinition;
         }

--- a/Assets/Engine/Tile/Fixtures/FixturesContainer.cs
+++ b/Assets/Engine/Tile/Fixtures/FixturesContainer.cs
@@ -250,11 +250,11 @@ namespace SS3D.Engine.Tiles
         public static TileDefinition ValidateFixtures(TileDefinition tileDefinition)
         {
             bool altered = false;
+            string reason = "";
 
-            // If lattice, remove turf and tile fixtures
+            // If lattice, remove tile fixtures
             if (tileDefinition.plenum.name.Contains("Lattice"))
             {
-                // tileDefinition.turf = null;
                 foreach (TileFixtureLayers layer in TileDefinition.GetTileFixtureLayerNames())
                 {
                     if (tileDefinition.fixtures.GetTileFixtureAtLayer(layer) != null)
@@ -263,16 +263,14 @@ namespace SS3D.Engine.Tiles
                         tileDefinition.fixtures.SetTileFixtureAtLayer(null, layer);
                     }
                 }
+                if (altered)
+                    reason += "Lattices do not support any wall/floor fixture.\n";
             }
 
             // If catwalk
             if (tileDefinition.plenum.name.Contains("Catwalk"))
             {
-                // Only allow floor plating
-                // if (tileDefinition.turf != null && !tileDefinition.turf.name.Contains("FloorPlating"))
-                    // tileDefinition.turf = null;
-
-                // Allow wire layer
+                // Allow only the wire layer in tile fixtures
                 foreach (TileFixtureLayers layer in TileDefinition.GetTileFixtureLayerNames())
                 {
                     if (layer != TileFixtureLayers.Wire)
@@ -280,6 +278,7 @@ namespace SS3D.Engine.Tiles
                         if (tileDefinition.fixtures.GetTileFixtureAtLayer(layer) != null)
                         {
                             altered = true;
+                            reason += "Catwalk only supports a wire and upper pipe layer.\n";
                             tileDefinition.fixtures.SetTileFixtureAtLayer(null, layer);
                         }
                     }
@@ -298,6 +297,7 @@ namespace SS3D.Engine.Tiles
                     if (tileDefinition.fixtures.GetFloorFixtureAtLayer(layer) != null)
                     {
                         altered = true;
+                        reason += "Cannot set a floor fixture when there is no floor.\n";
                         Debug.Log("Cannot set a floor fixture when there is no floor");
                     }
 
@@ -313,6 +313,7 @@ namespace SS3D.Engine.Tiles
                     if (tileDefinition.fixtures.GetWallFixtureAtLayer(layer) != null)
                     {
                         altered = true;
+                        reason += "Cannot set a wall fixture when there is no wall.\n";
                         Debug.Log("Cannot set a wall fixture when there is no wall");
                     }
 
@@ -330,6 +331,7 @@ namespace SS3D.Engine.Tiles
                         if (tileDefinition.fixtures.GetWallFixtureAtLayer(layer) != null)
                         {
                             altered = true;
+                            reason += "Glass walls do not allow low wall fixtures.\n";
                             tileDefinition.fixtures.SetWallFixtureAtLayer(null, layer);
                         }
                     }
@@ -361,7 +363,10 @@ namespace SS3D.Engine.Tiles
 #if UNITY_EDITOR
             if (altered)
             {
-                EditorUtility.DisplayDialog("Fixture combination", "You chose an invalid combination of fixtures. Definition has been reset.", "ok");
+                EditorUtility.DisplayDialog("Fixture combination", "Invalid because of the following: \n\n" +
+                    reason +
+                    "\n" +
+                    "Definition has been reset.", "ok");
             }
 #endif
 

--- a/Assets/Engine/Tile/Fixtures/FloorFixtures/FloorFixture.cs
+++ b/Assets/Engine/Tile/Fixtures/FloorFixtures/FloorFixture.cs
@@ -19,7 +19,8 @@ namespace SS3D.Engine.Tiles
 
         public bool IsEmpty()
         {
-            return pipeUpper != null || overlay1 != null || overlay2 != null || overlay3 != null
+            // Important: pipe upper is not checked as it can exist without a floor turf in place
+            return overlay1 != null || overlay2 != null || overlay3 != null
                 || furnitureMain != null || furniture2 != null || furniture3 != null || furniture4 != null || furniture5 != null;
         }
     }

--- a/Assets/Engine/Tile/TileObject.cs
+++ b/Assets/Engine/Tile/TileObject.cs
@@ -61,7 +61,7 @@ namespace SS3D.Engine.Tiles
             }
 
             // Go through Floor fixtures second
-            var floorLayers = TileDefinition.GetTileFixtureLayerNames();
+            var floorLayers = TileDefinition.GetFloorFixtureLayerNames();
             foreach (FloorFixtureLayers layer in floorLayers)
             {
                 UpdateFloorSingleAdjacency(direction, tile, layer);
@@ -107,7 +107,7 @@ namespace SS3D.Engine.Tiles
             }
 
             // Update every floor layer
-            var floorLayers = TileDefinition.GetTileFixtureLayerNames();
+            var floorLayers = TileDefinition.GetFloorFixtureLayerNames();
             foreach (FloorFixtureLayers layer in floorLayers)
             {
                 UpdateAllFloorAdjacencies(tiles, layer);
@@ -548,6 +548,7 @@ namespace SS3D.Engine.Tiles
                 }
                 fixtures[index + offset] = EditorAndRuntime.InstantiatePrefab(fixtureDefinition.prefab, transform);
                 floorFixtureConnectors[index] = fixtures[index + offset].GetComponent<AdjacencyConnector>();
+                floorFixtureConnectors[index].LayerIndex = index + offset;
             }
             else
             {
@@ -601,7 +602,7 @@ namespace SS3D.Engine.Tiles
         private void UpdateSubDataFromChildren()
         {
             // Plenum + Turf + all fixtures layers
-            tile.subStates = new object[1 + TileDefinition.GetAllFixtureLayerSize()];
+            tile.subStates = new object[2 + TileDefinition.GetAllFixtureLayerSize()];
 
             tile.subStates[0] = plenum != null ? plenum?.GetComponent<TileStateCommunicator>()?.GetTileState() : null;
             tile.subStates[1] = turf != null ? turf?.GetComponent<TileStateCommunicator>()?.GetTileState() : null;


### PR DESCRIPTION
<!-- Text within these arrows are notes for you and should be deleted. -->

### Summary
This PR adds restrictions for fixture layers in the tilemap editor. Implemented:

- Prevent all wall mounts on Girders
- Prevent low wall mounts on Windows
- Nothing can be built on Lattices
- Catwalk, only allow wire and upper pipe layer
- Wall, allow all wall fixtures
- Pipes can only go on their own layer (e.g. L1 on layer pipe 1)

**EDIT**
- Only allows floor plating on catwalks


Bonus:

- No more gas canisters opened by default

## Pictures/Videos 
![afbeelding](https://user-images.githubusercontent.com/5231626/86487201-c7ce0f80-bd5d-11ea-8184-51d77b125fc1.png)



## Known issues
~~Only allowing floor plating on catwalks does not work yet as I haven't found a way to remove the turf~~


## Fixes
Resolves #426, resolves #446 resolves #447, resolves #479 

Resolves #480 as well with a small fix to the tileobjects