### PR TITLE
Adds StartFilters to Attached Containers

### DIFF
--- a/Assets/Content/Furniture/Machines/Science/Cell Charger.prefab
+++ b/Assets/Content/Furniture/Machines/Science/Cell Charger.prefab
@@ -383,6 +383,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   HideItems: 0
   AttachItems: 1
+  AttachmentOffset: {x: 0, y: 0, z: 0}
 --- !u!114 &6554092212881448881
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -397,6 +398,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AttachedContainer: {fileID: 8312077444202497988}
   Size: {x: 1, y: 1}
+  StartFilter: {fileID: 11400000, guid: 47ba41d97fc87d9469fa5be5b67bcbc2, type: 2}
 --- !u!114 &387266436717436548
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Engine/Inventory/AttachedContainerGenerator.cs
+++ b/Assets/Engine/Inventory/AttachedContainerGenerator.cs
@@ -11,6 +11,7 @@ namespace SS3D.Engine.Inventory
     {
         public AttachedContainer AttachedContainer;
         public Vector2Int Size;
+        public Filter StartFilter;
 
         public void Start()
         {
@@ -20,6 +21,9 @@ namespace SS3D.Engine.Inventory
             {
                 Size = Size
             };
+
+            if (StartFilter != null)
+                AttachedContainer.Container.Filters.Add(StartFilter);
         }
     }
 }


### PR DESCRIPTION
### Summary

Basically allows Attached Containers to have a starting FIlter, something that was removed from the old system, only implemented in the Cell Charger for now, it will now correctly filter the item so only power cells can be put in it

## Technical Notes (optional)

It only adds a StartFilter variable to the AttachedContainerGenerator script since it's the most efficient way without having to to remove the readonly keyword from the Container Filters

## Fixes (optional)

Fixes #646 
