### PR TITLE
Fix chat message sending when out of focus

### DIFF
--- a/Assets/Content/Systems/UI/Game/Chat/ChatWindow.prefab
+++ b/Assets/Content/Systems/UI/Game/Chat/ChatWindow.prefab
@@ -183,6 +183,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_Padding: {x: 0, y: 0, z: 0, w: 0}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &2010881090619709967
 GameObject:
   m_ObjectHideFlags: 0
@@ -2674,7 +2676,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 5578169003587566749}
   m_HandleRect: {fileID: 5578169003587566748}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -3815,7 +3817,6 @@ MonoBehaviour:
   chatTabPrefab: {fileID: 8200174819641522885, guid: 77b4a247c9e13b84c949d930ecab4c36,
     type: 3}
   channelDropDown: {fileID: 3465179352210583905}
-  isSelected: 0
 --- !u!1 &7332559107077124948
 GameObject:
   m_ObjectHideFlags: 0
@@ -4600,6 +4601,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_Padding: {x: 0, y: 0, z: 0, w: 0}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &8858361151572742920
 GameObject:
   m_ObjectHideFlags: 0
@@ -4736,38 +4739,27 @@ MonoBehaviour:
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 7861828484222706393}
+        m_MethodName: FinishTyping
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_OnSubmit:
     m_PersistentCalls:
       m_Calls: []
   m_OnSelect:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 7861828484222706393}
-        m_MethodName: onSelect
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   m_OnDeselect:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 7861828484222706393}
-        m_MethodName: onDeselect
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   m_OnTextSelection:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Content/Systems/UI/Game/Chat/ChatWindow.prefab
+++ b/Assets/Content/Systems/UI/Game/Chat/ChatWindow.prefab
@@ -3433,7 +3433,7 @@ MonoBehaviour:
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
   m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: 0
+  m_TextStyleHashCode: -1183493901
   m_overrideHtmlColors: 0
   m_faceColor:
     serializedVersion: 2
@@ -3815,6 +3815,7 @@ MonoBehaviour:
   chatTabPrefab: {fileID: 8200174819641522885, guid: 77b4a247c9e13b84c949d930ecab4c36,
     type: 3}
   channelDropDown: {fileID: 3465179352210583905}
+  isSelected: 0
 --- !u!1 &7332559107077124948
 GameObject:
   m_ObjectHideFlags: 0
@@ -4735,9 +4736,15 @@ MonoBehaviour:
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:
+      m_Calls: []
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelect:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 7861828484222706393}
-        m_MethodName: FinishTyping
+        m_MethodName: onSelect
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4747,15 +4754,20 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  m_OnSubmit:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelect:
-    m_PersistentCalls:
-      m_Calls: []
   m_OnDeselect:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 7861828484222706393}
+        m_MethodName: onDeselect
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_OnTextSelection:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Engine/Chat/ChatWindow.cs
+++ b/Assets/Engine/Chat/ChatWindow.cs
@@ -238,7 +238,7 @@ namespace SS3D.Engine.Chat
 
         public void Update()
         {
-            if ((Input.GetKeyUp(KeyCode.Return) || Input.GetKeyUp(KeyCode.KeypadEnter) && this.isSelected)
+            if ((Input.GetKeyUp(KeyCode.Return) || Input.GetKeyUp(KeyCode.KeypadEnter)) && this.isSelected)
             { 
                 SendMessage(); 
             }

--- a/Assets/Engine/Chat/ChatWindow.cs
+++ b/Assets/Engine/Chat/ChatWindow.cs
@@ -238,7 +238,7 @@ namespace SS3D.Engine.Chat
 
         public void Update()
         {
-            if (Input.GetKeyUp(KeyCode.Return) && this.isSelected)
+            if ((Input.GetKeyUp(KeyCode.Return) || Input.GetKeyUp(KeyCode.KeypadEnter) && this.isSelected)
             { 
                 SendMessage(); 
             }

--- a/Assets/Engine/Chat/ChatWindow.cs
+++ b/Assets/Engine/Chat/ChatWindow.cs
@@ -25,8 +25,6 @@ namespace SS3D.Engine.Chat
 
         public ChatRegister ChatRegister => chatRegister;
 
-        public bool isSelected;
-
         public void Init(ChatTabData tabData, ChatRegister chatRegister)
         {
             this.chatRegister = chatRegister;
@@ -207,7 +205,6 @@ namespace SS3D.Engine.Chat
             }
 
             chatRegister.CmdSendMessage(chatMessage);
-            EventSystem.current.SetSelectedGameObject(null);
         }
 
         public void OnDrag(PointerEventData eventData)
@@ -221,27 +218,19 @@ namespace SS3D.Engine.Chat
             return (EventSystem.current.currentSelectedGameObject != null);
         }
 
+        public void FinishTyping(){
+            if ((Input.GetKey(KeyCode.Return) || Input.GetKey(KeyCode.KeypadEnter)) ) {
+                SendMessage();
+            }
+
+            EventSystem.current.SetSelectedGameObject(null);
+
+        }
         public void FocusInputField()
         {
             inputField.Select();
-        }
-
-        public void onSelect()
-        {
-            this.isSelected = true;
-        }
-
-        public void onDeselect()
-        {
-            this.isSelected = false;
-        }
-
-        public void Update()
-        {
-            if ((Input.GetKeyUp(KeyCode.Return) || Input.GetKeyUp(KeyCode.KeypadEnter)) && this.isSelected)
-            { 
-                SendMessage(); 
-            }
+        
         }
     }
+
 }

--- a/Assets/Engine/Chat/ChatWindow.cs
+++ b/Assets/Engine/Chat/ChatWindow.cs
@@ -25,6 +25,8 @@ namespace SS3D.Engine.Chat
 
         public ChatRegister ChatRegister => chatRegister;
 
+        public bool isSelected;
+
         public void Init(ChatTabData tabData, ChatRegister chatRegister)
         {
             this.chatRegister = chatRegister;
@@ -205,6 +207,7 @@ namespace SS3D.Engine.Chat
             }
 
             chatRegister.CmdSendMessage(chatMessage);
+            EventSystem.current.SetSelectedGameObject(null);
         }
 
         public void OnDrag(PointerEventData eventData)
@@ -218,15 +221,27 @@ namespace SS3D.Engine.Chat
             return (EventSystem.current.currentSelectedGameObject != null);
         }
 
-        public void FinishTyping()
-        {
-            SendMessage();
-            EventSystem.current.SetSelectedGameObject(null);
-        }
-
         public void FocusInputField()
         {
             inputField.Select();
+        }
+
+        public void onSelect()
+        {
+            this.isSelected = true;
+        }
+
+        public void onDeselect()
+        {
+            this.isSelected = false;
+        }
+
+        public void Update()
+        {
+            if (Input.GetKeyUp(KeyCode.Return) && this.isSelected)
+            { 
+                SendMessage(); 
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes issue #782 regarding messages sending when the window goes out of focus. It also adds the ability to send a message by pressing Enter.

## Changes to Files
* `ChatWindow.cs` has been updated a bit, I added a couple of methods.
* `ChatWindow.prefab` has also been updated. I linked new methods to the onSelect and onDeselect callbacks (?) of the text input.

## Technical Notes (optional)

* `ChatWindow` now has a `isSelected` public attribute that is true when the input field is in focus.
* `ChatWindow` has an `Update` method that checks if Enter is pressed and if the input field is in focus, and sends the message if that's the case. 
* The call to unfocus the input field after a message is sent has been moved to the end of the `SendMessage` method.  

## Fixes (optional)
Fixes #782 
