### PR TITLE
Fix tilemap sync

### DIFF
--- a/Assets/Engine/Atmospherics/AtmosRagdoll.cs
+++ b/Assets/Engine/Atmospherics/AtmosRagdoll.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using Mirror;
 using SS3D.Content.Creatures.Human;
 using SS3D.Engine.Tiles;
 using UnityEngine;
@@ -23,6 +24,11 @@ namespace SS3D.Engine.Atmospherics
 
         void Start()
         {
+            if (!NetworkServer.active)
+            {
+                Destroy(this);
+            }
+            
             ragdoll = GetComponent<HumanRagdoll>();
             tileManager = FindObjectOfType<TileManager>();
             Assert.IsNotNull(tileManager);
@@ -48,10 +54,6 @@ namespace SS3D.Engine.Atmospherics
                     lastX = x;
                     lastY = y;
                     atmosObject = tileManager.GetTile((int) (x - origin.x), (int) (y - origin.z))?.atmos;
-                    if (atmosObject == null)
-                    {
-                        Debug.Log($"{x}, {y}");
-                    }
                 }
 
                 // Check velocity

--- a/Assets/Engine/Tile/TileManager.cs
+++ b/Assets/Engine/Tile/TileManager.cs
@@ -226,9 +226,16 @@ namespace SS3D.Engine.Tiles {
         private void TargetReceiveChunkFromServer(NetworkConnection connection, NetworkableTileObject[] tileList)
         {
             foreach (var item in tileList) {
-                ulong key = GetKey(item.position.x, item.position.y);
-                tiles[key] = SpawnTileObject(item.position.x, item.position.y);
-                tiles[key].Tile = item.definition;
+                try
+                {
+                    ulong key = GetKey(item.position.x, item.position.y);
+                    tiles[key] = SpawnTileObject(item.position.x, item.position.y);
+                    tiles[key].Tile = item.definition;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
             }
         }
 

--- a/Assets/Engine/Tile/TileObject.cs
+++ b/Assets/Engine/Tile/TileObject.cs
@@ -584,8 +584,13 @@ namespace SS3D.Engine.Tiles
                     Debug.LogWarning("Trying to overwrite fixture");
                 }
                 fixtures[index + offset] = EditorAndRuntime.InstantiatePrefab(fixtureDefinition.prefab, transform);
-                floorFixtureConnectors[index] = fixtures[index + offset].GetComponent<AdjacencyConnector>();
-                floorFixtureConnectors[index].LayerIndex = index + offset;
+                var connector = fixtures[index + offset].GetComponent<AdjacencyConnector>();
+                if (connector != null)
+                {
+                    floorFixtureConnectors[index] = connector;
+                    connector.LayerIndex = index + offset;
+                }
+                
             }
             else
             {


### PR DESCRIPTION
### Summary

Fixes an error where a fixture without an adjacency connector would throw an exception, aborting a chunk and causing missing tiles.
Also ensures single tile errors will never abort the rest of a chunk.

## Fixes

Fixes #497
