### PR TITLE
Fix interaction with airlocks

### DIFF
--- a/Assets/Content/Structures/Doors/Classic Airlocks/Airlock Classic.prefab
+++ b/Assets/Content/Structures/Doors/Classic Airlocks/Airlock Classic.prefab
@@ -59,6 +59,7 @@ GameObject:
   - component: {fileID: 269803425871263521}
   - component: {fileID: -6833891496423765305}
   - component: {fileID: -8389530401997181573}
+  - component: {fileID: -6696039690863873960}
   m_Layer: 0
   m_Name: Airlock Classic
   m_TagString: Untagged
@@ -261,6 +262,22 @@ MonoBehaviour:
   DisplayName: Airlock
   Text: 
   MaxDistance: 0
+--- !u!54 &-6696039690863873960
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3290821787637386385}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &3667226139312871055
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Structures/Doors/Classic Airlocks/Airlock Double Classic.prefab
+++ b/Assets/Content/Structures/Doors/Classic Airlocks/Airlock Double Classic.prefab
@@ -203,6 +203,7 @@ GameObject:
   - component: {fileID: 970921969854155344}
   - component: {fileID: 1229972945574311675}
   - component: {fileID: 6206328579464716955}
+  - component: {fileID: 9031378453632522502}
   m_Layer: 0
   m_Name: Airlock Double Classic
   m_TagString: Untagged
@@ -404,3 +405,19 @@ MonoBehaviour:
   DisplayName: Airlock
   Text: 
   MaxDistance: 0
+--- !u!54 &9031378453632522502
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7100755734509837163}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Assets/Content/Structures/Doors/Station Airlocks/Airlock Glass.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Airlock Glass.prefab
@@ -190,6 +190,7 @@ GameObject:
   - component: {fileID: 3785474312019654586}
   - component: {fileID: 1594027951419558492}
   - component: {fileID: 5702311699610938402}
+  - component: {fileID: 7414406101432576224}
   m_Layer: 0
   m_Name: Airlock Glass
   m_TagString: Untagged
@@ -392,6 +393,22 @@ MonoBehaviour:
   DisplayName: Airlock
   Text: 
   MaxDistance: 0
+--- !u!54 &7414406101432576224
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1917799960222321674}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &4803013556368833953
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Structures/Doors/Station Airlocks/Airlock.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Airlock.prefab
@@ -234,6 +234,7 @@ GameObject:
   - component: {fileID: 3785474312019654586}
   - component: {fileID: 1594027951419558492}
   - component: {fileID: 5702311699610938402}
+  - component: {fileID: 7510031232805575769}
   m_Layer: 0
   m_Name: Airlock
   m_TagString: Untagged
@@ -436,6 +437,22 @@ MonoBehaviour:
   DisplayName: Airlock
   Text: 
   MaxDistance: 0
+--- !u!54 &7510031232805575769
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1917799960222321674}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &4803013556368833953
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Structures/Doors/Station Airlocks/Civilian/Airlock Civilian Glass.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Civilian/Airlock Civilian Glass.prefab
@@ -190,6 +190,7 @@ GameObject:
   - component: {fileID: 3785474312019654586}
   - component: {fileID: 1594027951419558492}
   - component: {fileID: 5702311699610938402}
+  - component: {fileID: -7467445690116658910}
   m_Layer: 0
   m_Name: Airlock Civilian Glass
   m_TagString: Untagged
@@ -392,6 +393,22 @@ MonoBehaviour:
   DisplayName: Airlock
   Text: 
   MaxDistance: 0
+--- !u!54 &-7467445690116658910
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1917799960222321674}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &4803013556368833953
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Structures/Doors/Station Airlocks/Civilian/Airlock Civilian.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Civilian/Airlock Civilian.prefab
@@ -190,6 +190,7 @@ GameObject:
   - component: {fileID: 3785474312019654586}
   - component: {fileID: 1594027951419558492}
   - component: {fileID: 5702311699610938402}
+  - component: {fileID: -2250944765177032769}
   m_Layer: 0
   m_Name: Airlock Civilian
   m_TagString: Untagged
@@ -392,6 +393,22 @@ MonoBehaviour:
   DisplayName: Airlock
   Text: 
   MaxDistance: 0
+--- !u!54 &-2250944765177032769
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1917799960222321674}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &4803013556368833953
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Structures/Doors/Station Airlocks/Double Airlock.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Double Airlock.prefab
@@ -268,6 +268,7 @@ GameObject:
   - component: {fileID: 2021576283312761790}
   - component: {fileID: 4510847360138614360}
   - component: {fileID: 8346248944536319079}
+  - component: {fileID: 8310574862063813360}
   m_Layer: 0
   m_Name: Double Airlock
   m_TagString: Untagged
@@ -470,6 +471,22 @@ MonoBehaviour:
   DisplayName: Airlock
   Text: 
   MaxDistance: 0
+--- !u!54 &8310574862063813360
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3610695960477650958}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &5755565538449260213
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Structures/Doors/Station Airlocks/Maintenance/Airlock Maintenance Glass.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Maintenance/Airlock Maintenance Glass.prefab
@@ -190,6 +190,7 @@ GameObject:
   - component: {fileID: 3785474312019654586}
   - component: {fileID: 1594027951419558492}
   - component: {fileID: 5702311699610938402}
+  - component: {fileID: -668847274251364507}
   m_Layer: 0
   m_Name: Airlock Maintenance Glass
   m_TagString: Untagged
@@ -392,6 +393,22 @@ MonoBehaviour:
   DisplayName: Airlock
   Text: 
   MaxDistance: 0
+--- !u!54 &-668847274251364507
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1917799960222321674}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &4803013556368833953
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Structures/Doors/Station Airlocks/Maintenance/Airlock Maintenance.prefab
+++ b/Assets/Content/Structures/Doors/Station Airlocks/Maintenance/Airlock Maintenance.prefab
@@ -190,6 +190,7 @@ GameObject:
   - component: {fileID: 3785474312019654586}
   - component: {fileID: 1594027951419558492}
   - component: {fileID: 5702311699610938402}
+  - component: {fileID: 4819634808480150573}
   m_Layer: 0
   m_Name: Airlock Maintenance
   m_TagString: Untagged
@@ -392,6 +393,22 @@ MonoBehaviour:
   DisplayName: Airlock
   Text: 
   MaxDistance: 0
+--- !u!54 &4819634808480150573
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1917799960222321674}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &2719521177239230849
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Summary

The interaction with airlocks was already implemented, but because the interaction system ignores Trigger colliders, they were bugged.

To fix that, I added a kinematic RigidBody to the main GameObject of the doors. When a GameObject has a RigidBody, the colliders of each child objects are interpreted as being its own, so the raycast hits work like they should.

## Pictures/Videos (optional)

https://user-images.githubusercontent.com/24720405/107721118-91c11880-6cba-11eb-8f18-a3893a91f665.mp4

## Changes to Files (optional)

Changed the prefab of every door.

## Known issues (optional)

- Basically impossible to interact with an open door because the mesh goes completly into the wall.
- Currently, clicking on a door while it's opening will trigger th open/close event again and the door will close immediately once it's fully open. This could be fixed somewhat easily by doing changes to the Openable class, was unsure if it would fit this pull request.

## Fixes (optional)

Closes #452 