### PR TITLE
[WIP] Basic asset data

### DIFF
--- a/Assets/Content/Systems/Registry.prefab
+++ b/Assets/Content/Systems/Registry.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7986618133810745213}
   - component: {fileID: 5226195998945532795}
+  - component: {fileID: 6741126584871303748}
   m_Layer: 0
   m_Name: Registry
   m_TagString: Untagged
@@ -56,3 +57,15 @@ MonoBehaviour:
   - {fileID: 11400000, guid: d3dcce9a1c63a3c46ad24cb7278deb31, type: 2}
   recipes:
   - {fileID: 11400000, guid: 65ff5f8d9cb1cb341bf58c4abd173ed8, type: 2}
+--- !u!114 &6741126584871303748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7688354943259046949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc9dc8ca0b585e9438a70d9c8d4e2a1b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Engine/Utilities/AssetData.meta
+++ b/Assets/Engine/Utilities/AssetData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1881a9c55e7ed7844b0110d3b9033fbb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Utilities/AssetData/AsdaSounds.cs
+++ b/Assets/Engine/Utilities/AssetData/AsdaSounds.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+[CreateAssetMenu(fileName = "SoundsData", menuName = "AssetData/Sounds", order = 1)]
+public class AsdaSounds : ScriptableObject
+{
+    public AudioClip Drink,
+    EatFood,
+    DisposalFlush,
+    MicrowaveEnd,
+    MicrowaveMid1,
+    MicroWaveMid2,
+    MicrowaveStart,
+    VendingMachine,
+    Bikehorn,
+    EnergySwordOff,
+    EnergySwordOn,
+    AirlockClose,
+    AirlockOpen,
+    Title1,
+    Title2,
+    Title3
+    ;
+}

--- a/Assets/Engine/Utilities/AssetData/AsdaSounds.cs.meta
+++ b/Assets/Engine/Utilities/AssetData/AsdaSounds.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35275a8e4e934cc47b5b27fcda7ab86b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Utilities/AssetData/AsdaSprites.cs
+++ b/Assets/Engine/Utilities/AssetData/AsdaSprites.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+[CreateAssetMenu(fileName = "SpritesData", menuName = "AssetData/Sprites", order = 1)]
+public class AsdaSprites : ScriptableObject
+{
+    public Sprite Missing,
+        Build, 
+        Container,
+        Discard,
+        Door,
+        Music,
+        Power,
+        Reinforce,
+        Cancel,
+        Take
+        ;
+}

--- a/Assets/Engine/Utilities/AssetData/AsdaSprites.cs.meta
+++ b/Assets/Engine/Utilities/AssetData/AsdaSprites.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfb8e8ac8d70dde4aa6ccb84969dea85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Utilities/AssetData/AssetData.cs
+++ b/Assets/Engine/Utilities/AssetData/AssetData.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AssetData : MonoBehaviour
+{
+    
+    public static AsdaSprites Sprites;
+    public static AsdaSounds Sounds;
+//    public static AssetDataSounds Sounds;
+
+    void Awake()
+    {
+        Sprites = Resources.Load<AsdaSprites>("SpritesData");
+        Sounds = Resources.Load<AsdaSounds>("SoundsData");
+    }
+}

--- a/Assets/Engine/Utilities/AssetData/AssetData.cs.meta
+++ b/Assets/Engine/Utilities/AssetData/AssetData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc9dc8ca0b585e9438a70d9c8d4e2a1b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Utilities/AssetData/Resources.meta
+++ b/Assets/Engine/Utilities/AssetData/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d436eb81c218abc4e80bb4822fa7831d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Utilities/AssetData/Resources/SoundsData.asset
+++ b/Assets/Engine/Utilities/AssetData/Resources/SoundsData.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 35275a8e4e934cc47b5b27fcda7ab86b, type: 3}
+  m_Name: SoundsData
+  m_EditorClassIdentifier: 
+  Drink: {fileID: 8300000, guid: d218c16bb0edfd44293704a97a562e9e, type: 3}
+  EatFood: {fileID: 8300000, guid: 560ee14cc17d54c4e893ea6fbb1f2ad6, type: 3}
+  DisposalFlush: {fileID: 8300000, guid: a08d26dd950708048a98dc0bc545f9f2, type: 3}
+  MicrowaveEnd: {fileID: 8300000, guid: f22e34e83e0f9874e8ebc28d164810c2, type: 3}
+  MicrowaveMid1: {fileID: 8300000, guid: 91dcb7669f644934b9c52d400421f1a7, type: 3}
+  MicroWaveMid2: {fileID: 8300000, guid: 4b7f6117196ba914e9a1c966f290da9b, type: 3}
+  MicrowaveStart: {fileID: 8300000, guid: 18088b9f0e2635142acd8908effffd7c, type: 3}
+  VendingMachine: {fileID: 8300000, guid: eb843a8e8fc1da54986c95ce909fd0d7, type: 3}
+  Bikehorn: {fileID: 8300000, guid: 8c8823796bbcb23438fcf68260070383, type: 3}
+  EnergySwordOff: {fileID: 8300000, guid: ae6a0d3a332b67f4d968b477273cea56, type: 3}
+  EnergySwordOn: {fileID: 8300000, guid: 81842472797700d479c0ea5aef90fe57, type: 3}
+  AirlockClose: {fileID: 8300000, guid: fc2485e75c5d3ab4e86e814043c9e9cb, type: 3}
+  AirlockOpen: {fileID: 8300000, guid: 34297ba204a9f3944872f100baaa2369, type: 3}
+  Title1: {fileID: 8300000, guid: f480632a83403024eab6321e689c5b75, type: 3}
+  Title2: {fileID: 8300000, guid: c7fb44f977cb4d943bef452174937c65, type: 3}
+  Title3: {fileID: 8300000, guid: 679e79545485afe4f8c68617c36b2f1d, type: 3}

--- a/Assets/Engine/Utilities/AssetData/Resources/SoundsData.asset.meta
+++ b/Assets/Engine/Utilities/AssetData/Resources/SoundsData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7326e2bf7f874894691a0a823b38ad92
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Utilities/AssetData/Resources/SpritesData.asset
+++ b/Assets/Engine/Utilities/AssetData/Resources/SpritesData.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfb8e8ac8d70dde4aa6ccb84969dea85, type: 3}
+  m_Name: SpritesData
+  m_EditorClassIdentifier: 
+  Missing: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
+  Build: {fileID: 21300000, guid: e1b5b9fab3120ad4c91ea3deb5197a7b, type: 3}
+  Container: {fileID: 21300000, guid: 0f4328c69a4a89541a87f2482052e497, type: 3}
+  Discard: {fileID: 21300000, guid: d6678ac9f1a1c714fa5afdb6f1a0ff11, type: 3}
+  Door: {fileID: 21300000, guid: ce4cb1c9f32561c4db2ae13a08e28987, type: 3}
+  Music: {fileID: 21300000, guid: facda86cccb56594eb7155ed03ebbb9e, type: 3}
+  Power: {fileID: 21300000, guid: 3788240ffacf45b4998b63134326628e, type: 3}
+  Reinforce: {fileID: 21300000, guid: 23d865b338954604e9e48be58edf53ad, type: 3}
+  Cancel: {fileID: 21300000, guid: 6da47d21e0dce3843855b53e05682c3e, type: 3}
+  Take: {fileID: 21300000, guid: d1f34343e08a14e48a856e409c355f32, type: 3}

--- a/Assets/Engine/Utilities/AssetData/Resources/SpritesData.asset.meta
+++ b/Assets/Engine/Utilities/AssetData/Resources/SpritesData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d506c697851dad4ab437cce4606fd30
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Summary
Adds a Scriptable Object list of sprites and sounds, allowing them to be accessed via code at runtime.
## Technical Notes
- AssetData.cs must be assigned to a single object in the scene to register categories, I've added it to the Registry for now.
- To access a file, e.g. 'Discard.png', use 'AssetData.Sprites.Discard'. This should be compatible with intellisense and accessible most anywhere in the code. Files must be manually added to the system.

- To add a file:
    1. Add a variable of its type to the relevant AsdaCategory's CS file. 
    2. Drag the file to its respective slot in the AsdaCategory's Asset file.

- To add a category:
    1. Create an AsdaExampleCategory.cs ScriptableObject, with an asset menu and a list of variable references
    2. Create an AsdaExampleCategory.asset via the right click menu, and assign the variable  references to the asset in the editor.
    3. Add and assign the AsdaExampleCategory to another category, or AssetData.
- Top level categories should be placed in a Resources folder for easy loading, this could be changed to manual assignment later.

## Known issues
- Creating and managing categories/assets is cumbersome since they're all separate from each other. Combining them into a single file would make for poor merging later, perhaps we can design a custom editor of some sort for it.
- Changing the categories/assets at runtime can cause issues, we should never need to do this though.
- I haven't fully tested networking. In theory it should work with no problems.