### PR TITLE
Toggle flashlight and desk lamp bulb materials

### DIFF
--- a/Assets/Content/Items/Functional/Tools/Generic/DeskLamp.cs
+++ b/Assets/Content/Items/Functional/Tools/Generic/DeskLamp.cs
@@ -17,12 +17,18 @@ namespace SS3D.Content.Items.Functional.Tools
         public Material materialOn;
         public Material materialOff;
 
+        private MeshRenderer meshRenderer;
+
+        public void Start()
+        {
+            meshRenderer = this.prefab.GetComponent<MeshRenderer>();
+            meshRenderer.material = light.enabled ? materialOn : materialOff;
+        }
+
         public void Toggle()
         {
             light.enabled = !light.enabled;
-
-            this.prefab.GetComponent<MeshRenderer>().sharedMaterial = light.enabled ?
-                materialOn : materialOff;
+            meshRenderer.material = light.enabled ? materialOn : materialOff;
 
             RpcToggle(light.enabled);
         }
@@ -35,16 +41,8 @@ namespace SS3D.Content.Items.Functional.Tools
         [ClientRpc]
         private void RpcToggle(bool lightEnabled) 
         {
-            if (lightEnabled)
-            {
-                light.enabled = true; 
-                this.prefab.GetComponent<MeshRenderer>().sharedMaterial = materialOn;
-            }
-            else
-            {
-                light.enabled = false;
-                this.prefab.GetComponent<MeshRenderer>().sharedMaterial = materialOff;
-            }
+            light.enabled = lightEnabled;
+            meshRenderer.material = light.enabled ? materialOn : materialOff;
         }
 
         public override IInteraction[] GenerateInteractionsFromTarget(InteractionEvent interactionEvent)

--- a/Assets/Content/Items/Functional/Tools/Generic/DeskLamp.cs
+++ b/Assets/Content/Items/Functional/Tools/Generic/DeskLamp.cs
@@ -14,10 +14,16 @@ namespace SS3D.Content.Items.Functional.Tools
         [SerializeField]
         public new Light light = null;
         public Sprite toggleIcon;
+        public Material materialOn;
+        public Material materialOff;
 
         public void Toggle()
         {
             light.enabled = !light.enabled;
+
+            this.prefab.GetComponent<MeshRenderer>().sharedMaterial = light.enabled ?
+                materialOn : materialOff;
+
             RpcToggle(light.enabled);
         }
 
@@ -32,10 +38,12 @@ namespace SS3D.Content.Items.Functional.Tools
             if (lightEnabled)
             {
                 light.enabled = true; 
+                this.prefab.GetComponent<MeshRenderer>().sharedMaterial = materialOn;
             }
             else
             {
                 light.enabled = false;
+                this.prefab.GetComponent<MeshRenderer>().sharedMaterial = materialOff;
             }
         }
 

--- a/Assets/Content/Items/Functional/Tools/Generic/Flashlight.cs
+++ b/Assets/Content/Items/Functional/Tools/Generic/Flashlight.cs
@@ -18,13 +18,18 @@ namespace SS3D.Content.Items.Functional.Tools
         public Material bulbMaterialOff;
 
         public GameObject bulbObject;
+        private MeshRenderer meshRenderer;
+
+        public void Start() 
+        {
+            meshRenderer = bulbObject.GetComponent<MeshRenderer>();
+            meshRenderer.material = (light.enabled ? bulbMaterialOn : bulbMaterialOff);
+        }
         
         public void Toggle()
         {
             light.enabled = !light.enabled;
-            
-            bulbObject.GetComponent<MeshRenderer>().sharedMaterial = (light.enabled ? 
-                bulbMaterialOn : bulbMaterialOff);
+            meshRenderer.material = (light.enabled ? bulbMaterialOn : bulbMaterialOff);
 
             RpcToggle(light.enabled);
         }
@@ -37,16 +42,8 @@ namespace SS3D.Content.Items.Functional.Tools
         [ClientRpc]
         private void RpcToggle(bool lightEnabled) 
         {
-            if (lightEnabled)
-            {
-                light.enabled = true;
-                bulbObject.GetComponent<MeshRenderer>().sharedMaterial = bulbMaterialOn;
-            }
-            else
-            {
-                light.enabled = false;
-                bulbObject.GetComponent<MeshRenderer>().sharedMaterial = bulbMaterialOff;
-            }
+            light.enabled = lightEnabled;
+            meshRenderer.material = lightEnabled ? bulbMaterialOn : bulbMaterialOff;
         }
 
         public override IInteraction[] GenerateInteractionsFromTarget(InteractionEvent interactionEvent)

--- a/Assets/Content/Items/Functional/Tools/Generic/Flashlight.cs
+++ b/Assets/Content/Items/Functional/Tools/Generic/Flashlight.cs
@@ -14,10 +14,18 @@ namespace SS3D.Content.Items.Functional.Tools
         [SerializeField]
         public new Light light = null;
         public Sprite toggleIcon;
+        public Material bulbMaterialOn;
+        public Material bulbMaterialOff;
+
+        public GameObject bulbObject;
         
         public void Toggle()
         {
             light.enabled = !light.enabled;
+            
+            bulbObject.GetComponent<MeshRenderer>().sharedMaterial = (light.enabled ? 
+                bulbMaterialOn : bulbMaterialOff);
+
             RpcToggle(light.enabled);
         }
 
@@ -31,11 +39,13 @@ namespace SS3D.Content.Items.Functional.Tools
         {
             if (lightEnabled)
             {
-                light.enabled = true; 
+                light.enabled = true;
+                bulbObject.GetComponent<MeshRenderer>().sharedMaterial = bulbMaterialOn;
             }
             else
             {
                 light.enabled = false;
+                bulbObject.GetComponent<MeshRenderer>().sharedMaterial = bulbMaterialOff;
             }
         }
 

--- a/Assets/Content/Items/Functional/Tools/Generic/desk lamp.prefab
+++ b/Assets/Content/Items/Functional/Tools/Generic/desk lamp.prefab
@@ -283,6 +283,8 @@ MonoBehaviour:
   Size: {x: 0, y: 0}
   light: {fileID: 5157351164716868161}
   toggleIcon: {fileID: 21300000, guid: 3788240ffacf45b4998b63134326628e, type: 3}
+  materialOn: {fileID: 2100000, guid: a4136159677bfb546846ebe3f0e64d9c, type: 2}
+  materialOff: {fileID: 2100000, guid: 7b91bd4845c08c04f96e3a5f5c47aeca, type: 2}
 --- !u!114 &-25655414377668572
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Items/Functional/Tools/Generic/flashlight.prefab
+++ b/Assets/Content/Items/Functional/Tools/Generic/flashlight.prefab
@@ -110,6 +110,9 @@ MonoBehaviour:
   Size: {x: 0, y: 0}
   light: {fileID: 5674409998555339756}
   toggleIcon: {fileID: 21300000, guid: 3788240ffacf45b4998b63134326628e, type: 3}
+  bulbMaterialOn: {fileID: 2100000, guid: a4136159677bfb546846ebe3f0e64d9c, type: 2}
+  bulbMaterialOff: {fileID: 2100000, guid: 7b91bd4845c08c04f96e3a5f5c47aeca, type: 2}
+  bulbObject: {fileID: 5294707152616912772}
 --- !u!114 &-5120229352581138748
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -294,7 +297,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a4136159677bfb546846ebe3f0e64d9c, type: 2}
+  - {fileID: 2100000, guid: 7b91bd4845c08c04f96e3a5f5c47aeca, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0


### PR DESCRIPTION
### Summary

Previously flashlight and desk lamp bulb materials have been static when toggling light. This caused them to look on despite being off.

There are already 2 open PRs on this issue (but only for the flashlight). Since FlashlightInteraction.cs was deleted, these PRs can't be merged.

Thanks to jake34b and their PR for reference.

## Pictures/Videos (optional)

### Before

https://user-images.githubusercontent.com/26187000/121820957-e5a63300-cc95-11eb-8386-7b2dc0c9bd14.mp4

### After

https://user-images.githubusercontent.com/26187000/121820962-efc83180-cc95-11eb-8e6d-e451cff05805.mp4

## Fixes

Closes #232 
