### PR TITLE
Airlock fixture rotation

### DIFF
--- a/Assets/Content/Structures/Doors/Door.cs
+++ b/Assets/Content/Structures/Doors/Door.cs
@@ -103,7 +103,7 @@ namespace SS3D.Content.Structures.Fixtures
                 int i = (int)direction / 2;
 
                 // Get the direction this applies to for the external world
-                Direction outsideDirection = DirectionHelper.Apply(RotationHelper.ToParallelDirection(TileState.rotation), direction);
+                Direction outsideDirection = DirectionHelper.Apply(RotationHelper.ToPerpendicularDirection(TileState.rotation), direction);
                 bool isPresent = adjacents.Adjacent(outsideDirection) == 1;
 
                 if (isPresent && wallCaps[i] == null) {

--- a/Assets/Content/Structures/Doors/Door.cs
+++ b/Assets/Content/Structures/Doors/Door.cs
@@ -7,22 +7,13 @@ using SS3D.Engine.Tiles.State;
 
 namespace SS3D.Content.Structures.Fixtures
 {
-    // I'd like this to be internal, but if i make it anything but public
-    // then OnStateUpdate complains
-    [Serializable]
-    public struct DoorState
-    {
-        // TODO: Construction phase
-        public Orientation orientation;
-    }
-
     /**
      * Door script handles opening and closing of door, as well as door related parephenalia.
      * Also does door things.
      * I haven't slept.
      */
     [ExecuteAlways]
-    public class Door : TileStateMaintainer<DoorState>, AdjacencyConnector
+    public class Door : FixtureStateMaintainer, AdjacencyConnector
     {
         public enum DoorType
         {
@@ -73,11 +64,9 @@ namespace SS3D.Content.Structures.Fixtures
                 UpdateWallCaps();
         }
 
-        protected override void OnStateUpdate(DoorState prevState = new DoorState())
+        protected override void OnStateUpdate(FixtureState prevState = new FixtureState())
         {
-            float rotation = OrientationHelper.AngleBetween(Orientation.Horizontal, TileState.orientation);
-            transform.localRotation = Quaternion.Euler(0, rotation, 0);
-
+            base.OnStateUpdate(prevState);
             UpdateWallCaps();
         }
 
@@ -114,7 +103,7 @@ namespace SS3D.Content.Structures.Fixtures
                 int i = (int)direction / 2;
 
                 // Get the direction this applies to for the external world
-                Direction outsideDirection = DirectionHelper.Apply(OrientationHelper.ToPrincipalDirection(TileState.orientation), direction);
+                Direction outsideDirection = DirectionHelper.Apply(RotationHelper.ToParallelDirection(TileState.rotation), direction);
                 bool isPresent = adjacents.Adjacent(outsideDirection) == 1;
 
                 if (isPresent && wallCaps[i] == null) {

--- a/Assets/Engine/Tile/State/FixtureStateMaintainer.cs
+++ b/Assets/Engine/Tile/State/FixtureStateMaintainer.cs
@@ -7,13 +7,6 @@ using UnityEngine;
 
 namespace SS3D.Engine.Tiles.State
 {
-    [Serializable]
-    public struct FixtureState
-    {
-        // Can be extended with other info like construction state
-        public Rotation rotation;
-    }
-
     [ExecuteAlways]
     public class FixtureStateMaintainer : TileStateMaintainer<FixtureState>
     {

--- a/Assets/Engine/Tile/Tile.cs
+++ b/Assets/Engine/Tile/Tile.cs
@@ -88,7 +88,7 @@ namespace SS3D.Engine.Tiles {
         {
             return (Direction)((int)rotation * 2);
         }
-        public static Direction ToParallelDirection(Rotation rotation)
+        public static Direction ToPerpendicularDirection(Rotation rotation)
         {
             return (Direction)(((int)rotation + 1 % 4) * 2);
         }

--- a/Assets/Engine/Tile/Tile.cs
+++ b/Assets/Engine/Tile/Tile.cs
@@ -82,6 +82,18 @@ namespace SS3D.Engine.Tiles {
         }
     }
 
+    public static class RotationHelper
+    {
+        public static Direction ToPrincipalDirection(Rotation rotation)
+        {
+            return (Direction)((int)rotation * 2);
+        }
+        public static Direction ToParallelDirection(Rotation rotation)
+        {
+            return (Direction)(((int)rotation + 1 % 4) * 2);
+        }
+    }
+
     public enum TileLayers
     {
         Plenum,


### PR DESCRIPTION
Base airlocks off of FixtureState instead of DoorState, using Rotation instead of Orientation.
## Known issues
- Airlocks will need to be remapped.
- Airlock prefabs may need to be updated.

These can be left to another PR to avoid merge conflicts.
## Fixes
Fixes #710 
