### PR TITLE
Resolved doubling of Mobile Container UI

### DIFF
--- a/Assets/Engine/Inventory/Inventory.cs
+++ b/Assets/Engine/Inventory/Inventory.cs
@@ -176,7 +176,19 @@ namespace SS3D.Engine.Inventory
                     Debug.Log(
                         "Still have that mirror bug where transmitting self in OnStartServer for some reason doesnt fucking work");
                 else
-                    containers.AddRange(obj.GetComponentsInChildren<Container>());
+				{
+					/* Checks whether the container is already listed before adding it. This is done because mobile inventories (such
+					   as the medkit or toolbox) are returned twice while they are held by a player (once as a child of the player, once
+					   in thier own right). This was previously causing errors with duplicate Dictionary entries and doubled UI. */
+					var objContainers = obj.GetComponentsInChildren<Container>();
+					foreach (Container subordinateContainer in objContainers)
+					{
+						if (!containers.Contains(subordinateContainer))
+						{
+							containers.Add(subordinateContainer);
+						}
+					}					
+				}
             }
 
             return containers;


### PR DESCRIPTION
### Summary

Removes the issue where twice the number of slots appeared for held toolboxes / medkits.

## Technical Notes (optional)

AddRange() was being used to add Containers within the Inventory.GetContainers() method. This led to the held mobile inventories being returned by both twice (once in their own right, once as a child of the player inventory). Simple check added to prevent duplicate addition into list.

## Fixes

Closes #514
