### PR TITLE
Fixes issue where clients can't host after quitting server

### DIFF
--- a/Assets/Content/Systems/Managers/LoadingScreenManager.cs
+++ b/Assets/Content/Systems/Managers/LoadingScreenManager.cs
@@ -20,10 +20,26 @@ public class LoadingScreenManager : MonoBehaviour
 
     private void Start()
     {
-        SceneLoaderManager.mapLoaded += delegate { Toggle(true); };
-        TileManager.tileManagerLoaded += delegate { Toggle(false); };
+        SceneLoaderManager.mapLoaded += SetAnimatorTrue;
+        TileManager.tileManagerLoaded += SetAnimatorFalse;
     }
 
+	public void SetAnimatorTrue()
+	{
+		Toggle(true);
+	}
+	
+	public void SetAnimatorFalse()
+	{
+		Toggle(false);
+	}	
+
+	public void OnDestroy()
+	{
+        SceneLoaderManager.mapLoaded -= SetAnimatorTrue;
+        TileManager.tileManagerLoaded -= SetAnimatorFalse;		
+	}
+	
     public void Toggle(bool state)
     {
         if (!animator.enabled) animator.enabled = true;

--- a/Assets/Engine/Server/Round/LoadingSceneUIHelper.cs
+++ b/Assets/Engine/Server/Round/LoadingSceneUIHelper.cs
@@ -11,10 +11,26 @@ public class LoadingSceneUIHelper : MonoBehaviour
 
     private void Awake()
     {
-        SceneLoaderManager.mapLoaded += delegate { Toggle(true); };
-        TileManager.tileManagerLoaded += delegate { Toggle(false); };
+        SceneLoaderManager.mapLoaded += SetAnimatorTrue;
+        TileManager.tileManagerLoaded += SetAnimatorFalse;
     }
-    
+
+	public void SetAnimatorTrue()
+	{
+		Toggle(true);
+	}
+	
+	public void SetAnimatorFalse()
+	{
+		Toggle(false);
+	}	
+	
+	public void OnDestroy()
+	{
+        SceneLoaderManager.mapLoaded -= SetAnimatorTrue;
+        TileManager.tileManagerLoaded -= SetAnimatorFalse;		
+	}
+
     public void Toggle(bool state)
     {
         if (!animator.enabled) animator.enabled = true;


### PR DESCRIPTION
### Summary

Fixes an issue where the map will not load after you have disconnected from the server lobby. This affected both servers and clients.

## Changes to Files

Anonymous delegates within LoadingScreenManager and LoadingSceneUIHelper were named, and unsubscribed from static mapLoaded event when the scene closes.

## Known issues

Although this closes the primary issue listed in #673, it does not solve the issue of the client being unable to disconnect. I will raise a separate issue for that so that #673 can be closed out.

## Fixes

Closes #673
