### PR TITLE
Use true velocity for Humanoid animator, Fixed updating mistake

### DIFF
--- a/Assets/Content/Systems/Player/HumanoidMovementController.cs
+++ b/Assets/Content/Systems/Player/HumanoidMovementController.cs
@@ -22,7 +22,7 @@ namespace SS3D.Content.Systems.Player
 
         private Animator characterAnimator;
         private CharacterController characterController;
-        private Camera camera;
+        private new Camera camera;
 
         // Current movement the player is making.
         private Vector2 currentMovement = new Vector2();
@@ -78,6 +78,8 @@ namespace SS3D.Content.Systems.Player
             }
             
             currentMovement = Vector2.MoveTowards(currentMovement, intendedMovement, Time.deltaTime * (Mathf.Pow(ACCELERATION / 5f, 3) / 5));
+            var movement = Vector3.zero;
+
             // Move the player
             if (currentMovement != Vector2.zero)
             {
@@ -98,11 +100,18 @@ namespace SS3D.Content.Systems.Player
                 {
                     absoluteMovement = Vector3.Lerp(absoluteMovement, Vector3.zero, Time.deltaTime * 5);
                 }
-                characterController.Move(absoluteMovement * Time.deltaTime);
+
+                movement = absoluteMovement * Time.deltaTime;
             }
+
+            characterController.Move(movement);
+
             // animation Speed is a proportion of maximum runSpeed, and we smoothly transitions the speed with the Lerp
             float currentSpeed = characterAnimator.GetFloat("Speed");
-            float newSpeed = Mathf.LerpUnclamped(currentSpeed, currentMovement.magnitude / runSpeed , Time.deltaTime * (isWalking ? walkSpeed : runSpeed) * 3);
+            float controllerSpeed = characterController.velocity.magnitude;
+
+            float newSpeed = Mathf.LerpUnclamped(currentSpeed, controllerSpeed, Time.deltaTime * (isWalking ? walkSpeed : runSpeed) * 3);
+
             characterAnimator.SetFloat("Speed", newSpeed);
 
             ForceHeightLevel();

--- a/Assets/Content/Systems/Player/HumanoidMovementController.cs
+++ b/Assets/Content/Systems/Player/HumanoidMovementController.cs
@@ -108,9 +108,9 @@ namespace SS3D.Content.Systems.Player
 
             // animation Speed is a proportion of maximum runSpeed, and we smoothly transitions the speed with the Lerp
             float currentSpeed = characterAnimator.GetFloat("Speed");
-            float controllerSpeed = characterController.velocity.magnitude;
+            float controllerSpeed = Mathf.Clamp01(characterController.velocity.magnitude / runSpeed);
 
-            float newSpeed = Mathf.LerpUnclamped(currentSpeed, controllerSpeed, Time.deltaTime * (isWalking ? walkSpeed : runSpeed) * 3);
+            float newSpeed = Mathf.Lerp(currentSpeed, controllerSpeed, Time.deltaTime * 15);
 
             characterAnimator.SetFloat("Speed", newSpeed);
 


### PR DESCRIPTION
## Summary
Replaces animation value being set from our internal velocity to the humanoids true velocity. An update to how the `CharacterController.Move` is called was required to ensure it was updated correctly.

## Pictures/Videos

https://user-images.githubusercontent.com/40436415/130316570-af7a0a14-a3d8-437f-b2db-b7e058cc6531.mp4

## Changes to Files

- [HumanoidCharacterController.cs](https://github.com/RE-SS3D/SS3D/compare/master...Liam-Harrison:humanoid-walking?expand=1#diff-2d10a69e56bbaefb1cef0eed6c9c4f401c95bd6d26fda05bf989fb37410e7755)

## Technical Notes

- `CharacterController.Move()` is designed to be called frequently, we previously only called `Move()` whenever we were moving (input vector non-zero). However this means internally the `CharacterController.velocity` is not updated frequently, and can be stuck at a low value such as `0.2`, which will cause scripts which read the `velocity` to be non-zero when they really should be zero. By calling `CharacterController.Move()` every frame, even if the movement is a zero vector, the `CharacterController` works perfectly as designed by Unity.

## Known issues

_NA_

## Fixes

_NA_
