### PR TITLE
Container System: Resolve ContainerSync OutOfRangeException on client embark

### DIFF
--- a/Assets/Engine/Inventory/AttachedContainerGenerator.cs
+++ b/Assets/Engine/Inventory/AttachedContainerGenerator.cs
@@ -13,7 +13,7 @@ namespace SS3D.Engine.Inventory
         public Vector2Int Size;
         public Filter StartFilter;
 
-        public void Start()
+        public void Awake()
         {
             Assert.IsNotNull(AttachedContainer);
             

--- a/Assets/Engine/Inventory/ContainerSync.cs
+++ b/Assets/Engine/Inventory/ContainerSync.cs
@@ -169,6 +169,13 @@ namespace SS3D.Engine.Inventory
                 return;
             }
 
+            // This prevents handler errors when TargetSyncContainer is called before the Start() method
+            // is executed. For example, this can occur for the player character on a client.
+            if (Containers.Count == 0)
+            {
+                UpdateContainers();
+            }
+
             Containers[containerId].Container.Reconcile(container);
         }
 

--- a/Assets/Engine/Inventory/Extensions/Hands.cs
+++ b/Assets/Engine/Inventory/Extensions/Hands.cs
@@ -49,7 +49,7 @@ namespace SS3D.Engine.Inventory.Extensions
         /// </summary>
         public bool SelectedHandEmpty => SelectedHandContainer.Empty;
 
-        public void Start()
+        public void Awake()
         {
             SupportsMultipleInteractions = true;
             


### PR DESCRIPTION
## Summary

Resolved exception in ContainerSync being thrown when client joins. 

## Technical Notes

Exception was caused by TargetSyncContainer() being called on the Human prefab before the Start() function.

A subsequent issue was caused by AttachedContainer.Container not being set by the time TargetSyncContainer() was called - again, on the Human prefab. This was resolved by setting AttachedContainer.Container in Awake() instead of Start().

## Fixes

Exception was identified in #793, although was not the root cause of the described behaviour. Request @stilnat to confirm that exception can no longer be replicated.