### PR TITLE
Prevent multiple audio listeners

### DIFF
--- a/Assets/Content/Systems/Player/PlayerListener.cs
+++ b/Assets/Content/Systems/Player/PlayerListener.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace SS3D.Content.Systems.Player
 {
     [RequireComponent(typeof(AudioListener))]
-    public class PlayerListener : MonoBehaviour
+    public class PlayerListener : NetworkBehaviour
     {
         private AudioListener listener;
 
@@ -13,17 +13,11 @@ namespace SS3D.Content.Systems.Player
         {
             if (NetworkClient.active)
             {
-                if (NetworkClient.connection.identity.gameObject != transform.parent.gameObject)
+                if (!GetComponentInParent<NetworkIdentity>().isLocalPlayer)
                 {
                     // Destroy if listener of other player
                     Destroy(gameObject);
                 }
-            }
-            
-            else if (NetworkServer.active)
-            {
-                // Destroy if server only
-                Destroy(gameObject);
             }
         }
     }


### PR DESCRIPTION
## Summary

The player prefab contains an audio listener. This PR destroys the audio listener of other players, to prevent multiple audio listeners being active in multiplayer.

## Changes to Files

Minor changes to PlayerListener.cs

## Known issues

While testing this issue, I noticed that when clients join at the start of the round, their player is a child of MiniStation. However, late joining clients have their player as a child of the ServerLobby. This will require remediation in future work.

## Fixes

Closes #795
