### PR TITLE
Optional connections for wires & pipes

### DIFF
--- a/Assets/Engine/Tile/Connections/OffsetPipesAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/Connections/OffsetPipesAdjacencyConnector.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using SS3D.Engine.Tiles.Connections;
 using System;
+using SS3D.Engine.Tiles.State;
 
 namespace SS3D.Engine.Tiles.Connections
 {
@@ -9,7 +10,7 @@ namespace SS3D.Engine.Tiles.Connections
      * The offset pipes adjacency connector is for small pipes layers 1 and 3...
      */
     [RequireComponent(typeof(MeshFilter))]
-    public class OffsetPipesAdjacencyConnector : MonoBehaviour, AdjacencyConnector
+    public class OffsetPipesAdjacencyConnector : AdjacencyStateMaintainer, AdjacencyConnector
     {
         public enum TileLayer
         {
@@ -116,7 +117,12 @@ namespace SS3D.Engine.Tiles.Connections
         {
             bool isConnected = (tile.turf && (tile.turf.genericType == type || type == null));
             if (tile.fixtures != null)
+            {
                 isConnected = isConnected || (tile.fixtures.GetFixtureAtLayerIndex(LayerIndex) && (tile.fixtures.GetFixtureAtLayerIndex(LayerIndex).genericType == type || type == null));
+            }
+
+            isConnected &= (AdjacencyBitmap.Adjacent(TileState.blockedDirection, direction) == 0);
+
             return adjacents.UpdateDirection(direction, isConnected, true);
         }
 

--- a/Assets/Engine/Tile/Connections/PipesAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/Connections/PipesAdjacencyConnector.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using SS3D.Engine.Tiles.Connections;
 using System;
+using SS3D.Engine.Tiles.State;
 
 namespace SS3D.Engine.Tiles.Connections
 {
@@ -9,7 +10,7 @@ namespace SS3D.Engine.Tiles.Connections
      * The pipes adjacency connector is for small pipes layers 2 and 4...
      */
     [RequireComponent(typeof(MeshFilter))]
-    public class PipesAdjacencyConnector : MonoBehaviour, AdjacencyConnector
+    public class PipesAdjacencyConnector : AdjacencyStateMaintainer, AdjacencyConnector
     {
         public enum TileLayer
         {
@@ -73,7 +74,12 @@ namespace SS3D.Engine.Tiles.Connections
         {
             bool isConnected = (tile.turf && (tile.turf.genericType == type || type == null));
             if (tile.fixtures != null)
+            {
                 isConnected = isConnected || (tile.fixtures.GetFixtureAtLayerIndex(LayerIndex) && (tile.fixtures.GetFixtureAtLayerIndex(LayerIndex).genericType == type || type == null));
+            }
+
+            isConnected &= (AdjacencyBitmap.Adjacent(TileState.blockedDirection, direction) == 0);
+
             return adjacents.UpdateDirection(direction, isConnected, true);
         }
 

--- a/Assets/Engine/Tile/Connections/WiresAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/Connections/WiresAdjacencyConnector.cs
@@ -18,6 +18,9 @@ namespace SS3D.Engine.Tiles.Connections
             Fixture,
         }
 
+        // Which locations should be blocked, from North -> West clockwise
+        public bool[] Blocked = new bool[Enum.GetValues(typeof(Direction)).Length];
+
         public int LayerIndex { get; set; }
 
         // Id that adjacent objects must be to count. If null, any id is accepted
@@ -94,6 +97,9 @@ namespace SS3D.Engine.Tiles.Connections
             isConnected |= (tile.turf && (tile.turf.genericType == type || type == null));
             if (tile.fixtures != null)
                 isConnected |= (tile.fixtures.GetFixtureAtLayerIndex(index) && (tile.fixtures.GetFixtureAtLayerIndex(index).genericType == type || type == null));
+
+            isConnected &= !Blocked[(int)direction];
+
             return adjacents.UpdateDirection(direction, isConnected, true);
         }
 

--- a/Assets/Engine/Tile/Connections/WiresAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/Connections/WiresAdjacencyConnector.cs
@@ -11,25 +11,14 @@ namespace SS3D.Engine.Tiles.Connections
      * The wires adjacency connector is built off the Simple adjaceny
      * connection but with some uniqueness.
      */
-
-    [Serializable]
-    public struct WireState
-    {
-        public byte blockedDirection;
-    }
-
-    [ExecuteAlways]
     [RequireComponent(typeof(MeshFilter))]
-    public class WiresAdjacencyConnector : TileStateMaintainer<WireState>, AdjacencyConnector
+    public class WiresAdjacencyConnector : AdjacencyStateMaintainer, AdjacencyConnector
     {
         public enum TileLayer
         {
             Turf,
             Fixture,
         }
-
-        // Which locations should be blocked
-        // public bool[] Blocked = new bool[Enum.GetValues(typeof(Direction)).Length];
 
         public int LayerIndex { get; set; }
 
@@ -108,19 +97,8 @@ namespace SS3D.Engine.Tiles.Connections
             if (tile.fixtures != null)
                 isConnected |= (tile.fixtures.GetFixtureAtLayerIndex(index) && (tile.fixtures.GetFixtureAtLayerIndex(index).genericType == type || type == null));
 
-            // Ugly hack because the array isn't initialized...
-            //if (Blocked.Length > 0)
-            //{
-            //    isConnected &= !Blocked[(int)direction];
-            //}
-            //else
-            //{
-            //    Blocked = new bool[Enum.GetValues(typeof(Direction)).Length];
-            //}
 
             isConnected &= (AdjacencyBitmap.Adjacent(TileState.blockedDirection, direction) == 0);
-                
-            // !Blocked[(int)direction];
 
             return adjacents.UpdateDirection(direction, isConnected, true);
         }
@@ -166,26 +144,6 @@ namespace SS3D.Engine.Tiles.Connections
             filter.mesh = mesh;
             transform.localRotation = Quaternion.Euler(transform.localRotation.eulerAngles.x, rotation, transform.localRotation.eulerAngles.z);
         }
-
-        //protected override void OnStateUpdate(WireState prevState = new WireState())
-        //{
-        //    //if (TileState.Blocked != null)
-        //    //    Blocked = TileState.Blocked;
-        //    /// 
-        //}
-
-//#if UNITY_EDITOR
-//        private void OnValidate()
-//        {
-//            EditorApplication.delayCall += () =>
-//            {
-//                if (this)
-//                {
-//                    OnStateUpdate();
-//                }
-//            };
-//        }
-//#endif
 
         // A bitfield of connections. Total of 8 connections -> 8 bits, ascending order with direction.
         private AdjacencyBitmap adjacents = new AdjacencyBitmap();

--- a/Assets/Engine/Tile/Connections/WiresAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/Connections/WiresAdjacencyConnector.cs
@@ -167,12 +167,12 @@ namespace SS3D.Engine.Tiles.Connections
             transform.localRotation = Quaternion.Euler(transform.localRotation.eulerAngles.x, rotation, transform.localRotation.eulerAngles.z);
         }
 
-        protected override void OnStateUpdate(WireState prevState = new WireState())
-        {
-            //if (TileState.Blocked != null)
-            //    Blocked = TileState.Blocked;
-            /// 
-        }
+        //protected override void OnStateUpdate(WireState prevState = new WireState())
+        //{
+        //    //if (TileState.Blocked != null)
+        //    //    Blocked = TileState.Blocked;
+        //    /// 
+        //}
 
 //#if UNITY_EDITOR
 //        private void OnValidate()

--- a/Assets/Engine/Tile/Connections/WiresAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/Connections/WiresAdjacencyConnector.cs
@@ -171,12 +171,14 @@ namespace SS3D.Engine.Tiles.Connections
         {
             //if (TileState.Blocked != null)
             //    Blocked = TileState.Blocked;
+            /// 
         }
 
 //#if UNITY_EDITOR
 //        private void OnValidate()
 //        {
-//            EditorApplication.delayCall += () => {
+//            EditorApplication.delayCall += () =>
+//            {
 //                if (this)
 //                {
 //                    OnStateUpdate();

--- a/Assets/Engine/Tile/Editor/AdjacencyEditor.cs
+++ b/Assets/Engine/Tile/Editor/AdjacencyEditor.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace SS3D.Engine.Tiles.Editor
 {
-    [CustomEditor(typeof(WiresAdjacencyConnector), true)]
+    [CustomEditor(typeof(AdjacencyStateMaintainer), true)]
     public class AdjacencyEditor : UnityEditor.Editor
     {
         private Dictionary<string, SerializedObject> extraState;
@@ -19,14 +19,7 @@ namespace SS3D.Engine.Tiles.Editor
         {
             base.DrawDefaultInspector();
 
-            WiresAdjacencyConnector connector = (WiresAdjacencyConnector)target;
-            //var connectorSerial = connector.GetComponentInChildren(typeof(TileStateCommunicator));
-            var subTiles = connector.GetComponentsInChildren(typeof(TileStateCommunicator));
-            if (extraState == null || subTiles.Length != extraState.Count || subTiles.Any(subTile => !extraState.ContainsKey(subTile.gameObject.name)))
-            {
-                extraState = subTiles.Select(state => new Tuple<string, SerializedObject>(state.gameObject.name, new SerializedObject(state))).ToDictionary(x => x.Item1, x => x.Item2);
-            }
-
+            AdjacencyStateMaintainer connector = (AdjacencyStateMaintainer)target;
             TileObject tileObject = connector.GetComponentInParent<TileObject>();
             
 
@@ -59,12 +52,6 @@ namespace SS3D.Engine.Tiles.Editor
             {
                 if (tileObject != null)
                 {
-                    //foreach (var state in extraState)
-                    //{
-                    //    state.Value.Update();
-                    //    SerializedProperty property = state.Value.FindProperty("tileState");
-                    //    state.Value.ApplyModifiedProperties();
-                    //}
 
                     bool modified = false;
                     var connectorSerial = new SerializedObject(connector);
@@ -73,13 +60,7 @@ namespace SS3D.Engine.Tiles.Editor
                     SerializedProperty property = connectorSerial.FindProperty("tileState");
                     property.FindPropertyRelative("blockedDirection").intValue = SetBitmap(blocked);
 
-                    //var stateNow = connector.TileState;
-
-                    //stateNow.blockedDirection = SetBitmap(blocked);
-                    //connector.SetTileState(stateNow);
-
                     modified = connectorSerial.ApplyModifiedProperties();
-
                     if (modified)
                     {
                         tileObject.RefreshSubData();

--- a/Assets/Engine/Tile/Editor/AdjacencyEditor.cs
+++ b/Assets/Engine/Tile/Editor/AdjacencyEditor.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace SS3D.Engine.Tiles.Editor
 {
-    [CustomEditor(typeof(WiresAdjacencyConnector))]
+    [CustomEditor(typeof(WiresAdjacencyConnector), true)]
     public class AdjacencyEditor : UnityEditor.Editor
     {
         private Dictionary<string, SerializedObject> extraState;
@@ -17,6 +17,8 @@ namespace SS3D.Engine.Tiles.Editor
 
         public override void OnInspectorGUI()
         {
+            base.DrawDefaultInspector();
+
             WiresAdjacencyConnector connector = (WiresAdjacencyConnector)target;
             //var connectorSerial = connector.GetComponentInChildren(typeof(TileStateCommunicator));
             var subTiles = connector.GetComponentsInChildren(typeof(TileStateCommunicator));

--- a/Assets/Engine/Tile/Editor/AdjacencyEditor.cs
+++ b/Assets/Engine/Tile/Editor/AdjacencyEditor.cs
@@ -1,4 +1,5 @@
 ﻿using SS3D.Engine.Tiles.Connections;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
@@ -9,11 +10,64 @@ namespace SS3D.Engine.Tiles.Editor
     [CustomEditor(typeof(WiresAdjacencyConnector))]
     public class AdjacencyEditor : UnityEditor.Editor
     {
+        private bool[] blocked = new bool[Enum.GetValues(typeof(Direction)).Length];
+
         public override void OnInspectorGUI()
         {
             WiresAdjacencyConnector connector = (WiresAdjacencyConnector)target;
+            TileObject tileObject = connector.GetComponentInParent<TileObject>();
+            blocked = connector.Blocked;
+
+            serializedObject.Update();
+            EditorGUILayout.PrefixLabel("Blocked direction");
+
+            // Top line
+            EditorGUILayout.BeginHorizontal(GUILayout.MaxWidth(20));
+            EditorGUILayout.Space(15);
+            blocked[0] = EditorGUILayout.Toggle(blocked[0]);
+
+            //for (int i = 0;  i < 3; i++)
+            //{
+            //    blocked[i] = EditorGUILayout.Toggle(blocked[i]);
+            //}
+
+            EditorGUILayout.EndHorizontal();
 
 
+            // Middle line
+            EditorGUILayout.BeginHorizontal(GUILayout.MaxWidth(20));
+            blocked[6] = EditorGUILayout.Toggle(blocked[6]);
+            EditorGUILayout.Space(15);
+            blocked[2] = EditorGUILayout.Toggle(blocked[2]);
+            EditorGUILayout.EndHorizontal();
+
+            // Last line
+            EditorGUILayout.BeginHorizontal(GUILayout.MaxWidth(20));
+            EditorGUILayout.Space(15);
+            blocked[4] = EditorGUILayout.Toggle(blocked[4]);
+
+            //for (int i = 5; i < 8; i++)
+            //{
+            //    blocked[i] = EditorGUILayout.Toggle(blocked[i]);
+            //}
+
+            EditorGUILayout.EndHorizontal();
+
+
+            serializedObject.ApplyModifiedProperties();
+
+            connector.Blocked = blocked;
+
+            if (GUI.changed)
+            {
+                if (tileObject != null)
+                {
+                    tileObject.RefreshAdjacencies();
+                    //tileObject.UpdateAllAdjacencies(new[] { tileObject.Tile });
+                }
+                else
+                    Debug.LogWarning("No tileobject found by adjacency editor");
+            }
         }
     }
 }

--- a/Assets/Engine/Tile/Editor/AdjacencyEditor.cs
+++ b/Assets/Engine/Tile/Editor/AdjacencyEditor.cs
@@ -1,0 +1,19 @@
+﻿using SS3D.Engine.Tiles.Connections;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace SS3D.Engine.Tiles.Editor
+{
+    [CustomEditor(typeof(WiresAdjacencyConnector))]
+    public class AdjacencyEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            WiresAdjacencyConnector connector = (WiresAdjacencyConnector)target;
+
+
+        }
+    }
+}

--- a/Assets/Engine/Tile/Editor/AdjacencyEditor.cs.meta
+++ b/Assets/Engine/Tile/Editor/AdjacencyEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e262c3ffb09d3a4fa4620e480ae32cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Tile/State/AdjacencyStateMaintainer.cs
+++ b/Assets/Engine/Tile/State/AdjacencyStateMaintainer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace SS3D.Engine.Tiles.State
+{
+    [Serializable]
+    public struct AdjacencyState
+    {
+        public byte blockedDirection;
+    }
+
+    [ExecuteAlways]
+    public class AdjacencyStateMaintainer : TileStateMaintainer<AdjacencyState>
+    {
+        protected override void OnStateUpdate(AdjacencyState prevState = new AdjacencyState())
+        {
+
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            EditorApplication.delayCall += () => {
+                if (this)
+                {
+                    OnStateUpdate();
+                }
+            };
+        }
+#endif
+    }
+}

--- a/Assets/Engine/Tile/State/AdjacencyStateMaintainer.cs.meta
+++ b/Assets/Engine/Tile/State/AdjacencyStateMaintainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32dd1a24b407fd24da49a4f56d4aa5c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Tile/TileManager.cs
+++ b/Assets/Engine/Tile/TileManager.cs
@@ -508,9 +508,6 @@ namespace SS3D.Engine.Tiles {
                 if (f)
                 {
                     writer.WriteString(f.name ?? "");
-
-                    // Write tile rotation
-                    // writer.WriteString(f.GetRotation().ToString());
                 }
                 else
                 {
@@ -527,9 +524,6 @@ namespace SS3D.Engine.Tiles {
                 if (f)
                 {
                     writer.WriteString(f.name ?? "");
-
-                    // Write tile rotation
-                    // writer.WriteString(f.GetRotation().ToString());
                 }
                 else
                 {
@@ -544,12 +538,6 @@ namespace SS3D.Engine.Tiles {
                 if (f)
                 {
                     writer.WriteString(f.name ?? "");
-
-                    // Write tile rotation
-                    // writer.WriteString(f.GetRotation().ToString());
-
-                    // if (f.GetRotation().ToString() != "North")
-                    //    Debug.Log("Not north");
                 }
                 else
                 {
@@ -603,9 +591,6 @@ namespace SS3D.Engine.Tiles {
                 {
                     TileFixture tf = (TileFixture)fixtures.FirstOrDefault(fixture => fixture.name == fixtureName);
 
-                    //string rotation = reader.ReadString();
-                    //tf.SetRotation((Rotation)Enum.Parse(typeof(Rotation), rotation));
-
                     tileDefinition.fixtures.SetTileFixtureAtLayer(tf, layer);
                     if (tf == null)
                     {
@@ -622,9 +607,6 @@ namespace SS3D.Engine.Tiles {
                 {
                     WallFixture wf = (WallFixture)fixtures.FirstOrDefault(fixture => fixture.name == fixtureName);
 
-                    //string rotation = reader.ReadString();
-                    //wf.SetRotation((Rotation)Enum.Parse(typeof(Rotation), rotation));
-
                     tileDefinition.fixtures.SetWallFixtureAtLayer(wf, layer);
                     if (wf == null)
                     {
@@ -640,12 +622,6 @@ namespace SS3D.Engine.Tiles {
                 if (!string.IsNullOrEmpty(fixtureName))
                 {
                     FloorFixture ff = (FloorFixture)fixtures.FirstOrDefault(fixture => fixture.name == fixtureName);
-
-                    //string rotation = reader.ReadString();
-                    //if (rotation != "North")
-                    //    Debug.Log("Not north rotation read");
-
-                    //ff.SetRotation((Rotation)Enum.Parse(typeof(Rotation), rotation));
 
                     tileDefinition.fixtures.SetFloorFixtureAtLayer(ff, layer);
                     if (ff == null)

--- a/Assets/Engine/Tile/TileManager.cs
+++ b/Assets/Engine/Tile/TileManager.cs
@@ -477,6 +477,33 @@ namespace SS3D.Engine.Tiles {
             return tiles.Values.ToList<TileObject>();
         }
 
+        public TileObject[] GetAdjacentTileObjects(TileObject tileObject)
+        {
+            TileObject[] adjacents = new TileObject[8];
+            var index = GetIndexAt(tileObject.transform.position);
+
+            for (Direction direction = Direction.North; direction <= Direction.NorthWest; direction += 1)
+            {
+                // Take the cardinal direction, but use it in negative, so direction means the direction from OTHER to the just updated tile.
+                var modifier = DirectionHelper.ToCardinalVector(direction);
+
+                if (index.y + modifier.Item2 < 0 || index.x + modifier.Item1 < 0)
+                    continue;
+
+                ulong otherKey = GetKey(index.x + modifier.Item1, index.y + modifier.Item2);
+                if (tiles.ContainsKey(otherKey))
+                {
+                    adjacents[(int)direction] = tiles[otherKey];
+                }
+                else
+                {
+                    adjacents[(int)direction] = null;
+                }
+            }
+
+            return adjacents;
+        }
+
         // TODO: This is an inefficient data structure for our purposes.
         // TODO: Allow negatives
         // The key is the concatenated y,x position of the tile.

--- a/Assets/Engine/Tile/TileMapEditorHelpers.cs
+++ b/Assets/Engine/Tile/TileMapEditorHelpers.cs
@@ -111,13 +111,23 @@ namespace Tile
 
             if (fixtureObject != null)
             {
+                
+
+
                 FixtureStateMaintainer maintainer = fixtureObject.GetComponent<FixtureStateMaintainer>();
                 if (maintainer != null)
                 {
-                    var stateNow = maintainer.TileState;
+                    var fixtureSerial = new SerializedObject(maintainer);
+                    fixtureSerial.Update();
+
+                    SerializedProperty property = fixtureSerial.FindProperty("tileState");
+                    property.FindPropertyRelative("rotation").intValue = (int)rotation;
+                    fixtureSerial.ApplyModifiedProperties();
+
+                    //var stateNow = maintainer.TileState;
                     
-                    stateNow.rotation = rotation;
-                    maintainer.SetTileState(stateNow);
+                    //stateNow.rotation = rotation;
+                    //maintainer.SetTileState(stateNow);
 
                     // Refresh the subdata because it still has the old tilestate
                     tileObject.RefreshSubData();

--- a/Assets/Engine/Tile/TileObject.cs
+++ b/Assets/Engine/Tile/TileObject.cs
@@ -123,6 +123,18 @@ namespace SS3D.Engine.Tiles
         {
             UpdateSubDataFromChildren();
         }
+
+        public void RefreshAdjacencies()
+        {
+            var tileManager = transform.root.GetComponent<TileManager>();
+
+            if (tileManager != null && tileManager.Count > 0 && !TileMapEditorHelpers.IsGhostTile(this))
+            {
+                var pos = tileManager.GetIndexAt(transform.position);
+                tileManager.EditorUpdateTile(pos.x, pos.y, tile);
+            }
+        }
+
 #endif
 
         /**

--- a/Assets/Engine/Tile/TileObject.cs
+++ b/Assets/Engine/Tile/TileObject.cs
@@ -610,14 +610,15 @@ namespace SS3D.Engine.Tiles
             if (newTile.subStates != null && newTile.subStates.Length >= 2 && newTile.subStates[1] != null)
                 turf?.GetComponent<TileStateCommunicator>()?.SetTileState(newTile.subStates[1]);
 
-            int i = 0;
-            foreach (GameObject fixture in fixtures)
+            // int i = 0;
+            // foreach (GameObject fixture in fixtures)
+            for (int i = 0; i < fixtures.Length; i++)
             {
                 if (newTile.subStates != null && newTile.subStates.Length >= i + 3 && newTile.subStates[i + 2] != null)
                 {
                     fixtures[i]?.GetComponent<TileStateCommunicator>()?.SetTileState(newTile.subStates[i + 2]);
                 }
-                i++;
+                //i++;
             }
         }
 
@@ -629,12 +630,13 @@ namespace SS3D.Engine.Tiles
             tile.subStates[0] = plenum != null ? plenum?.GetComponent<TileStateCommunicator>()?.GetTileState() : null;
             tile.subStates[1] = turf != null ? turf?.GetComponent<TileStateCommunicator>()?.GetTileState() : null;
 
-            int i = 2;
-            foreach (GameObject fixture in fixtures)
+            // int i = 2;
+            // foreach (GameObject fixture in fixtures)
+            for (int i = 0; i < fixtures.Length; i++)
             {
-                if (fixture)
-                    tile.subStates[i] = fixture?.GetComponent<TileStateCommunicator>()?.GetTileState();
-                i++;
+                if (fixtures[i] != null)
+                    tile.subStates[i + 2] = fixtures[i].GetComponent<TileStateCommunicator>()?.GetTileState();
+                // i++;
             }
         }
 #if UNITY_EDITOR

--- a/Assets/Engine/Tile/TileObject.cs
+++ b/Assets/Engine/Tile/TileObject.cs
@@ -639,6 +639,26 @@ namespace SS3D.Engine.Tiles
                 // i++;
             }
         }
+
+        public GameObject GetLayer(int i)
+        {
+            int offset = -2;
+
+            switch (i)
+            {
+                case 0:
+                    return plenum;
+                case 1:
+                    return turf;
+                default:
+                    if ((i + offset) >= fixtures.Length)
+                        return null;
+                    if (fixtures[i + offset] != null)
+                        return fixtures[i + offset];
+                    else return null;
+            }
+        }
+
 #if UNITY_EDITOR
         /**
          * Migrates existing fixtures that do not have a fixturelayer set.
@@ -662,25 +682,5 @@ namespace SS3D.Engine.Tiles
         private GameObject[] fixtures = new GameObject[TileDefinition.GetAllFixtureLayerSize()];
         private AdjacencyConnector[] tileFixtureConnectors = new AdjacencyConnector[TileDefinition.GetTileFixtureLayerSize()];
         private AdjacencyConnector[] floorFixtureConnectors = new AdjacencyConnector[TileDefinition.GetFloorFixtureLayerSize()];
-
-
-        public GameObject GetLayer(int i)
-        {
-            int offset = -2;
-
-            switch (i)
-            {
-                case 0:
-                    return plenum;
-                case 1:
-                    return turf;
-                default:
-                    if ((i + offset) >= fixtures.Length)
-                        return null;
-                    if (fixtures[i + offset] != null)
-                        return fixtures[i + offset];
-                    else return null;
-            }
-        }
     }
 }


### PR DESCRIPTION
<!-- Text within these arrows are notes for you and should be deleted. -->

### Summary
This PR adds the ability for the user to set optional connections for wires and pipes. These can now be changed easily via the editor and can be extended to in-game when we got a construction GUI ready.




## Pictures/Videos
![afbeelding](https://user-images.githubusercontent.com/5231626/107697082-0f812600-6cb3-11eb-8a25-6d620e5c5de5.png)

![afbeelding](https://user-images.githubusercontent.com/5231626/107697101-15770700-6cb3-11eb-97b4-bb9ceb8a496f.png)

![afbeelding](https://user-images.githubusercontent.com/5231626/107697119-1c057e80-6cb3-11eb-9f8b-23eed059489c.png)

## Fixes
Resolves #545, 
