### PR TITLE
Corrects issue where items are not on the Item layer.

### DIFF
--- a/Assets/Content/Items/Clothing/Headwear/Helmets/HardHatRed.prefab
+++ b/Assets/Content/Items/Clothing/Headwear/Helmets/HardHatRed.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9025388285410682761}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: GameObject
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -46,7 +46,7 @@ GameObject:
   - component: {fileID: 8798808914283824592}
   - component: {fileID: -4580143928426730034}
   - component: {fileID: 7335096185251245236}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: HardHatRed
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Clothing/Headwear/Helmets/HardHatYellow.prefab
+++ b/Assets/Content/Items/Clothing/Headwear/Helmets/HardHatYellow.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9025388285410682761}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: GameObject
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -46,7 +46,7 @@ GameObject:
   - component: {fileID: 8798808914283824592}
   - component: {fileID: -4580143928426730034}
   - component: {fileID: 8502499662783524481}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: HardHatYellow
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Containers/Liquid/LargeBeaker.prefab
+++ b/Assets/Content/Items/Functional/Containers/Liquid/LargeBeaker.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 6346642276291690734}
   - component: {fileID: 3546999150553349723}
   - component: {fileID: 4696884002918885688}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: LargeBeaker
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -264,7 +264,7 @@ GameObject:
   - component: {fileID: 8070120138524949723}
   - component: {fileID: 1289527130843278320}
   - component: {fileID: 298183472727955909}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Liquid
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -341,7 +341,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5747042748778270123}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Attachment
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -373,7 +373,7 @@ GameObject:
   - component: {fileID: 7229157555983638005}
   - component: {fileID: 4629176379242093924}
   - component: {fileID: 3693337679892817023}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Lid
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -452,7 +452,7 @@ GameObject:
   - component: {fileID: 7505678717344504723}
   - component: {fileID: 6692894116646048258}
   - component: {fileID: 5643062148299870269}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: LargeBeaker
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Containers/Liquid/SmallBeaker.prefab
+++ b/Assets/Content/Items/Functional/Containers/Liquid/SmallBeaker.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 5446891181622401204}
   - component: {fileID: 52698324414787720}
   - component: {fileID: 8353910763633493503}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Liquid
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -96,7 +96,7 @@ GameObject:
   - component: {fileID: -7777233483341371724}
   - component: {fileID: -6476219540935553843}
   - component: {fileID: 5848840416633041717}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: SmallBeaker
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -344,7 +344,7 @@ GameObject:
   - component: {fileID: 1975986242269109576}
   - component: {fileID: 4110601857047447259}
   - component: {fileID: 7434090838526271371}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: SmallBeaker
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -425,7 +425,7 @@ GameObject:
   - component: {fileID: 6908608555846075562}
   - component: {fileID: 4887438136146529181}
   - component: {fileID: 6015916186729498228}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Lid
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -502,7 +502,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8833359133489883299}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Attachment
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Containers/Liquid/beaker.prefab
+++ b/Assets/Content/Items/Functional/Containers/Liquid/beaker.prefab
@@ -17,8 +17,8 @@ GameObject:
   - component: {fileID: 6346642276291690734}
   - component: {fileID: 3546999150553349723}
   - component: {fileID: 3570669310606646338}
-  m_Layer: 0
-  m_Name: Beaker
+  m_Layer: 16
+  m_Name: beaker
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -264,7 +264,7 @@ GameObject:
   - component: {fileID: 6086832854285395519}
   - component: {fileID: 6230484662738128485}
   - component: {fileID: 6180688274897272698}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Lid
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -343,7 +343,7 @@ GameObject:
   - component: {fileID: 8070120138524949723}
   - component: {fileID: 1289527130843278320}
   - component: {fileID: 298183472727955909}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Liquid
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -420,7 +420,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5747042748778270123}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Attachment
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -452,7 +452,7 @@ GameObject:
   - component: {fileID: 7505678717344504723}
   - component: {fileID: 6692894116646048258}
   - component: {fileID: 5643062148299870269}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Beaker
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Containers/Liquid/mug.prefab
+++ b/Assets/Content/Items/Functional/Containers/Liquid/mug.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 5446891181622401204}
   - component: {fileID: 52698324414787720}
   - component: {fileID: 8353910763633493503}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Liquid
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -96,8 +96,8 @@ GameObject:
   - component: {fileID: -7777233483341371724}
   - component: {fileID: -6476219540935553843}
   - component: {fileID: 5848840416633041717}
-  m_Layer: 0
-  m_Name: Mug
+  m_Layer: 16
+  m_Name: mug
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -343,7 +343,7 @@ GameObject:
   - component: {fileID: 1975986242269109576}
   - component: {fileID: 4110601857047447259}
   - component: {fileID: 7434090838526271371}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Mug
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -421,7 +421,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8833359133489883299}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: Attachment
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonBlack.prefab
+++ b/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonBlack.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 6447688627046315522}
   - component: {fileID: 8555046361633480991}
   - component: {fileID: -8781191928576697897}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: CrayonBlack
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonBlue.prefab
+++ b/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonBlue.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 6909165344461321721}
   - component: {fileID: 618684551706682383}
   - component: {fileID: -2469115493504090853}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: CrayonBlue
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonGreen.prefab
+++ b/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonGreen.prefab
@@ -48,7 +48,7 @@ GameObject:
   - component: {fileID: 7910296348410097481}
   - component: {fileID: -872997292792617948}
   - component: {fileID: -4686216604784746079}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: CrayonGreen
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonOrange.prefab
+++ b/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonOrange.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 9118885136997525560}
   - component: {fileID: -368717394772122777}
   - component: {fileID: -4309091573439704350}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: CrayonOrange
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonPurple.prefab
+++ b/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonPurple.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 645931460658309619}
   - component: {fileID: -9120210531902757451}
   - component: {fileID: 5582532087290830820}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: CrayonPurple
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonRed.prefab
+++ b/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonRed.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 8438264071298373175}
   - component: {fileID: 1522704663804917393}
   - component: {fileID: -161041330142452396}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: CrayonRed
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonWhite.prefab
+++ b/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonWhite.prefab
@@ -48,7 +48,7 @@ GameObject:
   - component: {fileID: 5289911865508279092}
   - component: {fileID: 4650353189851888909}
   - component: {fileID: 5605873533124637808}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: CrayonWhite
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonYellow.prefab
+++ b/Assets/Content/Items/Functional/Generic/BooksPapersPens/Crayons/CrayonYellow.prefab
@@ -48,7 +48,7 @@ GameObject:
   - component: {fileID: 7468793210762665201}
   - component: {fileID: 8224646855654524911}
   - component: {fileID: -2773018317737842016}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: CrayonYellow
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Parts/Power Cells/BluespacePowerCell.prefab
+++ b/Assets/Content/Items/Functional/Parts/Power Cells/BluespacePowerCell.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 1941643679813000012}
   - component: {fileID: -2469115493504090853}
   - component: {fileID: 4659898452993661522}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: BluespacePowerCell
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Parts/Power Cells/HighPowerCell.prefab
+++ b/Assets/Content/Items/Functional/Parts/Power Cells/HighPowerCell.prefab
@@ -18,8 +18,8 @@ GameObject:
   - component: {fileID: -6716584860060542677}
   - component: {fileID: -2469115493504090853}
   - component: {fileID: 4659898452993661522}
-  m_Layer: 0
-  m_Name: HighPower Cell
+  m_Layer: 16
+  m_Name: HighPowerCell
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Content/Items/Functional/Parts/Power Cells/HyperPowerCell.prefab
+++ b/Assets/Content/Items/Functional/Parts/Power Cells/HyperPowerCell.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 4525722388647753547}
   - component: {fileID: -2469115493504090853}
   - component: {fileID: 4659898452993661522}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: HyperPowerCell
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Parts/Power Cells/PowerCell.prefab
+++ b/Assets/Content/Items/Functional/Parts/Power Cells/PowerCell.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: -2079972672662469876}
   - component: {fileID: -2469115493504090853}
   - component: {fileID: 4659898452993661522}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: PowerCell
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/Items/Functional/Parts/Power Cells/SuperPowerCell.prefab
+++ b/Assets/Content/Items/Functional/Parts/Power Cells/SuperPowerCell.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 4884682140181566839}
   - component: {fileID: -2469115493504090853}
   - component: {fileID: 4659898452993661522}
-  m_Layer: 0
+  m_Layer: 16
   m_Name: SuperPowerCell
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Engine/Inventory/Item.cs
+++ b/Assets/Engine/Inventory/Item.cs
@@ -85,6 +85,12 @@ namespace SS3D.Engine.Inventory
         public void Awake()
         {
             sprite = null;
+
+            // Add a warning if an item is not on the Item layer (layer 16).
+            if (gameObject.layer != 16)
+            {
+                Debug.LogWarning("Item " + Name + " is on layer " + gameObject.layer);
+            }
         }
         
         [ContextMenu("Create Icon")]


### PR DESCRIPTION
## Summary

Prefabs for all offending Items have been placed in the correct layer. Additionally, any Item that spawns on the incorrect layer will now have a warning during Awake(), so that the developer can resolve the issue.

## Fixes

Closes #735