### PR TITLE
Update VSCode package

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ext.nunit": "1.0.0",
     "com.unity.ide.rider": "1.1.4",
-    "com.unity.ide.vscode": "1.2.0",
+    "com.unity.ide.vscode": "1.2.3",
     "com.unity.postprocessing": "2.3.0",
     "com.unity.purchasing": "2.0.6",
     "com.unity.render-pipelines.lightweight": "7.3.1",


### PR DESCRIPTION
Fix Mirror namespace errors caused by outdated VSCode editor package.
You may need to regenerate your project files (Edit>Preferences>External Tools) after updating.

