### PR TITLE
Fixes Disconnect button for clients

### DIFF
--- a/Assets/Content/Systems/UI/Engine/ServerLobby/MainLobbyButtonHelper.cs
+++ b/Assets/Content/Systems/UI/Engine/ServerLobby/MainLobbyButtonHelper.cs
@@ -20,6 +20,7 @@ public class MainLobbyButtonHelper : MonoBehaviour
     {
         networkManager = LoginNetworkManager.singleton;
         player = LocalPlayerManager.singleton;
+		Debug.Log("player.name = " + player.name);
     }
 
     public void Quit()
@@ -35,10 +36,17 @@ public class MainLobbyButtonHelper : MonoBehaviour
 
     public void Disconnect()
     {
-        NetworkIdentity identity = player.networkConnection.identity;
-        if (identity.isServer)
+		// A client apparently doesn't know it's own connectionId, so we will use that
+		// as a proxy to determine whether we are the client or the server.
+		NetworkConnection connection = player.networkConnection;
+
+        if (connection != null)
+		{
             networkManager.StopHost();
-        if (identity.isClient)
+        }
+		else
+		{
             networkManager.StopClient();
+		}
     }
 }


### PR DESCRIPTION
### Summary

The Disconnect button previously did not work for clients either in-game or in the server lobby (i.e. once they had selected 'Join' in the main menu). It now works, and returns the client to the main menu.

## Technical Notes

I changed the way that MainLobbyButtonHelper decided whether it is the server or the client. According to the Mirror API, a client does not know its own connectionId, so I checked whether the networkConnection was unable to be assigned.

## Fixes

Closes #698
