### PR TITLE
Add 'Consumable' script to Foods

### DIFF
--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Absinthe.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Absinthe.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &1861453833026372563
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Absinthe.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Absinthe.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Ale.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Ale.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &6114283984059902716
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Ale.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Ale.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Beer.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Beer.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Beer.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Beer.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &6446191997104870732
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Captain Pete's Rum.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Captain Pete's Rum.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Captain Pete's Rum.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Captain Pete's Rum.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &-8023195135660676867
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Champagne.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Champagne.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &8007766618970146251
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Champagne.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Champagne.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Cognac.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Cognac.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Cognac.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Cognac.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &1085376433779955738
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Griffeater Gin.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Griffeater Gin.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Griffeater Gin.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Griffeater Gin.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &42966476225087036
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Robert Robust's Kahlua.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Robert Robust's Kahlua.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Robert Robust's Kahlua.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Robert Robust's Kahlua.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &8537094951476634685
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Tanguska Vodka.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Tanguska Vodka.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &3208315790591029780
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Tanguska Vodka.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Tanguska Vodka.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Uncle Git's Whisky.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Uncle Git's Whisky.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &7628843760292732928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Uncle Git's Whisky.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Uncle Git's Whisky.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &-7843511282263597710
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Wine.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Alcohol/Wine.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &846540291069206127
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Juice/Apple Juice.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Juice/Apple Juice.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &-6173571324145430837
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Juice/Grape Juice.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Juice/Grape Juice.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &6766920265302312201
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Juice/Lemon Juice.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Juice/Lemon Juice.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &5916578783003781652
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Juice/Lime Juice.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Juice/Lime Juice.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &-8588885193856872355
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Juice/Orange Juice.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Juice/Orange Juice.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &-3277866210014622133
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Juice/Tomato Juice.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Juice/Tomato Juice.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &-7444677638681580398
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Milk.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Milk.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 6162823455628302933}
 --- !u!82 &-5431605415766148546
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Soda/Beep's Cola.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Soda/Beep's Cola.prefab
@@ -205,8 +205,7 @@ MonoBehaviour:
   prefab: {fileID: 8953399703975470614}
   attachmentPoint: {fileID: 3742603716422439940}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &-2821121547162032549
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Soda/Beep's Cola.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Soda/Beep's Cola.prefab
@@ -263,7 +263,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 5820523130928049126}
 --- !u!82 &6650360349505443719
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Soda/Beepy Lime.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Soda/Beepy Lime.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 5205612090937000140}
 --- !u!82 &8562971194603966681
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Soda/Beepy Lime.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Soda/Beepy Lime.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 1998283610537428600}
   attachmentPoint: {fileID: 6056197512622027882}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &6661093949436954322
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Soda/Diet Beep's Soda.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Soda/Diet Beep's Soda.prefab
@@ -233,7 +233,7 @@ MonoBehaviour:
   feedTime: 1
   LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
     type: 3}
-  item: {fileID: 0}
+  item: {fileID: 1559324455486072875}
 --- !u!82 &-980747644787845634
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/Drinks/Soda/Diet Beep's Soda.prefab
+++ b/Assets/Content/Items/Consumables/Food/Drinks/Soda/Diet Beep's Soda.prefab
@@ -175,8 +175,7 @@ MonoBehaviour:
   prefab: {fileID: 6405106075082308508}
   attachmentPoint: {fileID: 1680750711217523086}
   bulkSize: 2
-  traits:
-  - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+  traits: []
 --- !u!114 &468259088459523041
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/Burger.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Burger.prefab
@@ -124,7 +124,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  ItemId: burguer
+  ItemId: burger
   Name: Burger
   Volume: 10
   container: {fileID: 0}
@@ -173,12 +173,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Volume: 9
+  Volume: 1000
   Temperature: 0
   Locked: 0
   substances:
-  - Substance: {fileID: 11400000, guid: 9a75665b85be2274882d93f14202cf57, type: 2}
-    Moles: 9
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 5
 --- !u!82 &7961324091246994682
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/Junk Food/4no raisins.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Junk Food/4no raisins.prefab
@@ -42,11 +42,14 @@ GameObject:
   - component: {fileID: 5772065308349761132}
   - component: {fileID: 8941549900616600112}
   - component: {fileID: 3398613710840100553}
-  - component: {fileID: 2748903352563225919}
   - component: {fileID: -2321550141522107793}
+  - component: {fileID: 2748903352563225919}
+  - component: {fileID: -2096131120537101781}
   - component: {fileID: 4211893044832035804}
   - component: {fileID: 1079151324591260441}
-  - component: {fileID: -2096131120537101781}
+  - component: {fileID: -2565055250822373788}
+  - component: {fileID: 3296860198860143425}
+  - component: {fileID: 4918683855648018327}
   m_Layer: 16
   m_Name: 4no raisins
   m_TagString: Untagged
@@ -132,6 +135,19 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!65 &-2321550141522107793
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.13662143, y: 0.19501211, z: 0.059939906}
+  m_Center: {x: 0.0018789619, y: 0.0031965375, z: -0.0004488062}
 --- !u!54 &2748903352563225919
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -148,19 +164,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!65 &-2321550141522107793
-BoxCollider:
+--- !u!114 &-2096131120537101781
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3969530706517246485}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.13662143, y: 0.19501211, z: 0.059939906}
-  m_Center: {x: 0.0018789619, y: 0.0031965375, z: -0.0004488062}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &4211893044832035804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -177,7 +198,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 4no_raisins
   Name: 4no Raisins
-  Volume: 7
+  Volume: 5
   container: {fileID: 0}
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 3969530706517246485}
@@ -199,7 +220,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: 
   MaxDistance: 0
---- !u!114 &-2096131120537101781
+--- !u!114 &-2565055250822373788
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -208,12 +229,135 @@ MonoBehaviour:
   m_GameObject: {fileID: 3969530706517246485}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  content: {fileID: 3296860198860143425}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 4918683855648018327}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 4211893044832035804}
+--- !u!114 &3296860198860143425
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 300
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 1.5
+--- !u!82 &4918683855648018327
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Content/Items/Consumables/Food/General/Junk Food/Cup Ramen.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Junk Food/Cup Ramen.prefab
@@ -42,11 +42,14 @@ GameObject:
   - component: {fileID: 5772065308349761132}
   - component: {fileID: 8941549900616600112}
   - component: {fileID: 3398613710840100553}
-  - component: {fileID: 2748903352563225919}
   - component: {fileID: 2972670713508023241}
+  - component: {fileID: 2748903352563225919}
+  - component: {fileID: -2096131120537101781}
   - component: {fileID: 4211893044832035804}
   - component: {fileID: 1079151324591260441}
-  - component: {fileID: -2096131120537101781}
+  - component: {fileID: -8245375839876018735}
+  - component: {fileID: 1076731294697049405}
+  - component: {fileID: 3600090017324841091}
   m_Layer: 16
   m_Name: Cup Ramen
   m_TagString: Untagged
@@ -132,22 +135,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!54 &2748903352563225919
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3969530706517246485}
-  serializedVersion: 2
-  m_Mass: 0.07
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
 --- !u!64 &2972670713508023241
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -162,6 +149,40 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: -384330148597822543, guid: 7ab11ec54ee44fc42b56d7d98ad51e21, type: 3}
+--- !u!54 &2748903352563225919
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  serializedVersion: 2
+  m_Mass: 0.1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &-2096131120537101781
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &4211893044832035804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -200,7 +221,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: 
   MaxDistance: 0
---- !u!114 &-2096131120537101781
+--- !u!114 &-8245375839876018735
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -209,12 +230,135 @@ MonoBehaviour:
   m_GameObject: {fileID: 3969530706517246485}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  content: {fileID: 1076731294697049405}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 3600090017324841091}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 4211893044832035804}
+--- !u!114 &1076731294697049405
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 300
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 1.5
+--- !u!82 &3600090017324841091
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Content/Items/Consumables/Food/General/Junk Food/Donk Pocket.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Junk Food/Donk Pocket.prefab
@@ -42,11 +42,14 @@ GameObject:
   - component: {fileID: 5772065308349761132}
   - component: {fileID: 8941549900616600112}
   - component: {fileID: 3398613710840100553}
-  - component: {fileID: 2748903352563225919}
   - component: {fileID: -2321550141522107793}
+  - component: {fileID: 2748903352563225919}
+  - component: {fileID: -2096131120537101781}
   - component: {fileID: 4211893044832035804}
   - component: {fileID: 1079151324591260441}
-  - component: {fileID: -2096131120537101781}
+  - component: {fileID: 6208101994002524489}
+  - component: {fileID: 943877375873949024}
+  - component: {fileID: 6704523476501461858}
   m_Layer: 16
   m_Name: Donk Pocket
   m_TagString: Untagged
@@ -132,22 +135,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!54 &2748903352563225919
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3969530706517246485}
-  serializedVersion: 2
-  m_Mass: 0.07
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
 --- !u!65 &-2321550141522107793
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -161,6 +148,40 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.13407764, y: 0.08387836, z: 0.27238357}
   m_Center: {x: -0.000028073788, y: 0.004808139, z: -0.00014153868}
+--- !u!54 &2748903352563225919
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  serializedVersion: 2
+  m_Mass: 0.1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &-2096131120537101781
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &4211893044832035804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -199,7 +220,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: 
   MaxDistance: 0
---- !u!114 &-2096131120537101781
+--- !u!114 &6208101994002524489
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -208,12 +229,135 @@ MonoBehaviour:
   m_GameObject: {fileID: 3969530706517246485}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  content: {fileID: 943877375873949024}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 6704523476501461858}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 4211893044832035804}
+--- !u!114 &943877375873949024
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 300
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 1.5
+--- !u!82 &6704523476501461858
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie .33.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie .33.prefab
@@ -42,11 +42,11 @@ GameObject:
   - component: {fileID: 5772065308349761132}
   - component: {fileID: 8941549900616600112}
   - component: {fileID: 3398613710840100553}
-  - component: {fileID: 2748903352563225919}
   - component: {fileID: -2321550141522107793}
+  - component: {fileID: 2748903352563225919}
+  - component: {fileID: -2096131120537101781}
   - component: {fileID: 4211893044832035804}
   - component: {fileID: 1079151324591260441}
-  - component: {fileID: -2096131120537101781}
   m_Layer: 16
   m_Name: Twinkie .33
   m_TagString: Untagged
@@ -132,6 +132,19 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!65 &-2321550141522107793
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.09304499, y: 0.084931225, z: 0.08957179}
+  m_Center: {x: -0.00031776354, y: 0.004425749, z: 0.0017624833}
 --- !u!54 &2748903352563225919
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -148,19 +161,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!65 &-2321550141522107793
-BoxCollider:
+--- !u!114 &-2096131120537101781
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3969530706517246485}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.09304499, y: 0.084931225, z: 0.08957179}
-  m_Center: {x: -0.00031776354, y: 0.004425749, z: 0.0017624833}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &4211893044832035804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -199,21 +217,3 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: 
   MaxDistance: 0
---- !u!114 &-2096131120537101781
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3969530706517246485}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01

--- a/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie .33.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie .33.prefab
@@ -23,13 +23,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 716931857196434506}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.002, z: -0.0801}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 93945561432043526}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3969530706517246485
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie .66.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie .66.prefab
@@ -42,11 +42,11 @@ GameObject:
   - component: {fileID: 5772065308349761132}
   - component: {fileID: 8941549900616600112}
   - component: {fileID: 3398613710840100553}
-  - component: {fileID: 2748903352563225919}
   - component: {fileID: -2321550141522107793}
+  - component: {fileID: 2748903352563225919}
+  - component: {fileID: -2096131120537101781}
   - component: {fileID: 4211893044832035804}
   - component: {fileID: 1079151324591260441}
-  - component: {fileID: -2096131120537101781}
   m_Layer: 16
   m_Name: Twinkie .66
   m_TagString: Untagged
@@ -132,6 +132,19 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!65 &-2321550141522107793
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.09304499, y: 0.084931225, z: 0.20257398}
+  m_Center: {x: -0.00031776354, y: 0.004425749, z: 0.0048941113}
 --- !u!54 &2748903352563225919
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -148,19 +161,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!65 &-2321550141522107793
-BoxCollider:
+--- !u!114 &-2096131120537101781
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3969530706517246485}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.09304499, y: 0.084931225, z: 0.20257398}
-  m_Center: {x: -0.00031776354, y: 0.004425749, z: 0.0048941113}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &4211893044832035804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -199,21 +217,3 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: 
   MaxDistance: 0
---- !u!114 &-2096131120537101781
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3969530706517246485}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01

--- a/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie .66.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie .66.prefab
@@ -23,13 +23,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 716931857196434506}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.002, z: -0.0801}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 93945561432043526}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3969530706517246485
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie.prefab
@@ -23,13 +23,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 716931857196434506}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.002, z: -0.0801}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 93945561432043526}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3969530706517246485
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/Junk Food/Twinkie.prefab
@@ -42,11 +42,14 @@ GameObject:
   - component: {fileID: 5772065308349761132}
   - component: {fileID: 8941549900616600112}
   - component: {fileID: 3398613710840100553}
-  - component: {fileID: 2748903352563225919}
   - component: {fileID: -2321550141522107793}
+  - component: {fileID: 2748903352563225919}
+  - component: {fileID: -2096131120537101781}
   - component: {fileID: 4211893044832035804}
   - component: {fileID: 1079151324591260441}
-  - component: {fileID: -2096131120537101781}
+  - component: {fileID: 817777820443792788}
+  - component: {fileID: 7810774744728787889}
+  - component: {fileID: 9092220197200983692}
   m_Layer: 16
   m_Name: Twinkie
   m_TagString: Untagged
@@ -132,6 +135,19 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!65 &-2321550141522107793
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.09304499, y: 0.08493124, z: 0.2650125}
+  m_Center: {x: -0.00031776354, y: 0.0044257436, z: 0.0076481923}
 --- !u!54 &2748903352563225919
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -148,19 +164,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!65 &-2321550141522107793
-BoxCollider:
+--- !u!114 &-2096131120537101781
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3969530706517246485}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.09304499, y: 0.08493124, z: 0.2650125}
-  m_Center: {x: -0.00031776354, y: 0.0044257436, z: 0.0076481923}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &4211893044832035804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -199,7 +220,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: 
   MaxDistance: 0
---- !u!114 &-2096131120537101781
+--- !u!114 &817777820443792788
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -208,12 +229,135 @@ MonoBehaviour:
   m_GameObject: {fileID: 3969530706517246485}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  content: {fileID: 7810774744728787889}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 9092220197200983692}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 4211893044832035804}
+--- !u!114 &7810774744728787889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 600
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 3
+--- !u!82 &9092220197200983692
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Content/Items/Consumables/Food/General/SpaceFries.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/SpaceFries.prefab
@@ -830,11 +830,14 @@ GameObject:
   m_Component:
   - component: {fileID: 7232019348805334279}
   - component: {fileID: 2045114757119070375}
-  - component: {fileID: 2154479770022788754}
   - component: {fileID: 9078880203578673513}
+  - component: {fileID: 2154479770022788754}
+  - component: {fileID: -342697699264856680}
   - component: {fileID: 8953095679271663709}
   - component: {fileID: 8656329211243488448}
-  - component: {fileID: -342697699264856680}
+  - component: {fileID: 1982316591228338259}
+  - component: {fileID: 8950354282276981418}
+  - component: {fileID: 7312695758170229688}
   m_Layer: 16
   m_Name: SpaceFries
   m_TagString: Untagged
@@ -887,6 +890,19 @@ MonoBehaviour:
   serverOnly: 0
   m_AssetId: 
   hasSpawned: 0
+--- !u!65 &9078880203578673513
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5910432035244984084}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.24531314, y: 0.3083501, z: 0.21692303}
+  m_Center: {x: -0.0009316653, y: 0.1486665, z: 0.00003837049}
 --- !u!54 &2154479770022788754
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -903,19 +919,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!65 &9078880203578673513
-BoxCollider:
+--- !u!114 &-342697699264856680
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5910432035244984084}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.24531314, y: 0.3083501, z: 0.21692303}
-  m_Center: {x: -0.0009316653, y: 0.1486665, z: 0.00003837049}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &8953095679271663709
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -932,7 +953,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: fries_space
   Name: Space Fries
-  Volume: 12
+  Volume: 10
   container: {fileID: 0}
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 5910432035244984084}
@@ -954,7 +975,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: Fried potato slices.
   MaxDistance: 0
---- !u!114 &-342697699264856680
+--- !u!114 &1982316591228338259
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -963,15 +984,138 @@ MonoBehaviour:
   m_GameObject: {fileID: 5910432035244984084}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  content: {fileID: 8950354282276981418}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 7312695758170229688}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 8953095679271663709}
+--- !u!114 &8950354282276981418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5910432035244984084}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 1000
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 5
+--- !u!82 &7312695758170229688
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5910432035244984084}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &6324070648879734009
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/banana peel.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/banana peel.prefab
@@ -12,12 +12,12 @@ GameObject:
   - component: {fileID: 6102422768218808755}
   - component: {fileID: 6303733993938204412}
   - component: {fileID: 6650144901923549122}
+  - component: {fileID: 1155936791591065296}
   - component: {fileID: 3233781620974244719}
+  - component: {fileID: 146116797563218815}
   - component: {fileID: 7689635437763503072}
   - component: {fileID: 448349732004621884}
-  - component: {fileID: 1240913746253889284}
   - component: {fileID: 2949647390327175656}
-  - component: {fileID: 146116797563218815}
   m_Layer: 16
   m_Name: banana peel
   m_TagString: Untagged
@@ -103,6 +103,20 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!64 &1155936791591065296
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5367923578081395378}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 3890010298973275403, guid: e40e3f4ef919bad45a7c34e8bf6473eb, type: 3}
 --- !u!54 &3233781620974244719
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -119,6 +133,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &146116797563218815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5367923578081395378}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &7689635437763503072
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -135,7 +167,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: banana_peel
   Name: Banana Peel
-  Volume: 10
+  Volume: 7
   container: {fileID: 0}
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 5367923578081395378}
@@ -158,20 +190,6 @@ MonoBehaviour:
 
     Take care not to slip.'
   MaxDistance: 0
---- !u!64 &1240913746253889284
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5367923578081395378}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 3890010298973275403, guid: e40e3f4ef919bad45a7c34e8bf6473eb, type: 3}
 --- !u!114 &2949647390327175656
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -186,24 +204,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &146116797563218815
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5367923578081395378}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  knockdownDuration: 3
+  knockdownPause: 1
 --- !u!1 &8560019361223259992
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/banana.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/banana.prefab
@@ -42,13 +42,13 @@ GameObject:
   - component: {fileID: 7477522284070196005}
   - component: {fileID: 7209712567220946026}
   - component: {fileID: 8016222924898131284}
-  - component: {fileID: 2275976470507102713}
   - component: {fileID: -6751516305611895406}
+  - component: {fileID: 2275976470507102713}
   - component: {fileID: 4927198185291025271}
   - component: {fileID: 6816536106933793647}
+  - component: {fileID: 6143507213145409448}
   - component: {fileID: 3512292834628846155}
   - component: {fileID: 5688882188462630418}
-  - component: {fileID: 6143507213145409448}
   - component: {fileID: 8805611969679259197}
   m_Layer: 16
   m_Name: banana
@@ -135,6 +135,20 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!64 &-6751516305611895406
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8722317747974713380}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 3216447080179446721, guid: e40e3f4ef919bad45a7c34e8bf6473eb, type: 3}
 --- !u!54 &2275976470507102713
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -151,20 +165,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!64 &-6751516305611895406
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8722317747974713380}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 3216447080179446721, guid: e40e3f4ef919bad45a7c34e8bf6473eb, type: 3}
 --- !u!114 &4927198185291025271
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -199,7 +199,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: banana
   Name: banana
-  Volume: 10
+  Volume: 9
   container: {fileID: 0}
   sprite: {fileID: 0}
   prefab: {fileID: 8722317747974713380}
@@ -207,6 +207,20 @@ MonoBehaviour:
   bulkSize: 2
   traits:
   - {fileID: 11400000, guid: 76dd1a5ac7fd55d428ed789d29c15f9c, type: 2}
+--- !u!114 &6143507213145409448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8722317747974713380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59d174b721ba45d285a8f164a519c314, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Text: 
+  MaxDistance: 0
 --- !u!114 &3512292834628846155
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -247,26 +261,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Volume: 5
+  Volume: 800
   Temperature: 0
   Locked: 0
   substances:
-  - Substance: {fileID: 11400000, guid: b8980899917cbe5448c75ab705a4751e, type: 2}
-    Moles: 5
---- !u!114 &6143507213145409448
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8722317747974713380}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59d174b721ba45d285a8f164a519c314, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Text: Careful.
-  MaxDistance: 0
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 4
 --- !u!82 &8805611969679259197
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/dough_flat.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/dough_flat.prefab
@@ -42,13 +42,16 @@ GameObject:
   - component: {fileID: 6548696891706493495}
   - component: {fileID: 8569540515471246955}
   - component: {fileID: 2725125109431974546}
-  - component: {fileID: 3232963276106930532}
   - component: {fileID: 6692222832881912123}
+  - component: {fileID: 3232963276106930532}
+  - component: {fileID: 7026458861616161635}
   - component: {fileID: 3497183203355209607}
   - component: {fileID: 1990269798252950696}
+  - component: {fileID: -4562768560119115629}
+  - component: {fileID: -4791193206500264321}
   - component: {fileID: 5602736186390864255}
   - component: {fileID: 4543423368307729912}
-  - component: {fileID: 7026458861616161635}
+  - component: {fileID: 589475324880954694}
   m_Layer: 16
   m_Name: dough_flat
   m_TagString: Untagged
@@ -134,6 +137,20 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!64 &6692222832881912123
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4462294093420203598}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -4699321145176856470, guid: 63ecbe31bc18b3947b6f6e61af7095c8, type: 3}
 --- !u!54 &3232963276106930532
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -150,20 +167,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!64 &6692222832881912123
-MeshCollider:
+--- !u!114 &7026458861616161635
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4462294093420203598}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: -4699321145176856470, guid: 63ecbe31bc18b3947b6f6e61af7095c8, type: 3}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &3497183203355209607
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -180,7 +201,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: dough_flat
   Name: Flat Dough
-  Volume: 10
+  Volume: 7
   container: {fileID: 0}
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 4462294093420203598}
@@ -202,6 +223,51 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: A flat piece of dough.
   MaxDistance: 0
+--- !u!114 &-4562768560119115629
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4462294093420203598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  content: {fileID: -4791193206500264321}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 589475324880954694}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 3497183203355209607}
+--- !u!114 &-4791193206500264321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4462294093420203598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 600
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 3
 --- !u!114 &5602736186390864255
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -244,21 +310,99 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ResultingObject: {fileID: 3586434867307094036, guid: 5f721ca3320ab2f4b883121e62bdc722,
     type: 3}
---- !u!114 &7026458861616161635
-MonoBehaviour:
+--- !u!82 &589475324880954694
+AudioSource:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4462294093420203598}
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Content/Items/Consumables/Food/General/dough_flat_strip.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/dough_flat_strip.prefab
@@ -42,11 +42,14 @@ GameObject:
   - component: {fileID: 607304499686474410}
   - component: {fileID: 2621427773929590518}
   - component: {fileID: 8601215309269004815}
-  - component: {fileID: 9102333268122751481}
   - component: {fileID: 1032375638008168870}
+  - component: {fileID: 9102333268122751481}
+  - component: {fileID: -5082456465847746151}
   - component: {fileID: 7062854236247353114}
   - component: {fileID: 8724229121176618736}
-  - component: {fileID: -5082456465847746151}
+  - component: {fileID: 6195544209730703047}
+  - component: {fileID: 5331741331010615761}
+  - component: {fileID: 2736423099677543994}
   m_Layer: 16
   m_Name: dough_flat_strip
   m_TagString: Untagged
@@ -132,6 +135,20 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!64 &1032375638008168870
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8025821132411324115}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -1312670080612827256, guid: 63ecbe31bc18b3947b6f6e61af7095c8, type: 3}
 --- !u!54 &9102333268122751481
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -148,20 +165,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!64 &1032375638008168870
-MeshCollider:
+--- !u!114 &-5082456465847746151
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8025821132411324115}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: -1312670080612827256, guid: 63ecbe31bc18b3947b6f6e61af7095c8, type: 3}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &7062854236247353114
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -178,7 +199,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: dough_flat_strip
   Name: Dough Strip
-  Volume: 10
+  Volume: 3
   container: {fileID: 0}
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 8025821132411324115}
@@ -200,7 +221,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: A single strip of dough.
   MaxDistance: 0
---- !u!114 &-5082456465847746151
+--- !u!114 &6195544209730703047
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -209,12 +230,135 @@ MonoBehaviour:
   m_GameObject: {fileID: 8025821132411324115}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  content: {fileID: 5331741331010615761}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 2736423099677543994}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 7062854236247353114}
+--- !u!114 &5331741331010615761
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8025821132411324115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 200
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 1
+--- !u!82 &2736423099677543994
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8025821132411324115}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Content/Items/Consumables/Food/General/dough_round.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/dough_round.prefab
@@ -12,12 +12,15 @@ GameObject:
   - component: {fileID: 8401997912625749112}
   - component: {fileID: 6383111433483456548}
   - component: {fileID: 840439668067527901}
+  - component: {fileID: 8261796892599394164}
   - component: {fileID: 190711725925060395}
+  - component: {fileID: -7818006830538394297}
   - component: {fileID: 2229347982406089160}
   - component: {fileID: 3539367462563155156}
-  - component: {fileID: 8261796892599394164}
+  - component: {fileID: -4924483264707824554}
+  - component: {fileID: 2853651941385813992}
   - component: {fileID: 7166567432907061237}
-  - component: {fileID: -7818006830538394297}
+  - component: {fileID: 7094869394559624161}
   m_Layer: 16
   m_Name: dough_round
   m_TagString: Untagged
@@ -103,6 +106,20 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!64 &8261796892599394164
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1411035571888707585}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -5377715398667767560, guid: 63ecbe31bc18b3947b6f6e61af7095c8, type: 3}
 --- !u!54 &190711725925060395
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -119,6 +136,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &-7818006830538394297
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1411035571888707585}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &2229347982406089160
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -135,7 +170,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: dough
   Name: Dough
-  Volume: 10
+  Volume: 7
   container: {fileID: 0}
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 1411035571888707585}
@@ -157,20 +192,49 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: Limitless potential.
   MaxDistance: 0
---- !u!64 &8261796892599394164
-MeshCollider:
+--- !u!114 &-4924483264707824554
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1411035571888707585}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: -5377715398667767560, guid: 63ecbe31bc18b3947b6f6e61af7095c8, type: 3}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  content: {fileID: 2853651941385813992}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 7094869394559624161}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 2229347982406089160}
+--- !u!114 &2853651941385813992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1411035571888707585}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 0
+  Temperature: 0
+  Locked: 0
+  substances: []
 --- !u!114 &7166567432907061237
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -191,24 +255,102 @@ MonoBehaviour:
       type: 3}
     Position: {x: 0, y: 0, z: 0}
     Rotation: {x: 0, y: 0, z: 0}
---- !u!114 &-7818006830538394297
-MonoBehaviour:
+--- !u!82 &7094869394559624161
+AudioSource:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1411035571888707585}
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &3274284041065487966
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/egg_fried.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/egg_fried.prefab
@@ -12,11 +12,14 @@ GameObject:
   - component: {fileID: 2715106678528874436}
   - component: {fileID: 693912447964453784}
   - component: {fileID: 6529600274299840353}
-  - component: {fileID: 6021753586946622615}
   - component: {fileID: 2563629241064264904}
+  - component: {fileID: 6021753586946622615}
+  - component: {fileID: -7976972077361276393}
   - component: {fileID: 5747762574740222580}
   - component: {fileID: 7375444279801537496}
-  - component: {fileID: -7976972077361276393}
+  - component: {fileID: 7806937448744261703}
+  - component: {fileID: 411077611754692082}
+  - component: {fileID: 8462207155458017799}
   m_Layer: 16
   m_Name: egg_fried
   m_TagString: Untagged
@@ -102,6 +105,20 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!64 &2563629241064264904
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4801148184707290045}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -7546834438339471214, guid: c4537179f902ad94d8265ea24ec86ea5, type: 3}
 --- !u!54 &6021753586946622615
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -118,20 +135,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!64 &2563629241064264904
-MeshCollider:
+--- !u!114 &-7976972077361276393
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4801148184707290045}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: -7546834438339471214, guid: c4537179f902ad94d8265ea24ec86ea5, type: 3}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &5747762574740222580
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -148,7 +169,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: egg_fried
   Name: Fried Egg
-  Volume: 10
+  Volume: 5
   container: {fileID: 0}
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 4801148184707290045}
@@ -170,7 +191,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: Cooked egg.
   MaxDistance: 0
---- !u!114 &-7976972077361276393
+--- !u!114 &7806937448744261703
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -179,15 +200,138 @@ MonoBehaviour:
   m_GameObject: {fileID: 4801148184707290045}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  content: {fileID: 411077611754692082}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 8462207155458017799}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 5747762574740222580}
+--- !u!114 &411077611754692082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4801148184707290045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 600
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 3
+--- !u!82 &8462207155458017799
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4801148184707290045}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &8954436211759437282
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Consumables/Food/General/omelette.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/omelette.prefab
@@ -42,11 +42,14 @@ GameObject:
   - component: {fileID: 5772065308349761132}
   - component: {fileID: 8941549900616600112}
   - component: {fileID: 3398613710840100553}
-  - component: {fileID: 2748903352563225919}
   - component: {fileID: 6207181591353656672}
+  - component: {fileID: 2748903352563225919}
+  - component: {fileID: -2096131120537101781}
   - component: {fileID: 4211893044832035804}
   - component: {fileID: 1079151324591260441}
-  - component: {fileID: -2096131120537101781}
+  - component: {fileID: -8675957228016265816}
+  - component: {fileID: -4641667771450322447}
+  - component: {fileID: 5100085244689216503}
   m_Layer: 16
   m_Name: omelette
   m_TagString: Untagged
@@ -132,6 +135,20 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!64 &6207181591353656672
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -6859419831718007711, guid: c4537179f902ad94d8265ea24ec86ea5, type: 3}
 --- !u!54 &2748903352563225919
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -148,20 +165,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!64 &6207181591353656672
-MeshCollider:
+--- !u!114 &-2096131120537101781
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3969530706517246485}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: -6859419831718007711, guid: c4537179f902ad94d8265ea24ec86ea5, type: 3}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &4211893044832035804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -178,7 +199,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: omelette
   Name: Omelette
-  Volume: 10
+  Volume: 7
   container: {fileID: 0}
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 3969530706517246485}
@@ -200,7 +221,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: Fancy scrambled egg.
   MaxDistance: 0
---- !u!114 &-2096131120537101781
+--- !u!114 &-8675957228016265816
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -209,12 +230,135 @@ MonoBehaviour:
   m_GameObject: {fileID: 3969530706517246485}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  content: {fileID: -4641667771450322447}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 5100085244689216503}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 4211893044832035804}
+--- !u!114 &-4641667771450322447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 800
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 4
+--- !u!82 &5100085244689216503
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3969530706517246485}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Content/Items/Consumables/Food/General/tortilla.prefab
+++ b/Assets/Content/Items/Consumables/Food/General/tortilla.prefab
@@ -42,11 +42,14 @@ GameObject:
   - component: {fileID: 6253659811080463469}
   - component: {fileID: 8846702328748959793}
   - component: {fileID: 3024525101589075144}
+  - component: {fileID: 5834235620601882465}
   - component: {fileID: 2374832618428708670}
+  - component: {fileID: -1575500026413867806}
   - component: {fileID: 4368683844044030429}
   - component: {fileID: 5954837848037063713}
-  - component: {fileID: 5834235620601882465}
-  - component: {fileID: -1575500026413867806}
+  - component: {fileID: 9117000747992934704}
+  - component: {fileID: 1195661807417070721}
+  - component: {fileID: 2222207985291738341}
   m_Layer: 16
   m_Name: tortilla
   m_TagString: Untagged
@@ -132,6 +135,20 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!64 &5834235620601882465
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3586434867307094036}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -5070004675342587353, guid: 5391afdc78c3b794eab4f8d6399183b6, type: 3}
 --- !u!54 &2374832618428708670
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -148,6 +165,24 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &-1575500026413867806
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3586434867307094036}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
 --- !u!114 &4368683844044030429
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -164,7 +199,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: tortilla
   Name: Tortilla
-  Volume: 14
+  Volume: 6
   container: {fileID: 0}
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 3586434867307094036}
@@ -186,21 +221,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Text: A thin, flat pancake made from flour.
   MaxDistance: 0
---- !u!64 &5834235620601882465
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3586434867307094036}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: -5070004675342587353, guid: 5391afdc78c3b794eab4f8d6399183b6, type: 3}
---- !u!114 &-1575500026413867806
+--- !u!114 &9117000747992934704
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -209,12 +230,135 @@ MonoBehaviour:
   m_GameObject: {fileID: 3586434867307094036}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d41435391f55af44bf8a254724a129a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  content: {fileID: 1195661807417070721}
+  contentPerUse: 2
+  trashPrefab: {fileID: 0}
+  destroyObject: 1
+  audio: {fileID: 2222207985291738341}
+  sounds:
+  - {fileID: 8300000, guid: dcb671bcc99906d49a3bbc0abbac071f, type: 3}
+  - {fileID: 8300000, guid: a24c00d8a1105b749a5bd770d80a3fc7, type: 3}
+  consumeVerb: eat
+  feedTime: 1
+  LoadingBarPrefab: {fileID: 1998198171871307260, guid: 58d68fcd6d5f2c5458ad32de2270df37,
+    type: 3}
+  item: {fileID: 4368683844044030429}
+--- !u!114 &1195661807417070721
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3586434867307094036}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85f26fb7523bc4fadefb445dc09f8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Volume: 500
+  Temperature: 0
+  Locked: 0
+  substances:
+  - Substance: {fileID: 11400000, guid: 80d989d222d73b54bb0fdded2783af74, type: 2}
+    Moles: 2.5
+--- !u!82 &2222207985291738341
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3586434867307094036}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Content/Systems/Substances/Nutrients/Nutriment.asset
+++ b/Assets/Content/Systems/Substances/Nutrients/Nutriment.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6990eeb981f25548bd671e7ef3e741c, type: 3}
+  m_Name: Nutriment
+  m_EditorClassIdentifier: 
+  Id: nutriment
+  Color: {r: 0.6226415, g: 0.41970104, b: 0.26726595, a: 0.78431374}
+  MillilitersPerMole: 200

--- a/Assets/Content/Systems/Substances/Nutrients/Nutriment.asset.meta
+++ b/Assets/Content/Systems/Substances/Nutrients/Nutriment.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80d989d222d73b54bb0fdded2783af74
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Inventory/Item.cs
+++ b/Assets/Engine/Inventory/Item.cs
@@ -121,6 +121,12 @@ namespace SS3D.Engine.Inventory
         /// </summary>
         public void Destroy()
         {
+            if (container != null)
+            {
+                container.RemoveItem(gameObject);
+                container = null;
+            }
+            
             if (isServer)
             {
                 NetworkServer.Destroy(gameObject);

--- a/Assets/Engine/Substances/SubstanceContainer.cs
+++ b/Assets/Engine/Substances/SubstanceContainer.cs
@@ -191,11 +191,24 @@ namespace SS3D.Engine.Substances
                 moles = totalMoles;
             }
 
+            if (moles <= 0)
+            {
+                return;
+            }
+
             for (var i = 0; i < Substances.Count; i++)
             {
                 SubstanceEntry entry = Substances[i];
                 entry.Moles -= entry.Moles / totalMoles * moles;
-                Substances[i] = entry;
+                if (entry.Moles <= 0.0001)
+                {
+                    Substances.RemoveAt(i);
+                    i--;
+                }
+                else
+                {
+                    Substances[i] = entry;
+                }
             }
         }
 


### PR DESCRIPTION
- Adds a new substance called 'nutriment' which will temporarily be used on all foods until our substance system is more robust.
- Adds the 'consumable' script to all food prefabs using the new nutriment substance.

## KNOWN ISSUES

I'm not exactly sure why... but this breaks consuming slightly.
You will notice that eating food does not destroy the prefab or replace it with the trash prefab.

I did some testing with this, and I realized it has to do with the settings of the substance in the food.
The way John had it set, was that the substance (calcium) had a Milliliter to Mole value of 1, with the food's substance container had a volume of 5, so he added 5 moles of the substance to the food.
The way I have it set now is, the substance (nutriment) has a Milliliter to Mole value of 200, with the food's substance container with volume of 400-1000 depending on the food, and the number of moles of the substance I would add would be the foods volume divided by the substance Milliliter to Mole value (so a food with 1000 volume would have 5 moles).

Anyway, I'm not sure why the change in the substance stats broke eating destroying/updating the prefabs...