### PR TITLE
Tilemap editor scrolling

### DIFF
--- a/Assets/Engine/Tile/Editor/TileMap/TileMapEditor.cs
+++ b/Assets/Engine/Tile/Editor/TileMap/TileMapEditor.cs
@@ -65,8 +65,7 @@ namespace SS3D.Engine.Tiles.Editor.TileMap
             tiles.Update(tileManager);
 
             enableVisualHelp = EditorGUILayout.Toggle("Enable visual help: ", enableVisualHelp);
-            EditorGUILayout.Space();
-
+            scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);
             for (int i = 0; i < tiles.Definitions.Count; ++i) {
                 tiles.ShowInspectorFor(i);
 
@@ -94,8 +93,7 @@ namespace SS3D.Engine.Tiles.Editor.TileMap
                 }
                 EditorGUILayout.EndHorizontal();
             }
-
-            GUILayout.Space(10);
+            EditorGUILayout.EndScrollView();
 
             if (GUILayout.Button("Add Tile Type")) {
                 tiles.Add();
@@ -205,5 +203,6 @@ namespace SS3D.Engine.Tiles.Editor.TileMap
         private Vector2Int lastPlacement;
 
         private TileDragHandler dragHandler;
+        private Vector2 scrollPosition;
     }
 }


### PR DESCRIPTION
### Summary
Adds a basic scrollbar to the tilemap editor. Visual help and Add Tile Type are accessible from any point in the scrolling.

## Pictures
![image](https://user-images.githubusercontent.com/38957910/89702560-23b12880-d908-11ea-93ec-b22cf2c3e96f.png)