### PR TITLE
Reduce deadzone ( 0.4 -> 0.1) when checking for wall top

### DIFF
--- a/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
+++ b/Assets/Engine/Interactions/Extensions/InteractionExtensions.cs
@@ -23,7 +23,7 @@ namespace SS3D.Engine.Interactions.Extensions
             }
 
             //Block interaction when point is on top of wall or above.
-            if (IsWallTop(point, 0.4f))
+            if (IsWallTop(point, 0.1f))
             {
                 return false;
             }


### PR DESCRIPTION
### Summary
Deadzone was to big and was preventing light interactions.

## Fixes
Closes #535 
#610 works fine now