### PR TITLE
Close UI of items put inside a container

### DIFF
--- a/Assets/Content/Systems/Interactions/OpenInteraction.cs
+++ b/Assets/Content/Systems/Interactions/OpenInteraction.cs
@@ -20,7 +20,7 @@ namespace SS3D.Content.Systems.Interactions
 
         public string GetName(InteractionEvent interactionEvent)
         {
-            return ((IGameObjectProvider)interactionEvent.Target).GameObject.GetComponent<Animator>().GetBool(OpenId) ? "Close" : "Open";
+            return ((IGameObjectProvider)interactionEvent.Target).GameObject.GetComponent<Animator>().GetBool(OpenId) ? "Open" : "Close";
         }
 
         public Sprite GetIcon(InteractionEvent interactionEvent)

--- a/Assets/Content/Systems/Interactions/OpenInteraction.cs
+++ b/Assets/Content/Systems/Interactions/OpenInteraction.cs
@@ -20,7 +20,7 @@ namespace SS3D.Content.Systems.Interactions
 
         public string GetName(InteractionEvent interactionEvent)
         {
-            return ((IGameObjectProvider)interactionEvent.Target).GameObject.GetComponent<Animator>().GetBool(OpenId) ? "Open" : "Close";
+            return ((IGameObjectProvider)interactionEvent.Target).GameObject.GetComponent<Animator>().GetBool(OpenId) ? "Close" : "Open";
         }
 
         public Sprite GetIcon(InteractionEvent interactionEvent)

--- a/Assets/Content/Systems/Interactions/StoreInteraction.cs
+++ b/Assets/Content/Systems/Interactions/StoreInteraction.cs
@@ -4,6 +4,8 @@ using SS3D.Engine.Interactions.Extensions;
 using SS3D.Engine.Inventory;
 using SS3D.Engine.Inventory.Extensions;
 using UnityEngine;
+using SS3D.Engine.Inventory.UI;
+using SS3D.Content.Furniture.Storage;
 
 namespace SS3D.Content.Systems.Interactions
 {
@@ -51,7 +53,7 @@ namespace SS3D.Content.Systems.Interactions
         {
             Hands hands = (Hands) interactionEvent.Source.Parent;
             interactionEvent.Target.GetComponent<AttachedContainer>().Container.AddItem(hands.ItemInHand);
-
+            CloseUIWhenStored(interactionEvent);
             return false;
         }
 
@@ -64,5 +66,28 @@ namespace SS3D.Content.Systems.Interactions
         {
             throw new System.NotImplementedException();
         }
+
+        /// <summary>
+        /// Checks if the UI of the stored item is opened, if it is, then close it. 
+        /// </summary>
+        private void CloseUIWhenStored(InteractionEvent interactionEvent)
+        {
+            if (interactionEvent.Source is Item)
+            {
+                Item item = interactionEvent.Source as Item;
+                GameObject gameObject = item.prefab; 
+                if (gameObject.GetComponent<OpenableContainer>() != null)
+                {
+                    ContainerUi[] UIs = GameObject.FindObjectsOfType<ContainerUi>(); //That's probably terrible
+                    foreach (ContainerUi UI in UIs)
+                    {
+                        if (UI.AttachedContainer == gameObject.GetComponent<AttachedContainer>())
+                        {
+                            UI.Close();
+                        }
+                    }
+                }
+            }
+        }      
     }
 }

--- a/Assets/Content/Systems/Interactions/StoreInteraction.cs
+++ b/Assets/Content/Systems/Interactions/StoreInteraction.cs
@@ -51,7 +51,7 @@ namespace SS3D.Content.Systems.Interactions
 
         public virtual bool Start(InteractionEvent interactionEvent, InteractionReference reference)
         {
-            Hands hands = (Hands) interactionEvent.Source.Parent;
+            Hands hands = (Hands)interactionEvent.Source.Parent;
             interactionEvent.Target.GetComponent<AttachedContainer>().Container.AddItem(hands.ItemInHand);
             CloseUIWhenStored(interactionEvent);
             return false;
@@ -68,26 +68,20 @@ namespace SS3D.Content.Systems.Interactions
         }
 
         /// <summary>
-        /// Checks if the UI of the stored item is opened, if it is, then close it. 
+        /// Checks if the UI of the stored item is opened, if it is, then close it.
+        /// <remark> This only works for OpenableContainer, it will be useless for other type of items with an UI.</remark>
         /// </summary>
         private void CloseUIWhenStored(InteractionEvent interactionEvent)
         {
             if (interactionEvent.Source is Item)
             {
                 Item item = interactionEvent.Source as Item;
-                GameObject gameObject = item.prefab; 
+                GameObject gameObject = item.prefab;
                 if (gameObject.GetComponent<OpenableContainer>() != null)
                 {
-                    ContainerUi[] UIs = GameObject.FindObjectsOfType<ContainerUi>(); //That's probably terrible
-                    foreach (ContainerUi UI in UIs)
-                    {
-                        if (UI.AttachedContainer == gameObject.GetComponent<AttachedContainer>())
-                        {
-                            UI.Close();
-                        }
-                    }
+                    interactionEvent.Source.Parent.GetHands().Inventory.RemoveContainer(gameObject.GetComponent<AttachedContainer>());
                 }
             }
-        }      
+        }
     }
 }

--- a/Assets/Engine/Inventory/UI/ContainerUi.cs
+++ b/Assets/Engine/Inventory/UI/ContainerUi.cs
@@ -16,6 +16,7 @@ namespace SS3D.Engine.Inventory.UI
 
         public AttachedContainer AttachedContainer
         {
+            get => attachedContainer;
             set
             {
                 attachedContainer = value;


### PR DESCRIPTION

### Summary

The UI of an Item should close everytime it's put inside a container. This should at least close the UI of openable containers put inside a container ( toolboxes, medkits and others).

## Pictures/Videos (optional)

https://user-images.githubusercontent.com/14344825/122656286-5bf4da80-d159-11eb-8998-708a91a71ee2.mp4

## Technical Notes (optional)

To get the opened UIs, I'm using GameObject.FindObjectsOfType<ContainerUi>() . There might be more efficient ways to retrieve them.

## Known issues (optional)

It only works for Openable Containers. I'm not aware of other items having an UI.

<!-- Any known bugs will likely require sorting out before the PR merges. -->

Closes #700
