### PR TITLE
Removed inconsistent ranges for opening/closing and viewing lockers.

### DIFF
--- a/Assets/Content/Systems/Interactions/OpenInteraction.cs
+++ b/Assets/Content/Systems/Interactions/OpenInteraction.cs
@@ -30,14 +30,26 @@ namespace SS3D.Content.Systems.Interactions
 
         public bool CanInteract(InteractionEvent interactionEvent)
         {
+            // Check whether the object is in range
             if (!InteractionExtensions.RangeCheck(interactionEvent))
             {
                 return false;
             }
-            
+
+            // Confirm that there is an entity doing this interaction
+            Entity entity = interactionEvent.Source.GetEntity();
+            if (entity == null)
+            {
+                return false;
+            }
+
             if (interactionEvent.Target is IGameObjectProvider target)
             {
-                return target.GameObject.GetComponent<Animator>() != null;
+                // Check that the entity is actually capable of interacting with the target
+                if (entity.CanInteract(target.GameObject))
+                {
+                    return target.GameObject.GetComponent<Animator>() != null;
+                }
             }
             return false;
         }


### PR DESCRIPTION
## Summary

Gets rid of the discrepancy where the player can close an open locker but viewing the contents of the locker is just beyond interaction range.

## Changes to Files

OpenInteraction.cs has had additional checks added - see Technical Notes.

## Technical Notes

Technically, the OpenInteraction (which also handles closing) and ViewContainerInteraction had exactly the same range - 1.5 units horizontally, and 1 unit vertically. However, OpenInteraction performed a single RangeCheck as part of CanInteract, whereas ViewContainerInteraction performed two. The second RangeCheck in ViewContainerInteraction is part of the Entity.CanInteract() method. The crucial difference between these RangeChecks is that the Entity.CanInteract() RangeCheck uses the distance to the target's position, and the other RangeCheck uses the interaction point calculated from the collider hit. The issue was resolved by giving the Entity.CanInteract() check to the OpenInteraction also.

## Known issues

I noticed that the Entity.CanInteract function requires the entity to have hands. I think we can improve the function to take into account what organs the entity actually requires for that interaction. For example, simply conducting a ViewInteraction *shouldn't* need the player to have hands (although they'd definitely need eyes!). In other cases such as the OpenInteraction, having at least one hand is essential. Still others (possibly construction interactions, for example) may require the entity to have two hands.

## Fixes

Closes #707. Request confirmation from @stilnat that the issue no longer occurs.
