### PR TITLE
Drops held item when player is knocked down.

### DIFF
--- a/Assets/Content/Entities/Humanoids/Human/HumanRagdoll.cs
+++ b/Assets/Content/Entities/Humanoids/Human/HumanRagdoll.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Mirror;
 using SS3D.Content.Systems.Player;
+using SS3D.Engine.Inventory;
+using SS3D.Engine.Inventory.Extensions;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -33,6 +35,9 @@ namespace SS3D.Content.Creatures.Human
         private float knockdownEnd;
         // Will the ragdoll get up by itself?
         private bool isKnockedDown;
+        // The characters' hands, if they exist.
+        private Hands hands;
+
         private HumanoidMovementController movementController;
         private CharacterController characterController;
 
@@ -42,6 +47,7 @@ namespace SS3D.Content.Creatures.Human
             SetEnabledInternal(false);
             character = ArmatureRoot.parent;
             center = ArmatureRoot.GetChild(0);
+            hands = gameObject.GetComponent<Hands>();
         }
 
         void Update()
@@ -93,6 +99,19 @@ namespace SS3D.Content.Creatures.Human
                 isKnockedDown = true;
                 knockdownEnd = Time.time + duration;
                 SetEnabledInternal(true);
+
+                // Drop whatever is in your hands.
+                if (hands != null) {
+                    
+                    foreach (AttachedContainer hand in hands.HandContainers)
+                    {
+                        if (!hand.Container.Empty)
+                        {
+                            hand.Container.Dump();
+                        }
+                    }
+                    
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

When a player is knocked down (for example, by tripping over a banana peel), one of the items in their hands will be dropped. This mitigates the current issue where an item held by the player will no longer be rendered once they fall (so you can no longer see the player is holding something), but actually remains within their hands. Future changes outside the scope of this PR will see both items dropped, if they are holding two items.

## Known issues

There is a known bug where only one item is dropped if two are being held. That is due to an InvalidOperationException originating in Container.Dump() due to a collection being modified while iterated over. It may be fixed within the container rework.