### PR TITLE
Tilemap change visibility per layer

### DIFF
--- a/Assets/Engine/Tile/Editor/TileMap/TileMapEditor.cs
+++ b/Assets/Engine/Tile/Editor/TileMap/TileMapEditor.cs
@@ -63,7 +63,7 @@ namespace SS3D.Engine.Tiles.Editor.TileMap
             tiles.Destroy();
             DestroyAllGhosts(tileManager);
 
-            ResetTileVisibility();
+            ResetTileVisibility(true);
 
             SceneView.duringSceneGui -= OnSceneGUI;
         }
@@ -89,9 +89,22 @@ namespace SS3D.Engine.Tiles.Editor.TileMap
                 {
                     if (layerVisibility[i].visibile = EditorGUILayout.Toggle(layerVisibility[i].name, layerVisibility[i].visibile))
                     {
-                        UpdateTileVisibility(false);
+                        UpdateTileVisibility();
                     }
                 }
+
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.Space();
+                if (GUILayout.Button("Show All"))
+                {
+                    ResetTileVisibility(true);
+                }
+                if (GUILayout.Button("Hide All"))
+                {
+                    ResetTileVisibility(false);
+                }
+                EditorGUILayout.EndHorizontal();
+
                 EditorGUI.indentLevel--;
             }
             EditorGUILayout.EndFoldoutHeaderGroup();
@@ -134,7 +147,7 @@ namespace SS3D.Engine.Tiles.Editor.TileMap
 
             if (GUILayout.Button("Refresh TileMap")) {
                 tileManager.ReinitializeFromChildren();
-                UpdateTileVisibility(false);
+                UpdateTileVisibility();
             }
         }
 
@@ -237,7 +250,7 @@ namespace SS3D.Engine.Tiles.Editor.TileMap
                 tiles.ShowTile(index);
         }
 
-        private void UpdateTileVisibility(bool reset)
+        private void UpdateTileVisibility()
         {
             // Loop all tiles
             foreach (TileObject tileObject in tileManager.GetAllTiles())
@@ -248,22 +261,22 @@ namespace SS3D.Engine.Tiles.Editor.TileMap
                     GameObject layerObject = tileObject.GetLayer(i);
                     if (layerObject != null)
                     {
-                        if (reset)
-                        {
-                            layerObject.SetActive(true);
-                        }
-                        else
-                        {
-                            layerObject.SetActive(layerVisibility[i].visibile);
-                        }
+                        layerObject.SetActive(layerVisibility[i].visibile);
                     }
                 }
             }
         }
 
-        private void ResetTileVisibility()
+        private void ResetTileVisibility(bool showAll)
         {
-            UpdateTileVisibility(true);
+            for (int i = 0; i < layerVisibility.Length; i++)
+            {
+                if (showAll)
+                    layerVisibility[i].visibile = true;
+                else
+                    layerVisibility[i].visibile = false;
+            }
+            UpdateTileVisibility();
         }
         
         private TileManager tileManager;

--- a/Assets/Engine/Tile/Tile.cs
+++ b/Assets/Engine/Tile/Tile.cs
@@ -74,11 +74,32 @@ namespace SS3D.Engine.Tiles {
         }
     }
 
-    public enum TileLayer
+    public enum TileLayers
     {
         Plenum,
         Turf,
-        FixturesContainer,
+        Wire,
+        Disposal,
+        Pipe1,
+        Pipe2,
+        Pipe3,
+        HighWallNorth,
+        HighWallEast,
+        HighWallSouth,
+        HighWallWest,
+        LowWallNorth,
+        LowWallEast,
+        LowWallSouth,
+        LowWallWest,
+        PipeUpper,
+        Overlay1,
+        Overlay2,
+        Overlay3,
+        FurnitureMain,
+        Furniture2,
+        Furniture3,
+        Furniture4,
+        Furniture5,
         AtmosObject,
     }
 

--- a/Assets/Engine/Tile/TileObject.cs
+++ b/Assets/Engine/Tile/TileObject.cs
@@ -750,5 +750,21 @@ namespace SS3D.Engine.Tiles
         private GameObject[] fixtures = new GameObject[TileDefinition.GetAllFixtureLayerSize()];
         private AdjacencyConnector[] tileFixtureConnectors = new AdjacencyConnector[TileDefinition.GetTileFixtureLayerSize()];
         private AdjacencyConnector[] floorFixtureConnectors = new AdjacencyConnector[TileDefinition.GetFloorFixtureLayerSize()];
+
+
+        public GameObject GetLayer(int i)
+        {
+            switch (i)
+            {
+                case 0:
+                    return plenum;
+                case 1:
+                    return turf;
+                default:
+                    if (i >= fixtures.Length)
+                        return null;
+                    return fixtures[i];
+            }
+        }
     }
 }

--- a/Assets/Engine/Tile/TileObject.cs
+++ b/Assets/Engine/Tile/TileObject.cs
@@ -754,6 +754,8 @@ namespace SS3D.Engine.Tiles
 
         public GameObject GetLayer(int i)
         {
+            int offset = -2;
+
             switch (i)
             {
                 case 0:
@@ -761,9 +763,11 @@ namespace SS3D.Engine.Tiles
                 case 1:
                     return turf;
                 default:
-                    if (i >= fixtures.Length)
+                    if ((i + offset) >= fixtures.Length)
                         return null;
-                    return fixtures[i];
+                    if (fixtures[i + offset] != null)
+                        return fixtures[i + offset];
+                    else return null;
             }
         }
     }


### PR DESCRIPTION
<!-- Text within these arrows are notes for you and should be deleted. -->

### Summary
This PR adds the ability to change the visibility of tilemap layers in the editor. Includes handy buttons for showing or hiding all layers.


<!-- Provide a general summary of the problem here and in the title. -->

<!-- Follow with a more concise explanation of the change here. -->

<!-- What features does this change include/not include? -->

## Pictures/Videos
![2021-01-17 11-41-21](https://user-images.githubusercontent.com/5231626/104839277-4173b800-58c0-11eb-9489-bc55739920aa.gif)
