### PR TITLE
Examine components

### DIFF
--- a/Assets/Art/Sounds/Effects.meta
+++ b/Assets/Art/Sounds/Effects.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: cdcf915dbe5152545b223f18312edf73
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/CompositeItemSelector.cs
+++ b/Assets/CompositeItemSelector.cs
@@ -1,0 +1,298 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using SS3D.Engine.Examine;
+
+
+namespace SS3D.Content.Systems.Examine
+{
+    /// <summary>
+    /// For composite GameObjects composed of multiple Examinable GameObjects, this script allows
+	/// us to return specifically which subordinate GameObject the cursor is over.
+    /// </summary>
+	public class CompositeItemSelector : MonoBehaviour
+	{
+		
+		public GameObject target;
+		public RawImage ri;
+		
+		private List<MeshColourAffiliation> meshes;
+		private List<ExaminableColourAffiliation> examinables;
+		private Stack<Color> colours;
+		
+		
+		private Mesh mesh;
+		private Material singleColourMaterial;
+		private Shader singleColourShader;
+		public Camera cam;
+		public Text output;
+		private Texture2D tex;
+		private Rect imageArea;
+		private RenderTexture rt;
+		private Transform ancestorSearch;
+		
+		private float rValue;
+		private float gValue;
+		private float bValue;
+		private float decrement;
+		
+		private int recordedScreenWidth;
+		private int recordedScreenHeight;
+		
+		public void Start(){
+			
+			// Initialise our collections
+			meshes = new List<MeshColourAffiliation>();
+			examinables = new List<ExaminableColourAffiliation>();
+			colours = new Stack<Color>();
+
+			singleColourShader = Shader.Find("Unlit/singleColourShader");
+			singleColourMaterial = new Material(singleColourShader);
+			GeneratePickingFramework();
+			//ri.texture = rt;
+			
+			target = GetAncestor(target);
+			GetListOfMeshes(target);
+
+		}
+		
+		public void OnPostRender()
+		{
+			if (AllTexturesAreValid())
+			{		
+				// Render all of our meshes to the invisible RenderTexture
+				foreach (MeshColourAffiliation mesh in meshes)
+				{
+					singleColourMaterial.SetVector("colour", mesh.GetColour());
+					singleColourMaterial.SetPass(0);
+					UnityEngine.Graphics.DrawMeshNow(mesh.GetMesh(), mesh.GetTransform().position, mesh.GetTransform().rotation);
+				}
+				
+				// Actually test the colour
+				int currentX = (int) Input.mousePosition.x;
+				int currentY = (int) Input.mousePosition.y;
+					//output.text = Input.mousePosition.x + ": " + currentX;
+				
+				if (currentX >= 0 && currentY >= 0 && currentX < Screen.width && currentY < Screen.height)
+				{
+					imageArea = new Rect(currentX, currentY, 1, 1);
+					tex.ReadPixels(imageArea, 0, 0, false);
+					Color point = tex.GetPixel(currentX,currentY);
+					bool hit = false;
+					foreach (ExaminableColourAffiliation examinable in examinables)
+					{
+						if (point == examinable.GetColour())
+						{
+							output.text = examinable.GetName();
+							hit = true;
+						}
+						if (!hit) output.text = "";
+					}
+					
+				}
+				else
+				{
+					output.text = "";
+				}				
+			}
+		
+		}
+		
+		private void GeneratePickingFramework(){
+			
+			rValue = 1.0f;
+			gValue = 1.0f;
+			bValue = 1.0f;
+			decrement = 0.6f;
+			
+			imageArea = new Rect(0, 0, Screen.width, Screen.height);
+			rt = new RenderTexture(Screen.width, Screen.height, 16);
+			tex = new Texture2D(1, 1);
+			recordedScreenWidth = Screen.width;
+			recordedScreenHeight = Screen.height;
+			cam.targetTexture = rt;
+		}
+		
+		private bool AllTexturesAreValid(){
+			
+			// If textures don't currently exist, create them at the correct size.
+			//if (readyToCreateAssets)
+				
+			return true; //---------------------------------------------------------------------------------------------------
+			if (recordedScreenWidth != Screen.width || recordedScreenHeight != Screen.height)	
+			{
+				imageArea = new Rect(0, 0, Screen.width, Screen.height);
+				cam.targetTexture = null;
+				rt.Release();
+				rt = new RenderTexture(Screen.width, Screen.height, 16);
+				cam.targetTexture = rt;
+
+				tex.Resize(Screen.width, Screen.height);
+				recordedScreenWidth = Screen.width;
+				recordedScreenHeight = Screen.height;
+				return false;
+			}
+			return true;
+		}
+		
+		private void ChangeToNextColour(){
+			if (rValue < 0.0f)
+			{
+				return;
+			}
+			bValue -= decrement;
+			if (bValue < 0.0f)
+			{
+				bValue = 1.0f;
+				gValue -= decrement;
+				if (gValue < 0.0f)
+				{
+					gValue = 1.0f;
+					rValue -= decrement;
+					if (rValue < 0.0f){
+						Debug.Log("CompositeItemSelector: Too many colours cycled through.");
+					}
+				}
+				
+			}
+		}
+		
+		private GameObject GetAncestor (GameObject descendant)
+		{
+			while (descendant.transform.parent != null && descendant.transform.parent.name != "TileMap")
+			{
+				descendant = descendant.transform.parent.gameObject;
+			}
+			return descendant;
+		}
+		
+		private void GetListOfMeshes(GameObject ancestor)
+		{			
+			colours.Push(new Color(rValue, gValue, bValue, 1.0f));
+			AddChildToLists(ancestor.transform);
+			string display = "Meshes within the meshes list:\n";
+			foreach (MeshColourAffiliation mesh in meshes)
+			{
+				display += "    " + mesh.GetTransform().gameObject.name + "\n";
+			}
+			Debug.Log(display);
+		}
+	
+		// This method calls recursively to find all descendants of a GameObject. If
+		// they have meshes to render, and/or are Examinable, they are recorded in our
+		// meshes and examinables lists.
+		private void AddChildToLists(Transform child)
+		{
+			
+			if (child.gameObject.activeSelf == false)
+			{
+				return;
+			}
+			
+			// Determine whether the GameObject has a mesh or is Examinable
+			MeshFilter mf = child.gameObject.GetComponent<MeshFilter>();
+			IExaminable examinable = child.gameObject.GetComponent<IExaminable>();
+			
+			// If examinable, create a unique colour to affiliate the examinable with. All non-
+			// examinable children will also be affiliated with this colour.
+			if (examinable != null)
+			{
+				ChangeToNextColour();
+				colours.Push(new Color(rValue, gValue, bValue, 1.0f));
+				examinables.Add(new ExaminableColourAffiliation(examinable, colours.Peek(), child.gameObject.name));
+			}
+			
+			// If mesh exists, record the colour affiliation of it 
+			if (mf != null && child.gameObject.GetComponent<Renderer>().enabled)
+			{
+				meshes.Add(new MeshColourAffiliation(mf.mesh, colours.Peek(), child, null));
+			}
+			
+			// Recursively call this method on each child
+			for (int i = 0; i < child.childCount; i++)
+			{
+				AddChildToLists(child.GetChild(i));
+			}
+			
+			// This object and all children have been affiliated with the colour. Remove it.
+			if (examinable != null)
+			{
+				colours.Pop();
+			}
+		}
+	
+		// This class is used to link particular meshes to the colour used to represent them
+		// with the CompositeItemSelector render texture. It is possible for multiple meshes
+		// to be affiliated with the same colour (for example, the meshes are all subordinate
+		// to an Examinable GameObject, without any of them being individually Examinable)
+		private class MeshColourAffiliation
+		{
+			private Mesh mesh;
+			private Color colour;
+			private Transform transform;
+			private MeshRenderer renderer;
+			
+			public MeshColourAffiliation(Mesh mesh, Color colour, Transform transform, MeshRenderer renderer)
+			{
+				this.mesh = mesh;
+				this.colour = colour;
+				this.transform = transform;
+				this.renderer = renderer;
+			}
+			
+			public Mesh GetMesh()
+			{
+				return mesh;
+			}
+			
+			public Color GetColour()
+			{
+				return colour;
+			}
+			
+			public Transform GetTransform()
+			{
+				return transform;
+			}			
+			
+			public MeshRenderer GetRenderer(){
+				return renderer;
+			}
+			
+		}
+		
+		// This class is used to link Examinable GameObjects to the colour used to represent
+		// them. There should be a 1:1 correlation between colours and Examinable GameObjects.
+		// Each Examinable will have one or more associated meshes, all of which share its colour.
+		private class ExaminableColourAffiliation
+		{
+			private IExaminable examinable;
+			private Color colour;
+			private string name;
+			
+			public ExaminableColourAffiliation(IExaminable examinable, Color colour, string name)
+			{
+				this.examinable = examinable;
+				this.colour = colour;
+				this.name = name;
+			}
+			
+			public IExaminable GetExaminable()
+			{
+				return examinable;
+			}
+			
+			public Color GetColour()
+			{
+				return colour;
+			}
+			
+			public string GetName()
+			{
+				return name;
+			}
+			
+		}
+	}
+}

--- a/Assets/CompositeItemSelector.cs.meta
+++ b/Assets/CompositeItemSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef59ce420ebdf1645aa58c640ac5c406
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/Main Camera.prefab
+++ b/Assets/Content/Main Camera.prefab
@@ -1,5 +1,104 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5176589148799271154
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2943651474182832065}
+  - component: {fileID: 2133984709589219736}
+  - component: {fileID: 2056983108831935898}
+  - component: {fileID: 5609341346179319566}
+  m_Layer: 0
+  m_Name: Selection Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2943651474182832065
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5176589148799271154}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8192375152356926015}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &2133984709589219736
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5176589148799271154}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &2056983108831935898
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5176589148799271154}
+  m_Enabled: 1
+--- !u!114 &5609341346179319566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5176589148799271154}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ef59ce420ebdf1645aa58c640ac5c406, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 0}
+  cam: {fileID: 2133984709589219736}
+  output: {fileID: 0}
 --- !u!1 &8192375152356925988
 GameObject:
   m_ObjectHideFlags: 0
@@ -33,7 +132,8 @@ Transform:
   m_LocalRotation: {x: 0.5, y: 0, z: 0, w: 0.8660254}
   m_LocalPosition: {x: 0, y: 5, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 2943651474182832065}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 60, y: 0, z: 0}

--- a/Assets/Content/Structures/Plenums/Plenum.prefab
+++ b/Assets/Content/Structures/Plenums/Plenum.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &7554077011319844899
 Transform:
   m_ObjectHideFlags: 0
@@ -97,7 +97,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &4230716652432141015
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Systems/Examine/SingleColourMaterial.mat
+++ b/Assets/Content/Systems/Examine/SingleColourMaterial.mat
@@ -40,7 +40,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 1dbe9ceb117c79d47898dfdfc5a960d5, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/Assets/Content/Systems/Examine/SingleColourMaterial.mat
+++ b/Assets/Content/Systems/Examine/SingleColourMaterial.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SingleColourMaterial
+  m_Shader: {fileID: 4800000, guid: 7e5ac53bdc3d50f458e4a23f21937aef, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Content/Systems/Examine/SingleColourMaterial.mat.meta
+++ b/Assets/Content/Systems/Examine/SingleColourMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 95867334491c7b247866b990bc1698b6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/Systems/Examine/singleColourShader.shader
+++ b/Assets/Content/Systems/Examine/singleColourShader.shader
@@ -1,6 +1,10 @@
 ﻿Shader "Unlit/singleColourShader"
 {
-    Properties {
+    Properties
+    {
+        // we have removed support for texture tiling/offset,
+        // so make them not be displayed in material inspector
+        [NoScaleOffset] _MainTex ("Texture", 2D) = "white" {}
     }
     SubShader {
         
@@ -13,10 +17,13 @@
             
             struct VertInput {
                 float4 pos : POSITION;
+                float2 uv : TEXCOORD0; // texture coordinate
+
             };
 			uniform float3 colour;
 
             struct VertOutput {
+                float2 uv : TEXCOORD0; // texture coordinate
                 float4 pos : SV_POSITION;
 				float3 colour : COLOR;
             };
@@ -25,11 +32,21 @@
                 VertOutput o;
                 o.pos = UnityObjectToClipPos(i.pos);
 				o.colour = colour;
+				o.uv = i.uv;
                 return o;
             }
-
+			
+            // texture we will sample
+            sampler2D _MainTex;
+			
             fixed4 frag (VertOutput i) : COLOR {
-                return fixed4(i.colour, 1.0f);
+				fixed4 sampledColour = tex2D(_MainTex, i.uv);
+				float alphaValue = sampledColour.a;
+				if (alphaValue < 1.0f)
+				{
+					alphaValue = 0.0f;
+				}
+                return fixed4(i.colour, alphaValue);
             }
             ENDCG
         }

--- a/Assets/Content/Systems/Examine/singleColourShader.shader
+++ b/Assets/Content/Systems/Examine/singleColourShader.shader
@@ -1,0 +1,37 @@
+﻿Shader "Unlit/singleColourShader"
+{
+    Properties {
+    }
+    SubShader {
+        
+        Pass {
+		
+            CGPROGRAM
+			
+            #pragma vertex vert
+            #pragma fragment frag
+            
+            struct VertInput {
+                float4 pos : POSITION;
+            };
+			uniform float3 colour;
+
+            struct VertOutput {
+                float4 pos : SV_POSITION;
+				float3 colour : COLOR;
+            };
+
+            VertOutput vert (VertInput i){
+                VertOutput o;
+                o.pos = UnityObjectToClipPos(i.pos);
+				o.colour = colour;
+                return o;
+            }
+
+            fixed4 frag (VertOutput i) : COLOR {
+                return fixed4(i.colour, 1.0f);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Content/Systems/Examine/singleColourShader.shader.meta
+++ b/Assets/Content/Systems/Examine/singleColourShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7e5ac53bdc3d50f458e4a23f21937aef
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Summary

Adds ability to examine tile-based pipes and wires (and any other tile-based Examinable).

Previously, wires and pipes had not been able to be examined due to lack of collider. Even if a collider had been present, pipes could not be examined because the larger Plenum collider would prevent a Raycast hitting it. 

## Pictures

![Successful Pipe Display](https://user-images.githubusercontent.com/64360820/91976017-7e02a500-ed5f-11ea-83db-e624cd50e242.png)

## Changes to Files

An additional camera ("Selection Camera") was added to the scene, as a child to the Main Camera.

## Technical Notes

Basic concept: When any GameObject descendant of a Tile is hit by the Examinator Raycast, the meshes of all descendants of that tile are recorded and assigned a unique colour (if they are Examinable). During post processing each frame, they are  rendered to a RenderTexture by the Selection Camera. The RenderTexture is then tested to determine what colour is at the mouse position, which then can be linked back to what Examinable we are looking at.

## Known issues

There is a slight performance penalty while examining things. I found this to be about 20% of framerate with my fairly old computer. I will leave to the reviewer to decide whether this is acceptable.

## Fixes

Closes #507 
Closes #462 
Closes #463 (although it appears wall mounts were already examinable anyway)
