### PR TITLE
Enhance interaction distance check

### DIFF
--- a/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
+++ b/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using SS3D.Engine.Tiles;
 
 namespace SS3D.Engine.Interactions.Extensions
 {
@@ -20,7 +21,13 @@ namespace SS3D.Engine.Interactions.Extensions
                 // No range limit
                 return true;
             }
-            
+
+            //Block interaction when point is on top of wall or above.
+            if (IsWallTop(point, 0.4f))
+            {
+                return false;
+            }
+
             Vector3 sourcePosition;
             if (provider is IInteractionOriginProvider origin)
             {
@@ -33,9 +40,46 @@ namespace SS3D.Engine.Interactions.Extensions
                 sourcePosition = provider.GameObject.transform.position;
             }
 
-
             RangeLimit range = interactionEvent.Source.GetRange();
-            return range.IsInRange(sourcePosition, point);
+            if (range.IsInRange(sourcePosition, point)) 
+            {
+                return true;
+            }
+
+            Collider targetCollider = interactionEvent.Target.GetComponent<Collider>();
+            if (targetCollider != null)
+            {
+                Vector3 closestPointOnCollider = targetCollider.ClosestPointOnBounds(sourcePosition);
+                return range.IsInRange(sourcePosition, closestPointOnCollider);
+            }
+
+            Rigidbody targetRigidBody = interactionEvent.Target.GetComponent<Rigidbody>();
+            if (targetRigidBody != null)
+            {
+                Vector3 closestPointOnRigidBody = targetRigidBody.ClosestPointOnBounds(sourcePosition);
+                return range.IsInRange(sourcePosition, closestPointOnRigidBody);
+            }
+
+            return false;
+        }
+
+        private static bool IsWallTop(Vector3 position, float deadzone = 0)
+        {
+            TileObject tileObject = TileManager.singleton.GetTile(position);
+            if (!tileObject.Tile.turf.isWall)
+            {
+                return false;
+            }
+
+            GameObject wallGameObject = tileObject.GetLayer(1);
+            Collider[] collidersOnWall = wallGameObject.GetComponentsInChildren<Collider>();
+            float topHeight = 0;
+            for (int i = 0; i < collidersOnWall.Length; i++)
+            {
+                topHeight = Mathf.Max(topHeight, collidersOnWall[i].bounds.max.y);
+            }
+
+            return position.y >= topHeight - deadzone;
         }
     }
 }


### PR DESCRIPTION
### Summary

Attempts to enhance the interaction distance check. Also implements a check to check if the interaction point is not on the top of a wall.

Ensures that the distance test will return true if any part of the target object is close enough to the player, and not only the interaction point.

## Pictures/Videos (optional)

The top of doors is now interactible and you cant place items directly on top of walls.

https://user-images.githubusercontent.com/24720405/108006305-df4ec580-6fd9-11eb-8501-61dad7cc2ae9.mp4

## Technical Notes (optional)

Check distance to interaction point. If it fails, look for the point on the target's collider that is closest to the interaction source and checks the distance to there. This 

## Known issues (optional)

 #236 can still cause items to end up on the top of walls.

## Fixes (optional)

Closes #614 