### PR TITLE
Fix infinite loop when container is destroying or dumping

### DIFF
--- a/Assets/Engine/Inventory/Container.cs
+++ b/Assets/Engine/Inventory/Container.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -458,10 +458,12 @@ namespace SS3D.Engine.Inventory
         public void Dump()
         {
             Item[] oldItems = items.Select(x => x.Item).ToArray();
-            while (items.Count > 0)
+            foreach (var item in items)
             {
-                items[0].Item.Container = null;
+                item.Item.Container = null;
             }
+            items.Clear();
+
             LastModification = Time.time;
             OnContainerChanged(oldItems, ContainerChangeType.Remove);
         }
@@ -472,10 +474,11 @@ namespace SS3D.Engine.Inventory
         public void Destroy()
         {
             Item[] oldItems = items.Select(x => x.Item).ToArray();
-            while (items.Count > 0)
+            foreach (var item in items)
             {
-                items[0].Item.Destroy();
+                item.Item.Destroy();
             }
+            items.Clear();
 
             LastModification = Time.time;
             OnContainerChanged(oldItems, ContainerChangeType.Remove);


### PR DESCRIPTION
## Summary

Closing the game by the client when somebody holds an Item in hand causes client's freezing. This PR fixes this freezing.

## Changes to Files

Assets/Engine/Inventory/Container.cs - fixed `Container.Destroy()` and `Container.Dump()` methods.

## Technical Notes (optional)

Freezing was caused by strange `while` loop in `Container.Destroy()` method (similar loop also is in `Container.Dump()`) that accidently became infinite. If I understand correctly, this part of code should destroy every `Item` in the container and after that clear item's collection.

## Fixes (optional)

Closes #674
