### PR TITLE
Prevents duplicate Examinators and ExamineUIs

### DIFF
--- a/Assets/Engine/Examine/Examinator.cs
+++ b/Assets/Engine/Examine/Examinator.cs
@@ -32,10 +32,11 @@ namespace SS3D.Engine.Examine
 
         private void Start()
         {
-            // Mirror is kinda whack
-            if (!hasAuthority)
+            // Prevent duplicate examinators from being in the scene in multiplayer.
+            if (!isLocalPlayer)
             {
                 Destroy(this);
+				return;
             }
 
 			// Establish our minimum frequency timer. This is used to ensure


### PR DESCRIPTION
## Summary

Performs a check to ensure that only the local player has an Examinator (and consequently an ExamineUI). This prevents an issue in multiplayer where each player's hover text is overlaid across the default "Examine Name" hovertext.

## Pictures/Videos

![Hovertext duplication](https://user-images.githubusercontent.com/64360820/131840306-ad9869d5-98eb-44b8-a68b-e46b9aedb253.png)
Original issue: "Wood Floor Tile" is overlaid with "Examine Name".
