### PR TITLE
IExaminable name/description separation

### DIFF
--- a/Assets/Content/Creatures/Player Races/Human/Human.prefab
+++ b/Assets/Content/Creatures/Player Races/Human/Human.prefab
@@ -453,9 +453,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Goao</b>
-
-    The naked man.'
+  DisplayName: Goao
+  Text: The naked man.
   MaxDistance: 0
 --- !u!114 &340761490495231774
 MonoBehaviour:

--- a/Assets/Content/Furniture/Flora/Potted Plants/exotic plant.prefab
+++ b/Assets/Content/Furniture/Flora/Potted Plants/exotic plant.prefab
@@ -125,5 +125,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Potted Plant</b>
+  DisplayName: Potted Plant
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Flora/Potted Plants/plant 0.prefab
+++ b/Assets/Content/Furniture/Flora/Potted Plants/plant 0.prefab
@@ -124,5 +124,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Potted Plant</b>
+  DisplayName: Potted Plant
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Flora/Potted Plants/sapling.prefab
+++ b/Assets/Content/Furniture/Flora/Potted Plants/sapling.prefab
@@ -124,5 +124,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Potted Plant</b>
+  DisplayName: Potted Plant
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Flora/Potted Plants/spiky plant.prefab
+++ b/Assets/Content/Furniture/Flora/Potted Plants/spiky plant.prefab
@@ -124,5 +124,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Potted Plant</b>
+  DisplayName: Potted Plant
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Jukebox.prefab
+++ b/Assets/Content/Furniture/Generic/Jukebox.prefab
@@ -146,9 +146,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Jukebox</b>
-
-    Plays sick beats.'
+  DisplayName: Jukebox
+  Text: Plays sick beats.
   MaxDistance: 0
 --- !u!114 &2780048927197938333
 MonoBehaviour:

--- a/Assets/Content/Furniture/Generic/Mop Bucket.prefab
+++ b/Assets/Content/Furniture/Generic/Mop Bucket.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Mop Bucket</b>
+  DisplayName: Mop Bucket
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Seats/Bar Stool.prefab
+++ b/Assets/Content/Furniture/Generic/Seats/Bar Stool.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Bar Stool</b>
+  DisplayName: Bar Stool
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Seats/Office Chair.prefab
+++ b/Assets/Content/Furniture/Generic/Seats/Office Chair.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Office Chair</b>
+  DisplayName: Office Chair
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Seats/Plastic Chair Blue.prefab
+++ b/Assets/Content/Furniture/Generic/Seats/Plastic Chair Blue.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Plastic Chair</b>
+  DisplayName: Plastic Chair
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Seats/Plastic Chair White.prefab
+++ b/Assets/Content/Furniture/Generic/Seats/Plastic Chair White.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Plastic Chair</b>
+  DisplayName: Plastic Chair
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Seats/Stool.prefab
+++ b/Assets/Content/Furniture/Generic/Seats/Stool.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Stool</b>
+  DisplayName: Stool
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Seats/Toilet/Toilet.prefab
+++ b/Assets/Content/Furniture/Generic/Seats/Toilet/Toilet.prefab
@@ -199,7 +199,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Toilet</b>
+  DisplayName: Toilet
+  Text: 
   MaxDistance: 0
 --- !u!95 &6933098557949719560
 Animator:

--- a/Assets/Content/Furniture/Generic/Sink.prefab
+++ b/Assets/Content/Furniture/Generic/Sink.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Sink</b>
+  DisplayName: 
+  Text: <b></b>
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Surfaces/Glass/Table - Glass.prefab
+++ b/Assets/Content/Furniture/Generic/Surfaces/Glass/Table - Glass.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Glass Table</b>
+  DisplayName: Glass Table
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Surfaces/Metal/Table - Metal.prefab
+++ b/Assets/Content/Furniture/Generic/Surfaces/Metal/Table - Metal.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 1683531520590988412}
   - component: {fileID: 4978950379207847613}
   m_Layer: 0
-  m_Name: MetalTable
+  m_Name: Table - Metal
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -143,7 +143,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Metal Table</b>
+  DisplayName: Metal Table
+  Text: 
   MaxDistance: 0
 --- !u!1001 &5077701558365432987
 PrefabInstance:

--- a/Assets/Content/Furniture/Generic/Surfaces/Poker/Table - Poker.prefab
+++ b/Assets/Content/Furniture/Generic/Surfaces/Poker/Table - Poker.prefab
@@ -142,7 +142,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poker Table</b>
+  DisplayName: Poker Table
+  Text: 
   MaxDistance: 0
 --- !u!1001 &6293662703714347641
 PrefabInstance:

--- a/Assets/Content/Furniture/Generic/Surfaces/Table Frame - Metal.prefab
+++ b/Assets/Content/Furniture/Generic/Surfaces/Table Frame - Metal.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Metal Table Frame</b>
+  DisplayName: Metal Table Frame
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Surfaces/Table Frame - Wood.prefab
+++ b/Assets/Content/Furniture/Generic/Surfaces/Table Frame - Wood.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wood Table Frame</b>
+  DisplayName: Wood Table Frame
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Generic/Surfaces/Wood/Table - Wood.prefab
+++ b/Assets/Content/Furniture/Generic/Surfaces/Wood/Table - Wood.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5549007176416625144}
   - component: {fileID: -6754659111865001399}
   m_Layer: 0
-  m_Name: WoodTable
+  m_Name: Table - Wood
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -142,7 +142,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wood Table</b>
+  DisplayName: Wood Table
+  Text: 
   MaxDistance: 0
 --- !u!1001 &6293662703714347641
 PrefabInstance:

--- a/Assets/Content/Furniture/Generic/Water Cooler.prefab
+++ b/Assets/Content/Furniture/Generic/Water Cooler.prefab
@@ -142,9 +142,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Water Cooler</b>
-
-    Dispenses cups and water.'
+  DisplayName: Water Cooler
+  Text: Dispenses cups and water.
   MaxDistance: 0
 --- !u!114 &4497921957389231919
 MonoBehaviour:

--- a/Assets/Content/Furniture/Generic/WaterCooler.cs
+++ b/Assets/Content/Furniture/Generic/WaterCooler.cs
@@ -44,5 +44,10 @@ namespace SS3D.Content.Furniture.Generic
         {
             return $"{NumberOfCups} cups remaining.";
         }
+		
+        public virtual string GetName(GameObject examinator)
+        {
+            return gameObject.name;
+        }		
     }
 }

--- a/Assets/Content/Furniture/Generic/WaterCooler.cs
+++ b/Assets/Content/Furniture/Generic/WaterCooler.cs
@@ -47,7 +47,7 @@ namespace SS3D.Content.Furniture.Generic
 		
         public virtual string GetName(GameObject examinator)
         {
-            return gameObject.name;
+            return "";
         }		
     }
 }

--- a/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister - Air.prefab
+++ b/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister - Air.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 7394184406077612064}
   - component: {fileID: 8839139762038401630}
   m_Layer: 0
-  m_Name: Canister_Air
+  m_Name: Canister - Air
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -172,8 +172,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Air Canister</b>
-
-    Contains Oxygen, so make sure this doesn''t run
-    out.'
+  DisplayName: Air Canister
+  Text: Contains Oxygen, so make sure this doesn't run out.
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister - Oxygen.prefab
+++ b/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister - Oxygen.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 7394184406077612064}
   - component: {fileID: 8839139762038401630}
   m_Layer: 0
-  m_Name: Canister_Oxygen
+  m_Name: Canister - Oxygen
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -172,8 +172,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Oxygen Canister</b>
-
-    Contains Oxygen, so make sure this doesn''t
-    run out.'
+  DisplayName: Oxygen Canister
+  Text: Contains Oxygen, so make sure this doesn't run out.
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister - Plasma.prefab
+++ b/Assets/Content/Furniture/Machines/Atmospherics/Canister/Canister - Plasma.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 7394184406077612064}
   - component: {fileID: 8839139762038401630}
   m_Layer: 0
-  m_Name: Canister_Plasma
+  m_Name: Canister - Plasma
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -172,7 +172,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Plasma Canister</b>
-
-    CAUTION, contains Plasma!'
+  DisplayName: Plasma Canister
+  Text: CAUTION, contains Plasma!
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Atmospherics/Disposal Bin/Disposal Bin.prefab
+++ b/Assets/Content/Furniture/Machines/Atmospherics/Disposal Bin/Disposal Bin.prefab
@@ -281,8 +281,10 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   containerName: Disposals
-  containerType: 2
-  slots: 00000000
+  containerFilter: {fileID: 0}
+  volumeLimited: 1
+  maxVolume: 50
+  slots: 0
 --- !u!114 &4265221962216021434
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -295,9 +297,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Disposal Bin</b>
-
-    Flushes away items.'
+  DisplayName: Disposal Bin
+  Text: Flushes away items.
   MaxDistance: 0
 --- !u!1 &7531797193249841566
 GameObject:

--- a/Assets/Content/Furniture/Machines/Atmospherics/Tank Storage Unit.prefab
+++ b/Assets/Content/Furniture/Machines/Atmospherics/Tank Storage Unit.prefab
@@ -272,5 +272,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Tank Storage Unit</b>
+  DisplayName: Tank Storage Unit
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Engineering/SMES.prefab
+++ b/Assets/Content/Furniture/Machines/Engineering/SMES.prefab
@@ -124,5 +124,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>SMES</b>
+  DisplayName: SMES
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Engineering/Solar Panel.prefab
+++ b/Assets/Content/Furniture/Machines/Engineering/Solar Panel.prefab
@@ -693,7 +693,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Solar Panel</b>
+  DisplayName: Solar Panel
+  Text: 
   MaxDistance: 0
 --- !u!1 &7567171903771937248
 GameObject:

--- a/Assets/Content/Furniture/Machines/Generic/Computers/Console - Off.prefab
+++ b/Assets/Content/Furniture/Machines/Generic/Computers/Console - Off.prefab
@@ -430,7 +430,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Console</b>
+  DisplayName: Console
+  Text: 
   MaxDistance: 0
 --- !u!1 &6505763806015701181
 GameObject:

--- a/Assets/Content/Furniture/Machines/Generic/Computers/Console - Surgery.prefab
+++ b/Assets/Content/Furniture/Machines/Generic/Computers/Console - Surgery.prefab
@@ -556,7 +556,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Surgery Console</b>
+  DisplayName: Surgery Console
+  Text: 
   MaxDistance: 0
 --- !u!1 &6505763806015701181
 GameObject:

--- a/Assets/Content/Furniture/Machines/Kitchen/Microwave/microwave.prefab
+++ b/Assets/Content/Furniture/Machines/Kitchen/Microwave/microwave.prefab
@@ -246,9 +246,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Microwave</b>
-
-    Uses radiation to cook food.
+  DisplayName: Microwave
+  Text: 'Uses radiation to cook food.
 
     MMMMMMMMMMM'
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Kitchen/Stove.prefab
+++ b/Assets/Content/Furniture/Machines/Kitchen/Stove.prefab
@@ -159,5 +159,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Stove</b>
+  DisplayName: Stove
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Kitchen/Table Booze Dispenser.prefab
+++ b/Assets/Content/Furniture/Machines/Kitchen/Table Booze Dispenser.prefab
@@ -350,9 +350,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Booze Dispenser</b>
-
-    Dispenses various types of booze.'
+  DisplayName: Booze Dispenser
+  Text: Dispenses various types of booze.
   MaxDistance: 0
 --- !u!1 &8961199219136555141
 GameObject:

--- a/Assets/Content/Furniture/Machines/Kitchen/blender.prefab
+++ b/Assets/Content/Furniture/Machines/Kitchen/blender.prefab
@@ -174,9 +174,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Blender</b>
-
-    Will it blend?'
+  DisplayName: Blender
+  Text: Will it blend?
   MaxDistance: 0
 --- !u!1 &6833785211540108661
 GameObject:

--- a/Assets/Content/Furniture/Machines/Medical/Chemical Dispenser.prefab
+++ b/Assets/Content/Furniture/Machines/Medical/Chemical Dispenser.prefab
@@ -219,5 +219,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Chemical Dispenser</b>
+  DisplayName: Chemical Dispenser
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Medical/Chemical Heater.prefab
+++ b/Assets/Content/Furniture/Machines/Medical/Chemical Heater.prefab
@@ -218,5 +218,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Chemical Heater</b>
+  DisplayName: Chemical Heater
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Medical/Sleeper Bed.prefab
+++ b/Assets/Content/Furniture/Machines/Medical/Sleeper Bed.prefab
@@ -157,7 +157,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Sleeper</b>
+  DisplayName: Sleeper
+  Text: 
   MaxDistance: 0
 --- !u!1 &9199454391362990948
 GameObject:

--- a/Assets/Content/Furniture/Machines/Medical/cryotube.prefab
+++ b/Assets/Content/Furniture/Machines/Medical/cryotube.prefab
@@ -258,6 +258,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Volume: 1000
   Temperature: 2
+  Locked: 0
   substances: []
 --- !u!114 &1176681601152780847
 MonoBehaviour:
@@ -271,7 +272,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Cryotube</b>
+  DisplayName: Cryotube
+  Text: 
   MaxDistance: 0
 --- !u!1 &5625392702527621547
 GameObject:

--- a/Assets/Content/Furniture/Machines/Science/Cell Charger.prefab
+++ b/Assets/Content/Furniture/Machines/Science/Cell Charger.prefab
@@ -376,7 +376,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Cell Charger</b>
+  DisplayName: Cell Charger
+  Text: 
   MaxDistance: 0
 --- !u!114 &8950008734791454200
 MonoBehaviour:

--- a/Assets/Content/Furniture/Machines/Science/Holopad.prefab
+++ b/Assets/Content/Furniture/Machines/Science/Holopad.prefab
@@ -125,5 +125,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Holopad</b>
+  DisplayName: Holopad
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Machines/Vendors/Booze Vendor.prefab
+++ b/Assets/Content/Furniture/Machines/Vendors/Booze Vendor.prefab
@@ -572,9 +572,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Booze-O-Mat</b>
-
-    Dispenses booze.'
+  DisplayName: Booze-O-Mat
+  Text: Dispenses booze.
   MaxDistance: 0
 --- !u!1 &9139902570717850779
 GameObject:

--- a/Assets/Content/Furniture/Machines/Vendors/Cigarette Vendor.prefab
+++ b/Assets/Content/Furniture/Machines/Vendors/Cigarette Vendor.prefab
@@ -536,9 +536,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Poke N'' Toke</b>
-
-    Dispenses cigarette paraphernalia.'
+  DisplayName: Poke N' Toke
+  Text: Dispenses cigarette paraphernalia.
   MaxDistance: 0
 --- !u!1 &9139902570717850779
 GameObject:

--- a/Assets/Content/Furniture/Machines/Vendors/Kitchenware Vendor.prefab
+++ b/Assets/Content/Furniture/Machines/Vendors/Kitchenware Vendor.prefab
@@ -293,9 +293,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Dinnerware</b>
-
-    Dispenses dinnerware and utencils.'
+  DisplayName: Dinnerware
+  Text: Dispenses dinnerware and utensils.
   MaxDistance: 0
 --- !u!1 &3135266143589959528
 GameObject:

--- a/Assets/Content/Furniture/Machines/Vendors/Snack Vendor.prefab
+++ b/Assets/Content/Furniture/Machines/Vendors/Snack Vendor.prefab
@@ -294,9 +294,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Getmore Chocolate Corp</b>
-
-    Dispenses snacks.'
+  DisplayName: Getmore Chocolate Corp
+  Text: Dispenses snacks.
   MaxDistance: 0
 --- !u!1 &3135266143589959528
 GameObject:

--- a/Assets/Content/Furniture/Machines/Vendors/Soda Vendor.prefab
+++ b/Assets/Content/Furniture/Machines/Vendors/Soda Vendor.prefab
@@ -318,9 +318,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Robust Softdrinks</b>
-
-    Dispenses sodas.'
+  DisplayName: Robust Softdrinks
+  Text: Dispenses sodas.
   MaxDistance: 0
 --- !u!1 &5847245816668003842
 GameObject:

--- a/Assets/Content/Furniture/Machines/Vendors/Tool Vendor.prefab
+++ b/Assets/Content/Furniture/Machines/Vendors/Tool Vendor.prefab
@@ -428,7 +428,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>YouTool</b>
-
-    Dispenses tools.'
+  DisplayName: YouTool
+  Text: Dispenses tools.
   MaxDistance: 0

--- a/Assets/Content/Furniture/NetworkedOpenable.cs
+++ b/Assets/Content/Furniture/NetworkedOpenable.cs
@@ -8,7 +8,7 @@ namespace SS3D.Content.Furniture
     [RequireComponent(typeof(Animator))]
     public class NetworkedOpenable : InteractionTargetNetworkBehaviour
     {
-        private Animator animator;
+        protected Animator animator;
         private static readonly int Open = Animator.StringToHash("Open");
 
         [SerializeField] private Sprite OpenIcon;

--- a/Assets/Content/Furniture/Openable.cs
+++ b/Assets/Content/Furniture/Openable.cs
@@ -9,7 +9,7 @@ namespace SS3D.Content.Furniture
     [RequireComponent(typeof(Animator))]
     public class Openable : InteractionTargetBehaviour
     {
-        private Animator animator;
+        protected Animator animator;
         private static readonly int OpenId = Animator.StringToHash("Open");
         [SerializeField] private Sprite openInteractionIcon;
 

--- a/Assets/Content/Furniture/Storage/Crates/crate.prefab
+++ b/Assets/Content/Furniture/Storage/Crates/crate.prefab
@@ -357,7 +357,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Crate</b>
-
-    Stores stuff.'
+  DisplayName: Crate
+  Text: Stores stuff.
   MaxDistance: 0

--- a/Assets/Content/Furniture/Storage/Fridge/fridge.prefab
+++ b/Assets/Content/Furniture/Storage/Fridge/fridge.prefab
@@ -228,9 +228,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Fridge</b>
-
-    Stores food and bodyparts (optional).'
+  DisplayName: Fridge
+  Text: Stores food and bodyparts (optional).
   MaxDistance: 0
 --- !u!1 &5240830354732226920
 GameObject:

--- a/Assets/Content/Furniture/Storage/Janitorial Cart.prefab
+++ b/Assets/Content/Furniture/Storage/Janitorial Cart.prefab
@@ -174,11 +174,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 98817192546812284}
   attachmentPoint: {fileID: 588640168151614680}
+  bulkSize: 2
+  traits: []
 --- !u!54 &1083607476504503504
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -387,11 +389,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 299036864769005122}
   attachmentPoint: {fileID: 3332213703804836053}
+  bulkSize: 2
+  traits: []
 --- !u!54 &136366877182507820
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -537,11 +541,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 537510913525999881}
   attachmentPoint: {fileID: 0}
+  bulkSize: 2
+  traits: []
 --- !u!54 &325119174336063320
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -748,11 +754,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 1767105460036955147}
   attachmentPoint: {fileID: 1293185816858175919}
+  bulkSize: 2
+  traits: []
 --- !u!54 &2065765061887679786
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1115,11 +1123,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 2954702816147868532}
   attachmentPoint: {fileID: 2338883495983009488}
+  bulkSize: 2
+  traits: []
 --- !u!54 &2586193647671002034
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1266,11 +1276,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 3100858152501622538}
   attachmentPoint: {fileID: 2484899183094133422}
+  bulkSize: 2
+  traits: []
 --- !u!114 &2240058995338629586
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1285,6 +1297,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  knockdownDuration: 3
+  knockdownPause: 1
 --- !u!54 &6304221418328680100
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1430,11 +1444,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 3278308036721701354}
   attachmentPoint: {fileID: 8885211440114728023}
+  bulkSize: 2
+  traits: []
 --- !u!54 &5745052125497751448
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1611,11 +1627,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 3707473956010934445}
   attachmentPoint: {fileID: 7296931575052619024}
+  bulkSize: 2
+  traits: []
 --- !u!54 &6334490238877212173
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1748,11 +1766,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 3944235866505903018}
   attachmentPoint: {fileID: 0}
+  bulkSize: 2
+  traits: []
 --- !u!54 &5140523793104339387
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2032,11 +2052,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 4696157158292155660}
   attachmentPoint: {fileID: 1665317550003970225}
+  bulkSize: 2
+  traits: []
 --- !u!54 &5801429455750956107
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2270,9 +2292,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Janitorial Cart</b>
-
-    Neatly holds all of the janitor''s equipment.'
+  DisplayName: Janitorial Cart
+  Text: Neatly holds all of the janitor's equipment.
   MaxDistance: 0
 --- !u!1 &5221473445564893971
 GameObject:
@@ -2569,11 +2590,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 6200101252375068876}
   attachmentPoint: {fileID: 6881354644099237224}
+  bulkSize: 2
+  traits: []
 --- !u!54 &8808370119886968644
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2855,11 +2878,13 @@ MonoBehaviour:
   syncInterval: 0.1
   ItemId: 
   Name: 
+  Volume: 10
   container: {fileID: 0}
-  itemType: 0
   sprite: {fileID: 21300000, guid: 66026a73b54c5814aa62ed061b556bbd, type: 3}
   prefab: {fileID: 8630155634588003791}
   attachmentPoint: {fileID: 9128845340931549291}
+  bulkSize: 2
+  traits: []
 --- !u!54 &1299280962751579616
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Furniture/Storage/Lockers/Locker Basic Secure.prefab
+++ b/Assets/Content/Furniture/Storage/Lockers/Locker Basic Secure.prefab
@@ -473,7 +473,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Secure Locker</b>
-
-    Stores stuff.'
+  DisplayName: Secure Locker
+  Text: Stores stuff.
   MaxDistance: 0

--- a/Assets/Content/Furniture/Storage/Lockers/Locker Basic.prefab
+++ b/Assets/Content/Furniture/Storage/Lockers/Locker Basic.prefab
@@ -357,7 +357,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: '<b>Locker</b>
-
-    Stores stuff.'
+  DisplayName: Locker
+  Text: Stores stuff.
   MaxDistance: 0

--- a/Assets/Content/Furniture/Storage/StorageContainer.cs
+++ b/Assets/Content/Furniture/Storage/StorageContainer.cs
@@ -12,7 +12,6 @@ namespace SS3D.Content.Furniture.Storage
     {
         public bool OnlyStoreWhenOpen = false;
         public float MaxDistance = 5f;
-        private Animator animator;
 
         [SerializeField] private Sprite viewContainerIcon;
 

--- a/Assets/Content/Furniture/Storage/filing cabinet tall.prefab
+++ b/Assets/Content/Furniture/Storage/filing cabinet tall.prefab
@@ -251,5 +251,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Filing Cabinet</b>
+  DisplayName: Filing Cabinet
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Furniture/Storage/filing cabinet.prefab
+++ b/Assets/Content/Furniture/Storage/filing cabinet.prefab
@@ -251,5 +251,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Filing Cabinet</b>
+  DisplayName: Filing Cabinet
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Items/Consumables/Chemical/Cigarettes/Cigarette Butt.prefab
+++ b/Assets/Content/Items/Consumables/Chemical/Cigarettes/Cigarette Butt.prefab
@@ -168,7 +168,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59d174b721ba45d285a8f164a519c314, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: A dirt, ashy cigarette butt.
+  DisplayName: Cigarette butt
+  Text: Dirty, ashy and unhygienic.
   MaxDistance: 0
 --- !u!114 &-396234361631906964
 MonoBehaviour:

--- a/Assets/Content/Items/Consumables/Chemical/Cigarettes/Cigarette.prefab
+++ b/Assets/Content/Items/Consumables/Chemical/Cigarettes/Cigarette.prefab
@@ -293,6 +293,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59d174b721ba45d285a8f164a519c314, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DisplayName: Cigarette
   Text: Smoke em if ya got em.
   MaxDistance: 0
 --- !u!114 &-396234361631906964

--- a/Assets/Content/Items/Consumables/Chemical/Cigarettes/Packs/Cigarette Pack.prefab
+++ b/Assets/Content/Items/Consumables/Chemical/Cigarettes/Packs/Cigarette Pack.prefab
@@ -648,7 +648,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59d174b721ba45d285a8f164a519c314, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: A pack of smokes.
+  DisplayName: A pack of smokes
+  Text: 
   MaxDistance: 0
 --- !u!114 &-396234361631906964
 MonoBehaviour:

--- a/Assets/Content/Items/Functional/Materials/wood plank.prefab
+++ b/Assets/Content/Items/Functional/Materials/wood plank.prefab
@@ -168,6 +168,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59d174b721ba45d285a8f164a519c314, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DisplayName: 
   Text: 
   MaxDistance: 0
 --- !u!114 &4131194204592248743

--- a/Assets/Content/Structures/Doors/Classic Airlocks/Airlock Classic.prefab
+++ b/Assets/Content/Structures/Doors/Classic Airlocks/Airlock Classic.prefab
@@ -258,7 +258,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Airlock</b>
+  DisplayName: Airlock
+  Text: 
   MaxDistance: 0
 --- !u!1 &3667226139312871055
 GameObject:

--- a/Assets/Content/Structures/Doors/Classic Airlocks/Airlock Double Classic.prefab
+++ b/Assets/Content/Structures/Doors/Classic Airlocks/Airlock Double Classic.prefab
@@ -401,5 +401,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Airlock</b>
+  DisplayName: Airlock
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Doors/DoorOpener.cs
+++ b/Assets/Content/Structures/Doors/DoorOpener.cs
@@ -34,7 +34,6 @@ namespace SS3D.Content.Structures.Fixtures
         private int playersInTrigger; // Server Only
         private Coroutine closeTimer; // Server Only
 
-        private Animator animator;
         private AudioSource audioSource;
 
         // Interaction stuff

--- a/Assets/Content/Structures/Doors/Station Airlocks/Airlock Glass.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Airlock Glass.prefab
@@ -389,7 +389,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Airlock</b>
+  DisplayName: Airlock
+  Text: 
   MaxDistance: 0
 --- !u!1 &4803013556368833953
 GameObject:

--- a/Assets/Content/Structures/Doors/Station Airlocks/Airlock.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Airlock.prefab
@@ -433,7 +433,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Airlock</b>
+  DisplayName: Airlock
+  Text: 
   MaxDistance: 0
 --- !u!1 &4803013556368833953
 GameObject:

--- a/Assets/Content/Structures/Doors/Station Airlocks/Civilian/Airlock Civilian Glass.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Civilian/Airlock Civilian Glass.prefab
@@ -389,7 +389,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Airlock</b>
+  DisplayName: Airlock
+  Text: 
   MaxDistance: 0
 --- !u!1 &4803013556368833953
 GameObject:

--- a/Assets/Content/Structures/Doors/Station Airlocks/Civilian/Airlock Civilian.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Civilian/Airlock Civilian.prefab
@@ -389,7 +389,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Airlock</b>
+  DisplayName: Airlock
+  Text: 
   MaxDistance: 0
 --- !u!1 &4803013556368833953
 GameObject:

--- a/Assets/Content/Structures/Doors/Station Airlocks/Double Airlock.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Double Airlock.prefab
@@ -467,7 +467,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Airlock</b>
+  DisplayName: Airlock
+  Text: 
   MaxDistance: 0
 --- !u!1 &5755565538449260213
 GameObject:

--- a/Assets/Content/Structures/Doors/Station Airlocks/Maintenance/Airlock Maintenance Glass.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Maintenance/Airlock Maintenance Glass.prefab
@@ -389,7 +389,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Airlock</b>
+  DisplayName: Airlock
+  Text: 
   MaxDistance: 0
 --- !u!1 &4803013556368833953
 GameObject:

--- a/Assets/Content/Structures/Doors/Station Airlocks/Maintenance/Airlock Maintenance.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Maintenance/Airlock Maintenance.prefab
@@ -389,7 +389,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Airlock</b>
+  DisplayName: Airlock
+  Text: 
   MaxDistance: 0
 --- !u!1 &2719521177239230849
 GameObject:

--- a/Assets/Content/Structures/Floors/Bar Floor/Floor - Bar.prefab
+++ b/Assets/Content/Structures/Floors/Bar Floor/Floor - Bar.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 4334502282384565545}
   - component: {fileID: -8169158029566518480}
   m_Layer: 0
-  m_Name: BarFloor
+  m_Name: Floor - Bar
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Bar Floor</b>
+  DisplayName: Bar Floor
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Floors/Dark Grey Floor/Floor - Grey Dark.prefab
+++ b/Assets/Content/Structures/Floors/Dark Grey Floor/Floor - Grey Dark.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 4722452816941087978}
   - component: {fileID: 5843852423922428640}
   m_Layer: 0
-  m_Name: DarkGreyFloor
+  m_Name: Floor - Grey Dark
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Dark Grey Floor</b>
+  DisplayName: Dark Grey Floor
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Floors/Grey Floor/Floor - Grey.prefab
+++ b/Assets/Content/Structures/Floors/Grey Floor/Floor - Grey.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 1398198900295277428}
   - component: {fileID: -8794324230095091808}
   m_Layer: 0
-  m_Name: GreyFloor
+  m_Name: Floor - Grey
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Grey Floor</b>
+  DisplayName: Grey Floor
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Floors/Kitchen Floor/Floor - Kitchen.prefab
+++ b/Assets/Content/Structures/Floors/Kitchen Floor/Floor - Kitchen.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 3989804833102372943}
   - component: {fileID: -1645010173133357927}
   m_Layer: 0
-  m_Name: KitchenFloor
+  m_Name: Floor - Kitchen
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Kitchen Floor</b>
+  DisplayName: Kitchen Floor
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Floors/Plating/Floor - Plating.prefab
+++ b/Assets/Content/Structures/Floors/Plating/Floor - Plating.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 7808292210134878818}
   - component: {fileID: -5715087418548358362}
   m_Layer: 0
-  m_Name: FloorPlating
+  m_Name: Floor - Plating
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Plating</b>
+  DisplayName: Plating
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Floors/Reinforced Floor/Floor - Reinforced.prefab
+++ b/Assets/Content/Structures/Floors/Reinforced Floor/Floor - Reinforced.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 1121645015612626649}
   - component: {fileID: 1879159850004301609}
   m_Layer: 0
-  m_Name: ReinforcedFloor
+  m_Name: Floor - Reinforced
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Reinforced Floor</b>
+  DisplayName: Reinforced Floor
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Floors/White Floor/Floor - White.prefab
+++ b/Assets/Content/Structures/Floors/White Floor/Floor - White.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 2004507843881267251}
   - component: {fileID: 1723362531818412098}
   m_Layer: 0
-  m_Name: WhiteFloor
+  m_Name: Floor - White
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>White Floor</b>
+  DisplayName: White Floor
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Floors/Wood Floor/Floor - Wood.prefab
+++ b/Assets/Content/Structures/Floors/Wood Floor/Floor - Wood.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 1767991713297487601}
   - component: {fileID: 7909755215942669040}
   m_Layer: 0
-  m_Name: WoodFloor
+  m_Name: Floor - Wood
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wood Floor</b>
+  DisplayName: Wood Floor
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pipe Layers/Pipe - Under L1.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pipe Layers/Pipe - Under L1.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 2183948917681095833}
   - component: {fileID: -153587711557402241}
   m_Layer: 0
-  m_Name: Pipe L1 Under
+  m_Name: Pipe - Under L1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -150,5 +150,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Pipe</b>
+  DisplayName: Atmospheric Pipe
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pipe Layers/Pipe - Under L2.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pipe Layers/Pipe - Under L2.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 840758331285195934}
   - component: {fileID: 3397851465445616214}
   m_Layer: 0
-  m_Name: Pipe L2 Under
+  m_Name: Pipe - Under L2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -129,5 +129,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Pipe</b>
+  DisplayName: Atmospheric Pipe
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pipe Layers/Pipe - Under L3.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pipe Layers/Pipe - Under L3.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 2183948917681095833}
   - component: {fileID: 8044363620118605159}
   m_Layer: 0
-  m_Name: Pipe L3 Under
+  m_Name: Pipe - Under L3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -150,5 +150,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Pipe</b>
+  DisplayName: Atmospheric Pipe
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pipe Layers/Pipe - Under L4.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pipe Layers/Pipe - Under L4.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 840758331285195934}
   - component: {fileID: -4121827069175738176}
   m_Layer: 0
-  m_Name: Pipe L4 Upper
+  m_Name: Pipe - Under L4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -129,5 +129,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Pipe</b>
+  DisplayName: Atmospheric Pipe
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/3 Layer Manifold.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/3 Layer Manifold.prefab
@@ -139,5 +139,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Pipe Layer Manifold</b>
+  DisplayName: Atmospheric Pipe Layer Manifold
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/4 Layer Manifold.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/4 Layer Manifold.prefab
@@ -139,5 +139,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Pipe Layer Manifold</b>
+  DisplayName: Atmospheric Pipe Layer Manifold
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Injector.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Injector.prefab
@@ -138,5 +138,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Injector</b>
+  DisplayName: Atmospheric Injector
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Mixer.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Mixer.prefab
@@ -171,5 +171,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Mixer</b>
+  DisplayName: Atmospheric Mixer
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Port.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Port.prefab
@@ -124,5 +124,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Canister Port</b>
+  DisplayName: Atmospheric Canister Port
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Pressure Pump.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Pressure Pump.prefab
@@ -158,5 +158,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Pump</b>
+  DisplayName: Atmospheric Pump
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Scrubber.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Scrubber.prefab
@@ -225,5 +225,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Scrubber</b>
+  DisplayName: Scrubber
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Valve.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Valve.prefab
@@ -154,5 +154,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Digital Valve</b>
+  DisplayName: Atmospheric Digital Valve
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Vent.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Vent.prefab
@@ -222,5 +222,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Vent</b>
+  DisplayName: Vent
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Volume Pump.prefab
+++ b/Assets/Content/Structures/Pipes/Atmospherics/Pumps, Valves, Etc/Volume Pump.prefab
@@ -154,5 +154,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Atmospheric Volume Pump</b>
+  DisplayName: Atmospheric Volume Pump
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Pipes/Disposals/Disposals Pipe.prefab
+++ b/Assets/Content/Structures/Pipes/Disposals/Disposals Pipe.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Disposal Pipe</b>
+  DisplayName: Disposal Pipe
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Plenums/Catwalk.prefab
+++ b/Assets/Content/Structures/Plenums/Catwalk.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Catwalk</b>
+  DisplayName: Catwalk
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Plenums/Lattice.prefab
+++ b/Assets/Content/Structures/Plenums/Lattice.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Lattice</b>
+  DisplayName: Lattice
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Plenums/Plenum.prefab
+++ b/Assets/Content/Structures/Plenums/Plenum.prefab
@@ -288,5 +288,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Plenum</b>
+  DisplayName: Plenum
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/APC.prefab
+++ b/Assets/Content/Structures/Wall Mounts/APC.prefab
@@ -108,5 +108,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>APC</b>
+  DisplayName: APC
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Air Alarm.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Air Alarm.prefab
@@ -108,5 +108,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Air Alarm</b>
+  DisplayName: Air Alarm
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Fire Alarm.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Fire Alarm.prefab
@@ -108,5 +108,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Fire Alarm</b>
+  DisplayName: Fire Alarm
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Light Switch.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Light Switch.prefab
@@ -108,5 +108,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Light Switch</b>
+  DisplayName: Light Switch
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Lights/Emergency Light Fixture.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Lights/Emergency Light Fixture.prefab
@@ -517,5 +517,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Emergency Light Fixture</b>
+  DisplayName: Emergency Light Fixture
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Lights/Light Bulb Fixture.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Lights/Light Bulb Fixture.prefab
@@ -390,5 +390,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Light Bulb Fixture</b>
+  DisplayName: Light Bulb Fixture
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Lights/Light Tube Fixture.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Lights/Light Tube Fixture.prefab
@@ -58,7 +58,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Light Tube Fixture</b>
+  DisplayName: Light Tube Fixture
+  Text: 
   MaxDistance: 0
 --- !u!1 &5181080420812569886
 GameObject:

--- a/Assets/Content/Structures/Wall Mounts/Mirror.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Mirror.prefab
@@ -139,7 +139,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Mirror</b>
+  DisplayName: Mirror
+  Text: 
   MaxDistance: 0
 --- !u!1 &5218468364695561986
 GameObject:

--- a/Assets/Content/Structures/Wall Mounts/Posters/Horizontal/Poster.H REBELS.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Horizontal/Poster.H REBELS.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - REBELS</b>
+  DisplayName: Poster - REBELS
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V ARF.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V ARF.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - ARF</b>
+  DisplayName: Poster - ARF
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V CLEAN.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V CLEAN.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - CLEAN</b>
+  DisplayName: Poster - CLEAN
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V EAT.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V EAT.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - EAT</b>
+  DisplayName: Poster - EAT
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V FUN POLICE.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V FUN POLICE.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - FUN POLICE</b>
+  DisplayName: Poster - FUN POLICE
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V GREYTIDE.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V GREYTIDE.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - GREY TIDE</b>
+  DisplayName: Poster - GREY TIDE
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V HONKMOTHER.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V HONKMOTHER.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - HONK MOTHER</b>
+  DisplayName: Poster - HONK MOTHER
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V LUSTY XENO.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V LUSTY XENO.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - LUSTY XENO</b>
+  DisplayName: Poster - LUSTY XENO
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V MISSING.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V MISSING.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - MISSING</b>
+  DisplayName: Poster - MISSING
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V NT.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V NT.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - NANOTRASEN</b>
+  DisplayName: Poster - NANOTRASEN
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V NT2.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V NT2.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - NANOTRASEN #2</b>
+  DisplayName: Poster - NANOTRASEN #2
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V NT3.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V NT3.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - NANOTRASEN #3</b>
+  DisplayName: Poster - NANOTRASEN #3
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V OBEY.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V OBEY.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - OBEY</b>
+  DisplayName: Poster - OBEY
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V PUFF.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V PUFF.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - PUFF</b>
+  DisplayName: Poster - PUFF
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V PostersRock.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V PostersRock.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - POSTERS ROCK</b>
+  DisplayName: Poster - POSTERS ROCK
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V REDRUM.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V REDRUM.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - RED RUM</b>
+  DisplayName: Poster - RED RUM
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V SMOKE.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V SMOKE.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - SMOKE</b>
+  DisplayName: Poster - SMOKE
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V SPACE_L.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V SPACE_L.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - SPACE LEFT</b>
+  DisplayName: Poster - SPACE LEFT
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V SPACE_R.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Posters/Vertical/Poster.V SPACE_R.prefab
@@ -106,5 +106,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Poster - SPACE RIGHT</b>
+  DisplayName: Poster - SPACE RIGHT
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Walls/Girder.prefab
+++ b/Assets/Content/Structures/Walls/Girder.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Girder</b>
+  DisplayName: Girder
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Walls/Wall - Metal Reinforced.prefab
+++ b/Assets/Content/Structures/Walls/Wall - Metal Reinforced.prefab
@@ -236,7 +236,7 @@ GameObject:
   - component: {fileID: -1603528896830197534}
   - component: {fileID: 181711760065846440}
   m_Layer: 0
-  m_Name: ReinforcedWall
+  m_Name: Wall - Metal Reinforced
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -391,7 +391,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Reinforced Wall</b>
+  DisplayName: Reinforced Wall
+  Text: 
   MaxDistance: 0
 --- !u!1 &5351388144419023931
 GameObject:

--- a/Assets/Content/Structures/Walls/Wall - Metal.prefab
+++ b/Assets/Content/Structures/Walls/Wall - Metal.prefab
@@ -236,7 +236,7 @@ GameObject:
   - component: {fileID: 8185897957132118111}
   - component: {fileID: -6476499872734153616}
   m_Layer: 0
-  m_Name: BasicWall
+  m_Name: Wall - Metal
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -392,7 +392,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wall</b>
+  DisplayName: Wall
+  Text: 
   MaxDistance: 0
 --- !u!1 &3720934538700132716
 GameObject:

--- a/Assets/Content/Structures/Walls/Window - Metal Reinforced.prefab
+++ b/Assets/Content/Structures/Walls/Window - Metal Reinforced.prefab
@@ -256,7 +256,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Reinforced Window</b>
+  DisplayName: Reinforced Window
+  Text: 
   MaxDistance: 0
 --- !u!1 &4495244649162546676
 GameObject:

--- a/Assets/Content/Structures/Walls/Window - Metal.prefab
+++ b/Assets/Content/Structures/Walls/Window - Metal.prefab
@@ -300,7 +300,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Window</b>
+  DisplayName: Window
+  Text: 
   MaxDistance: 0
 --- !u!1 &5752331563943711543
 GameObject:

--- a/Assets/Content/Structures/Wires/Cables.prefab
+++ b/Assets/Content/Structures/Wires/Cables.prefab
@@ -143,5 +143,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>High-Voltage Cable</b>
+  DisplayName: High-Voltage Cable
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - Blue.prefab
+++ b/Assets/Content/Structures/Wires/Wires - Blue.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - Brown.prefab
+++ b/Assets/Content/Structures/Wires/Wires - Brown.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - Green.prefab
+++ b/Assets/Content/Structures/Wires/Wires - Green.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - Orange.prefab
+++ b/Assets/Content/Structures/Wires/Wires - Orange.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - Pink.prefab
+++ b/Assets/Content/Structures/Wires/Wires - Pink.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - Purple.prefab
+++ b/Assets/Content/Structures/Wires/Wires - Purple.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - Red.prefab
+++ b/Assets/Content/Structures/Wires/Wires - Red.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - Teal.prefab
+++ b/Assets/Content/Structures/Wires/Wires - Teal.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - White.prefab
+++ b/Assets/Content/Structures/Wires/Wires - White.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Structures/Wires/Wires - Yellow.prefab
+++ b/Assets/Content/Structures/Wires/Wires - Yellow.prefab
@@ -144,5 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 671f779259184f2c984b9c017a5141df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Text: <b>Wire</b>
+  DisplayName: Wire
+  Text: 
   MaxDistance: 0

--- a/Assets/Content/Systems/Examine/Examinator.cs
+++ b/Assets/Content/Systems/Examine/Examinator.cs
@@ -193,8 +193,19 @@ namespace SS3D.Content.Systems.Examine
             {
                 if (examinable.CanExamine(go))
                 {
-                    builder.AppendLine("<b>" + examinable.GetName(go) + "</b>");
-					builder.AppendLine(examinable.GetDescription(go));
+					
+					string displayName = examinable.GetName(go);
+					string displayDesc = examinable.GetDescription(go);
+					
+					// Prevent blank lines being appended (relevant where a GameObject has multiple components implementing iExaminable.
+					// (in this case, make displayName blank in all but one of them. For example, see Water Cooler prefab)
+					if (displayName != ""){
+						builder.AppendLine("<b>" + displayName + "</b>");
+					}
+                    if (displayDesc != ""){
+						builder.AppendLine(displayDesc);
+					}
+					
                 }
             }
 

--- a/Assets/Content/Systems/Examine/Examinator.cs
+++ b/Assets/Content/Systems/Examine/Examinator.cs
@@ -193,7 +193,8 @@ namespace SS3D.Content.Systems.Examine
             {
                 if (examinable.CanExamine(go))
                 {
-                    builder.AppendLine(examinable.GetDescription(go));
+                    builder.AppendLine("<b>" + examinable.GetName(go) + "</b>");
+					builder.AppendLine(examinable.GetDescription(go));
                 }
             }
 

--- a/Assets/Engine/Examine/IExaminable.cs
+++ b/Assets/Engine/Examine/IExaminable.cs
@@ -6,5 +6,6 @@ namespace SS3D.Engine.Examine
     {
         bool CanExamine(GameObject examinator);
         string GetDescription(GameObject examinator);
+		string GetName(GameObject examinator);
     }
 }

--- a/Assets/Engine/Examine/ItemExaminable.cs
+++ b/Assets/Engine/Examine/ItemExaminable.cs
@@ -13,9 +13,17 @@ namespace SS3D.Engine.Examine
             item = GetComponent<Item>();
         }
 
+        public override string GetName(GameObject examinator)
+        {
+			return item.Name;
+        }
+		
         public override string GetDescription(GameObject examinator)
         {
-            return $"<b>{item.Name}</b>\n{base.GetDescription(examinator)}";
+            return base.GetDescription(examinator);
         }
+		
+		//Original GetDescription: return $"<b>{item.Name}</b>\n{base.GetDescription(examinator)}";
+
     }
 }

--- a/Assets/Engine/Examine/SimpleExaminable.cs
+++ b/Assets/Engine/Examine/SimpleExaminable.cs
@@ -4,8 +4,12 @@ namespace SS3D.Engine.Examine
 {
     public class SimpleExaminable : MonoBehaviour, IExaminable
     {
+        [TextArea(1, 15)]
+		[SerializeField]
+        private string DisplayName;
         [TextArea(5, 15)]
         public string Text;
+
         public float MaxDistance;
 
         public bool CanExamine(GameObject examinator)
@@ -32,7 +36,7 @@ namespace SS3D.Engine.Examine
 		
         public virtual string GetName(GameObject examinator)
         {
-            return gameObject.name;
+            return DisplayName;
         }		
 		
 		

--- a/Assets/Engine/Examine/SimpleExaminable.cs
+++ b/Assets/Engine/Examine/SimpleExaminable.cs
@@ -29,5 +29,12 @@ namespace SS3D.Engine.Examine
         {
             return Text;
         }
+		
+        public virtual string GetName(GameObject examinator)
+        {
+            return gameObject.name;
+        }		
+		
+		
     }
 }

--- a/Assets/Engine/Inventory/Stackable.cs
+++ b/Assets/Engine/Inventory/Stackable.cs
@@ -34,5 +34,10 @@ namespace SS3D.Engine.Inventory
         {
             return $"{amountInStack} in stack";
         }
+		
+        public virtual string GetName(GameObject examinator)
+        {
+            return gameObject.name;
+        }		
     }
 }


### PR DESCRIPTION
### Summary
Separates name and description within the Examinable system. Fixes #547.
Removed requirement for bold tags for names, as that is now handled in Examinator.cs
Updated existing IExaminable and SimpleExaminable prefabs.

## Known issues
Attempted to make displayName private to SimpleExaminable so that ItemExaminable does not see that variable; however, displayName is visible to ItemExaminable. This field has no effect because ItemExaminable retrieves its name from the Item class.