### PR TITLE
add name of containers to the containerUI

### DIFF
--- a/Assets/Content/Items/Functional/Containers/Object/Toolboxes/Toolbox Red.prefab
+++ b/Assets/Content/Items/Functional/Containers/Object/Toolboxes/Toolbox Red.prefab
@@ -342,7 +342,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59d174b721ba45d285a8f164a519c314, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  DisplayName: 
+  DisplayName: Red tool box
   Text: Stores tools.
   MaxDistance: 0
 --- !u!95 &5206759755089209485

--- a/Assets/Content/Systems/UI/Game/Inventory/ContainerDisplay.prefab
+++ b/Assets/Content/Systems/UI/Game/Inventory/ContainerDisplay.prefab
@@ -173,8 +173,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -11.26}
-  m_SizeDelta: {x: -20.660706, y: -49.739975}
+  m_AnchoredPosition: {x: 0.6000061, y: -19.300003}
+  m_SizeDelta: {x: -21.913727, y: -65.79132}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &176838956871534865
 MonoBehaviour:
@@ -287,8 +287,10 @@ GameObject:
   - component: {fileID: 176838957447208626}
   - component: {fileID: 176838957447208629}
   - component: {fileID: 176838957447208625}
+  - component: {fileID: 8355071219440756668}
+  - component: {fileID: 1275290753067954247}
   m_Layer: 5
-  m_Name: Container Display
+  m_Name: ContainerDisplay
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -387,6 +389,53 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grid: {fileID: 176838956871534865}
+--- !u!222 &8355071219440756668
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 176838957447208628}
+  m_CullTransparentMesh: 0
+--- !u!23 &1275290753067954247
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 176838957447208628}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ad03effc37bf12f49bd065abbbe702e9, type: 3}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1 &176838957876275808
 GameObject:
   m_ObjectHideFlags: 0
@@ -516,6 +565,84 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &2291101419958647663
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 47307097510334265}
+  - component: {fileID: 3817062495811823534}
+  - component: {fileID: 337808250292447736}
+  m_Layer: 5
+  m_Name: Container name
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &47307097510334265
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2291101419958647663}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1417458471359616312}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -162, y: 117}
+  m_SizeDelta: {x: 15.190792, y: 16.00227}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3817062495811823534
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2291101419958647663}
+  m_CullTransparentMesh: 0
+--- !u!114 &337808250292447736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2291101419958647663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 150
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 200
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: PlaceHolder
 --- !u!1 &5098213259485877267
 GameObject:
   m_ObjectHideFlags: 0
@@ -528,6 +655,7 @@ GameObject:
   - component: {fileID: 8658399598170317973}
   - component: {fileID: 4116999197522443580}
   - component: {fileID: 8688264441537686106}
+  - component: {fileID: 1159261075221532237}
   m_Layer: 5
   m_Name: Display
   m_TagString: Untagged
@@ -548,12 +676,13 @@ RectTransform:
   m_Children:
   - {fileID: 176838956500443483}
   - {fileID: 176838957876275809}
+  - {fileID: 47307097510334265}
   m_Father: {fileID: 176838957447208624}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -101.6, y: 21.7}
   m_SizeDelta: {x: 350, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8658399598170317973
@@ -605,3 +734,42 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bc75650a71c9bfe40a6ee0346b80fb5f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!23 &1159261075221532237
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5098213259485877267}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ad03effc37bf12f49bd065abbbe702e9, type: 3}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0

--- a/Assets/Content/Systems/UI/Game/Inventory/ContainerDisplay.prefab
+++ b/Assets/Content/Systems/UI/Game/Inventory/ContainerDisplay.prefab
@@ -389,6 +389,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Grid: {fileID: 176838956871534865}
+  containerName: {fileID: 337808250292447736}
 --- !u!222 &8355071219440756668
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Engine/Inventory/AttachedContainer.cs
+++ b/Assets/Engine/Inventory/AttachedContainer.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using Mirror;
 using SS3D.Content;
 using UnityEngine;
+using SS3D.Content.Systems.Examine.Examinables;
+using SS3D.Engine.Examine;
+
 
 namespace SS3D.Engine.Inventory
 {
@@ -45,6 +48,33 @@ namespace SS3D.Engine.Inventory
         {
             get => container;
             set => UpdateContainer(value);
+        }
+
+        /// <summary>
+        /// Return the name of the Object as defined by the Examine System. 
+        /// <remarks> If multiple classes implement the Interface IExaminable
+        /// and have an ExamineType equal to SIMPLE_TEXT, it returns the first name encountered. </remarks>
+        /// </summary>
+        public string GetName()
+        {
+            String Name;
+
+            //Gets all components on this object implementing the interface IExaminable
+            var iExaminables = GetComponents<IExaminable>();
+            //Go through each components until one has a ExamineType equal to SIMPLE_TEXT and is not an empty string, then returns the name linked to it.
+            foreach (IExaminable iExaminable in iExaminables)
+            {
+               if (iExaminable.GetData().GetExamineType() == ExamineType.SIMPLE_TEXT)
+                {
+                    DataNameDescription DataName = (DataNameDescription)(iExaminable.GetData());
+                    Name = DataName.GetName();
+                    if (Name != "")
+                    {
+                        return Name;
+                    }
+                }
+            }
+            return null;
         }
 
         public static AttachedContainer CreateEmpty(GameObject gameObject, Vector2Int size, IEnumerable<Filter> filters = null)

--- a/Assets/Engine/Inventory/AttachedContainer.cs
+++ b/Assets/Engine/Inventory/AttachedContainer.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Mirror;
 using SS3D.Content;
 using UnityEngine;
-using SS3D.Content.Systems.Examine.Examinables;
 using SS3D.Engine.Examine;
 
 

--- a/Assets/Engine/Inventory/UI/ContainerUi.cs
+++ b/Assets/Engine/Inventory/UI/ContainerUi.cs
@@ -25,6 +25,7 @@ namespace SS3D.Engine.Inventory.UI
         }
 
         private AttachedContainer attachedContainer;
+        public Text containerName;
 
         public void Close()
         {
@@ -47,16 +48,11 @@ namespace SS3D.Engine.Inventory.UI
             var rect = transform.GetChild(0).GetComponent<RectTransform>();
             rect.sizeDelta = new Vector2(width, height);
 
-            
-
             // Set the text inside the containerUI to be the name of the container
-            GameObject containerName = GameObject.Find("Container name");
-            Text containerNameText = containerName.GetComponent<Text>();
-            containerNameText.text = attachedContainer.GetName();
+            containerName.text = attachedContainer.GetName();
 
-
-           // Position the text correctly inside the UI.
-           Vector3[] v = new Vector3[4];
+            // Position the text correctly inside the UI.
+            Vector3[] v = new Vector3[4];
             rect.GetLocalCorners(v); 
             containerName.transform.localPosition = v[1] + new Vector3(0.03f * width, -0.02f * height, 0);
         }

--- a/Assets/Engine/Inventory/UI/ContainerUi.cs
+++ b/Assets/Engine/Inventory/UI/ContainerUi.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using UnityEngine;
 using UnityEngine.UI;
-using SS3D.Content.Systems.Examine.Examinables;
 
 namespace SS3D.Engine.Inventory.UI
 {

--- a/Assets/Engine/Inventory/UI/ContainerUi.cs
+++ b/Assets/Engine/Inventory/UI/ContainerUi.cs
@@ -48,23 +48,16 @@ namespace SS3D.Engine.Inventory.UI
             var rect = transform.GetChild(0).GetComponent<RectTransform>();
             rect.sizeDelta = new Vector2(width, height);
 
+            
+
             // Set the text inside the containerUI to be the name of the container
             GameObject containerName = GameObject.Find("Container name");
             Text containerNameText = containerName.GetComponent<Text>();
-            SimpleExaminable simpleExaminable = attachedContainer.GetComponent<SimpleExaminable>();
-            ItemExaminable itemExaminable = attachedContainer.GetComponent<ItemExaminable>();
-            // Use the appropriate Examinable script, 
-            if(simpleExaminable)
-            {
-                containerNameText.text = attachedContainer.GetComponent<SimpleExaminable>().DisplayName;
-            }
-            else if (itemExaminable)
-            {
-                containerNameText.text = attachedContainer.GetComponent<ItemExaminable>().DisplayName;
-            }
+            containerNameText.text = attachedContainer.GetName();
 
-            // Position the text correctly inside the UI.
-            Vector3[] v = new Vector3[4];
+
+           // Position the text correctly inside the UI.
+           Vector3[] v = new Vector3[4];
             rect.GetLocalCorners(v); 
             containerName.transform.localPosition = v[1] + new Vector3(0.03f * width, -0.02f * height, 0);
         }

--- a/Assets/Engine/Inventory/UI/ContainerUi.cs
+++ b/Assets/Engine/Inventory/UI/ContainerUi.cs
@@ -46,6 +46,16 @@ namespace SS3D.Engine.Inventory.UI
             float height = rectTransform.offsetMin.y + Math.Abs(rectTransform.offsetMax.y) + gridDimensions.y;
             var rect = transform.GetChild(0).GetComponent<RectTransform>();
             rect.sizeDelta = new Vector2(width, height);
+
+            // Set the text inside the containerUI to be the name of the container
+            GameObject containerName = GameObject.Find("Container name");
+            Text containerNameText = containerName.GetComponent<Text>(); 
+            containerNameText.text = attachedContainer.name; 
+
+            // Position the text correctly inside the UI.
+            Vector3[] v = new Vector3[4];
+            rect.GetLocalCorners(v); 
+            containerName.transform.localPosition = v[1] + new Vector3(0.03f * width, -0.02f * height, 0);
         }
     }
 }

--- a/Assets/Engine/Inventory/UI/ContainerUi.cs
+++ b/Assets/Engine/Inventory/UI/ContainerUi.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using UnityEngine.UI;
+using SS3D.Content.Systems.Examine.Examinables;
 
 namespace SS3D.Engine.Inventory.UI
 {
@@ -50,7 +51,7 @@ namespace SS3D.Engine.Inventory.UI
             // Set the text inside the containerUI to be the name of the container
             GameObject containerName = GameObject.Find("Container name");
             Text containerNameText = containerName.GetComponent<Text>(); 
-            containerNameText.text = attachedContainer.name; 
+            containerNameText.text = attachedContainer.GetComponentInParent<SimpleExaminable>().DisplayName; 
 
             // Position the text correctly inside the UI.
             Vector3[] v = new Vector3[4];

--- a/Assets/Engine/Inventory/UI/ContainerUi.cs
+++ b/Assets/Engine/Inventory/UI/ContainerUi.cs
@@ -50,8 +50,18 @@ namespace SS3D.Engine.Inventory.UI
 
             // Set the text inside the containerUI to be the name of the container
             GameObject containerName = GameObject.Find("Container name");
-            Text containerNameText = containerName.GetComponent<Text>(); 
-            containerNameText.text = attachedContainer.GetComponentInParent<SimpleExaminable>().DisplayName; 
+            Text containerNameText = containerName.GetComponent<Text>();
+            SimpleExaminable simpleExaminable = attachedContainer.GetComponent<SimpleExaminable>();
+            ItemExaminable itemExaminable = attachedContainer.GetComponent<ItemExaminable>();
+            // Use the appropriate Examinable script, 
+            if(simpleExaminable)
+            {
+                containerNameText.text = attachedContainer.GetComponent<SimpleExaminable>().DisplayName;
+            }
+            else if (itemExaminable)
+            {
+                containerNameText.text = attachedContainer.GetComponent<ItemExaminable>().DisplayName;
+            }
 
             // Position the text correctly inside the UI.
             Vector3[] v = new Vector3[4];


### PR DESCRIPTION
See issue #701 . The name of the container is now displayed at the top of the containerUI.

## Pictures/Videos (optional)

![image](https://user-images.githubusercontent.com/14344825/122220408-97b94700-ceb0-11eb-8108-4bfcc7324acc.png)

The quality of the picture looks terrible, but that's how I see the game, I never found out why that was happening. I think it affects only me though. It should look normal on your side.

## Changes to Files (optional)

Added a text GameObject  to the containerDisplay.
Add a method GetName() to attachedContainers to get the name of the object on which the container is attached. It's done in a robust manner and in coherence with the Examine system.


Closes #701 
