### PR TITLE
Fixed rendering bug when examining certain items

### DIFF
--- a/Assets/Engine/Examine/CompositeItemSelector.cs
+++ b/Assets/Engine/Examine/CompositeItemSelector.cs
@@ -336,9 +336,9 @@ namespace SS3D.Engine.Examine
 			}
 			
 			// If mesh exists, record the colour affiliation of it 
-			if (mf != null && child.gameObject.GetComponent<Renderer>().enabled)
+			if (mf != null && mf.sharedMesh != null && child.gameObject.GetComponent<Renderer>().enabled)
 			{
-				meshes.Add(new MeshColourAffiliation(mf.mesh, colours.Peek(), child, child.gameObject.GetComponent<Renderer>().material.mainTexture));
+				meshes.Add(new MeshColourAffiliation(mf.sharedMesh, colours.Peek(), child, child.gameObject.GetComponent<Renderer>().material.mainTexture));
 			}
 			if (smr != null && smr.sharedMesh != null && child.gameObject.GetComponent<Renderer>().enabled)
 			{


### PR DESCRIPTION
## Summary

Examining certain objects previously caused an inexplicable rendering error, even after the objects were no longer being examined. Examples are the Janicart, sink, hydroponics tray and light switch. This PR resolves that rendering error.

The rendering error **does not occur** when testing the game in Unity. In order to validate the issue as resolved, please test a compiled build.

## Pictures/Videos (optional)

![Janicart Rendering Bug](https://user-images.githubusercontent.com/64360820/126039087-8b382928-8006-45db-b64c-0dbd20040b62.png)
Bug showing incorrect render (left) and image of correct render (right)

## Technical Notes (optional)

CompositeItemSelector was amended to render the sharedMesh (rather than the mesh) of examinable MeshFilters.

## Fixes

Closes #464
