### PR TITLE
Add emergency light and light interactions

### DIFF
--- a/Assets/Content/Structures/Wall Mounts/Lights/Emergency Light Fixture.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Lights/Emergency Light Fixture.prefab
@@ -38,7 +38,7 @@ Light:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 313226461210813974}
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 10
   m_Type: 2
   m_Shape: 0
@@ -130,7 +130,7 @@ Light:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3482271348664395926}
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 10
   m_Type: 0
   m_Shape: 0
@@ -222,7 +222,7 @@ Light:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6579512670480499150}
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 10
   m_Type: 0
   m_Shape: 0
@@ -450,7 +450,7 @@ Animator:
   m_GameObject: {fileID: 8808820507163946139}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 27849457b0c5d304daa8de6926a07c79, type: 2}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -471,6 +471,7 @@ GameObject:
   - component: {fileID: 5034072719782870709}
   - component: {fileID: -1648229310630695525}
   - component: {fileID: 4210036883970617636}
+  - component: {fileID: -809169823751194735}
   m_Layer: 0
   m_Name: Emergency Light Fixture
   m_TagString: Untagged
@@ -535,3 +536,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tileState:
     rotation: 0
+--- !u!114 &-809169823751194735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8824907131049981641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 307b90d11903d8c42bef2ae0d15ce5f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  turnOnIcon: {fileID: 21300000, guid: 3788240ffacf45b4998b63134326628e, type: 3}

--- a/Assets/Content/Structures/Wall Mounts/Lights/Emergency Light Fixture.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Lights/Emergency Light Fixture.prefab
@@ -472,6 +472,7 @@ GameObject:
   - component: {fileID: -1648229310630695525}
   - component: {fileID: 4210036883970617636}
   - component: {fileID: -809169823751194735}
+  - component: {fileID: -5483626464106783721}
   m_Layer: 0
   m_Name: Emergency Light Fixture
   m_TagString: Untagged
@@ -551,3 +552,19 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   turnOnIcon: {fileID: 21300000, guid: 3788240ffacf45b4998b63134326628e, type: 3}
+--- !u!114 &-5483626464106783721
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8824907131049981641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 0
+  serverOnly: 0
+  m_AssetId: 
+  hasSpawned: 0

--- a/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLight.controller
+++ b/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLight.controller
@@ -93,7 +93,7 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -124,12 +124,12 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
-  m_InterruptionSource: 2
+  m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
 --- !u!1107 &9201545263781260974

--- a/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLight.controller
+++ b/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLight.controller
@@ -1,0 +1,159 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-8487947640280166305
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Active
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -3070464125558026438}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-3070464125558026438
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Active
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 4342532345526595152}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 42edad1dc70b8a04185d937421fd1ba3, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-2665741168170977335
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Stop
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -8487947640280166305}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: EmergencyLight
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: Active
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: 9201545263781260974}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1101 &4342532345526595152
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Active
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2665741168170977335}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 2
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1107 &9201545263781260974
+AnimatorStateMachine:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -2665741168170977335}
+    m_Position: {x: 450, y: 130, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -3070464125558026438}
+    m_Position: {x: 450, y: -10, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 60, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -2665741168170977335}

--- a/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLight.controller.meta
+++ b/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLight.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27849457b0c5d304daa8de6926a07c79
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightAnim.anim
+++ b/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightAnim.anim
@@ -1,0 +1,199 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: EmergencyLightAnim
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 360}
+        outSlope: {x: 0, y: 0, z: 360}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 1
+        value: {x: 0, y: 0, z: 360}
+        inSlope: {x: 0, y: 0, z: 360}
+        outSlope: {x: 0, y: 0, z: 360}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: 
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 4
+      script: {fileID: 0}
+      typeID: 4
+      customType: 4
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: localEulerAnglesRaw.x
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: localEulerAnglesRaw.y
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 360
+        outSlope: 360
+        tangentMode: 34
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 360
+        inSlope: 360
+        outSlope: 360
+        tangentMode: 34
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: localEulerAnglesRaw.z
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  m_EulerEditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalEulerAngles.x
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalEulerAngles.y
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalEulerAngles.z
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  m_HasGenericRootTransform: 1
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightAnim.anim.meta
+++ b/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightAnim.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42edad1dc70b8a04185d937421fd1ba3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightObject.cs
+++ b/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightObject.cs
@@ -1,4 +1,5 @@
-﻿using SS3D.Content.Systems.Interactions;
+﻿using Mirror;
+using SS3D.Content.Systems.Interactions;
 using SS3D.Engine.Interactions;
 using SS3D.Engine.Interactions.Extensions;
 using System.Collections;
@@ -34,10 +35,23 @@ public class EmergencyLightObject : InteractionTargetNetworkBehaviour
         return new IInteraction[] { interaction };
     }
 
+    
     private void Toggle(InteractionEvent interactionEvent, InteractionReference reference)
     {
         on = !on;
 
+        animator.SetBool(OnHash, on);
+        foreach (Light light in lights)
+        {
+            light.enabled = on;
+        }
+
+        RpcToggle(on);
+    }
+
+    [ClientRpc]
+    private void RpcToggle(bool on)
+    {
         animator.SetBool(OnHash, on);
         foreach (Light light in lights)
         {

--- a/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightObject.cs
+++ b/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightObject.cs
@@ -1,0 +1,47 @@
+﻿using SS3D.Content.Systems.Interactions;
+using SS3D.Engine.Interactions;
+using SS3D.Engine.Interactions.Extensions;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EmergencyLightObject : InteractionTargetNetworkBehaviour
+{
+    private static readonly int OnHash = Animator.StringToHash("Active");
+
+    public Sprite turnOnIcon;
+    private Animator animator;
+
+    private Light[] lights;
+    private bool on;
+
+    void Start()
+    {
+        animator = GetComponentInChildren<Animator>();
+        lights = GetComponentsInChildren<Light>();
+    }
+
+
+    public override IInteraction[] GenerateInteractions(InteractionEvent interactionEvent)
+    {
+        var interaction = new SimpleInteraction
+        {
+            Name = on ? "Turn off" : "Turn on",
+            icon = turnOnIcon,
+            CanInteractCallback = InteractionExtensions.RangeCheck,
+            Interact = Toggle,
+        };
+        return new IInteraction[] { interaction };
+    }
+
+    private void Toggle(InteractionEvent interactionEvent, InteractionReference reference)
+    {
+        on = !on;
+
+        animator.SetBool(OnHash, on);
+        foreach (Light light in lights)
+        {
+            light.enabled = on;
+        }
+    }
+}

--- a/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightObject.cs.meta
+++ b/Assets/Content/Structures/Wall Mounts/Lights/EmergencyLightObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 307b90d11903d8c42bef2ae0d15ce5f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/Structures/Wall Mounts/Lights/Light Bulb Fixture.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Lights/Light Bulb Fixture.prefab
@@ -344,6 +344,8 @@ GameObject:
   - component: {fileID: 5034072719782870709}
   - component: {fileID: -1648229310630695525}
   - component: {fileID: -2312561482214671454}
+  - component: {fileID: 709808169560035747}
+  - component: {fileID: 7846543073528734464}
   m_Layer: 0
   m_Name: Light Bulb Fixture
   m_TagString: Untagged
@@ -408,3 +410,37 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tileState:
     rotation: 0
+--- !u!114 &709808169560035747
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8824907131049981641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 0
+  serverOnly: 0
+  m_AssetId: 
+  hasSpawned: 0
+--- !u!114 &7846543073528734464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8824907131049981641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96366c8f4df7c734e856c80b8620ecc3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  turnOnIcon: {fileID: 21300000, guid: 3788240ffacf45b4998b63134326628e, type: 3}
+  onMaterial: {fileID: 2100000, guid: a4136159677bfb546846ebe3f0e64d9c, type: 2}
+  offMaterial: {fileID: 2100000, guid: 7b91bd4845c08c04f96e3a5f5c47aeca, type: 2}
+  bulbRenderer: {fileID: 3189588032500677955}

--- a/Assets/Content/Structures/Wall Mounts/Lights/Light Tube Fixture.prefab
+++ b/Assets/Content/Structures/Wall Mounts/Lights/Light Tube Fixture.prefab
@@ -12,6 +12,8 @@ GameObject:
   - component: {fileID: 8648403125281566512}
   - component: {fileID: -5688893441080166448}
   - component: {fileID: -7347470021286839313}
+  - component: {fileID: 4876898310796429852}
+  - component: {fileID: 211638627342979835}
   m_Layer: 0
   m_Name: Light Tube Fixture
   m_TagString: Untagged
@@ -76,6 +78,40 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tileState:
     rotation: 0
+--- !u!114 &4876898310796429852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5161561551087789900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 0
+  serverOnly: 0
+  m_AssetId: 
+  hasSpawned: 0
+--- !u!114 &211638627342979835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5161561551087789900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96366c8f4df7c734e856c80b8620ecc3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  turnOnIcon: {fileID: 21300000, guid: 3788240ffacf45b4998b63134326628e, type: 3}
+  onMaterial: {fileID: 2100000, guid: a4136159677bfb546846ebe3f0e64d9c, type: 2}
+  offMaterial: {fileID: 2100000, guid: 7b91bd4845c08c04f96e3a5f5c47aeca, type: 2}
+  bulbRenderer: {fileID: 1268435986470628550}
 --- !u!1 &5181080420812569886
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Structures/Wall Mounts/Lights/LightBulb.controller
+++ b/Assets/Content/Structures/Wall Mounts/Lights/LightBulb.controller
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1107 &-835496177091773496
+AnimatorStateMachine:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 5669832506261711458}
+    m_Position: {x: 290, y: 10, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 5669832506261711458}
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LightBulb
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -835496177091773496}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &5669832506261711458
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: EmergencyLightAnim
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 42edad1dc70b8a04185d937421fd1ba3, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Content/Structures/Wall Mounts/Lights/LightBulb.controller.meta
+++ b/Assets/Content/Structures/Wall Mounts/Lights/LightBulb.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c340bbb70b4fc3a4d824af2daf5812e6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/Structures/Wall Mounts/Lights/SimpleLight.cs
+++ b/Assets/Content/Structures/Wall Mounts/Lights/SimpleLight.cs
@@ -1,4 +1,5 @@
-﻿using SS3D.Content.Systems.Interactions;
+﻿using Mirror;
+using SS3D.Content.Systems.Interactions;
 using SS3D.Engine.Interactions;
 using SS3D.Engine.Interactions.Extensions;
 using System.Collections;
@@ -36,6 +37,20 @@ public class SimpleLight : InteractionTargetNetworkBehaviour
     {
         on = !on;
 
+        foreach (Light light in lights)
+        {
+            light.enabled = on;
+        }
+
+        bulbRenderer.material = on ? onMaterial : offMaterial;
+
+        RpcToggle(on);
+    }
+
+
+    [ClientRpc]
+    private void RpcToggle(bool on)
+    {
         foreach (Light light in lights)
         {
             light.enabled = on;

--- a/Assets/Content/Structures/Wall Mounts/Lights/SimpleLight.cs
+++ b/Assets/Content/Structures/Wall Mounts/Lights/SimpleLight.cs
@@ -14,7 +14,7 @@ public class SimpleLight : InteractionTargetNetworkBehaviour
     public MeshRenderer bulbRenderer;
 
     private Light[] lights;
-    private bool on;
+    private bool on = true;
 
     void Start()
     {

--- a/Assets/Content/Structures/Wall Mounts/Lights/SimpleLight.cs
+++ b/Assets/Content/Structures/Wall Mounts/Lights/SimpleLight.cs
@@ -1,0 +1,46 @@
+﻿using SS3D.Content.Systems.Interactions;
+using SS3D.Engine.Interactions;
+using SS3D.Engine.Interactions.Extensions;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SimpleLight : InteractionTargetNetworkBehaviour
+{
+    public Sprite turnOnIcon;
+    public Material onMaterial;
+    public Material offMaterial;
+    public MeshRenderer bulbRenderer;
+
+    private Light[] lights;
+    private bool on;
+
+    void Start()
+    {
+        lights = GetComponentsInChildren<Light>();
+    }
+
+    public override IInteraction[] GenerateInteractions(InteractionEvent interactionEvent)
+    {
+        var interaction = new SimpleInteraction
+        {
+            Name = on ? "Turn off" : "Turn on",
+            icon = turnOnIcon,
+            CanInteractCallback = InteractionExtensions.RangeCheck,
+            Interact = Toggle,
+        };
+        return new IInteraction[] { interaction };
+    }
+
+    private void Toggle(InteractionEvent interactionEvent, InteractionReference reference)
+    {
+        on = !on;
+
+        foreach (Light light in lights)
+        {
+            light.enabled = on;
+        }
+
+        bulbRenderer.material = on ? onMaterial : offMaterial;
+    }
+}

--- a/Assets/Content/Structures/Wall Mounts/Lights/SimpleLight.cs.meta
+++ b/Assets/Content/Structures/Wall Mounts/Lights/SimpleLight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96366c8f4df7c734e856c80b8620ecc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!-- Text within these arrows are notes for you and should be deleted. -->

### Summary
This PR adds an animation and interaction to the emergency light and other light bulbs. Future implementations will use knobs and fire alarms, but for now this will suffice.
<!-- Provide a general summary of the problem here and in the title. -->

<!-- Follow with a more concise explanation of the change here. -->

<!-- What features does this change include/not include? -->

## Pictures/Videos
![2021-02-12 23-16-55](https://user-images.githubusercontent.com/5231626/107828198-a4a21e80-6d88-11eb-9f06-1fb00bced10f.gif)
![2021-02-12 23-17-09](https://user-images.githubusercontent.com/5231626/107828201-a5d34b80-6d88-11eb-9f9f-0e5708ab2a00.gif)

### Known issues
Changes to lights are currently not correctly send to another player even though the network code is there. This is due to #606 and applies to all fixtures on the tilemap.

## Fixes
Resolves #535
