### PR TITLE
Prefab of Janitorial Cart created at start [ready for review]

### DIFF
--- a/Assets/Content/Furniture/Storage/Carts/Janitorial Cart.prefab
+++ b/Assets/Content/Furniture/Storage/Carts/Janitorial Cart.prefab
@@ -485,12 +485,20 @@ GameObject:
   - component: {fileID: 8305683950039309293}
   - component: {fileID: -5588627775791933915}
   - component: {fileID: 5653810206906820092}
+  - component: {fileID: 951511212552825910}
+  - component: {fileID: 4511136058155355368}
   - component: {fileID: 1747826808586102803}
   - component: {fileID: 3230899053323025513}
-  - component: {fileID: 4511136058155355368}
   - component: {fileID: 1777746915210031534}
   - component: {fileID: 7882230928867587852}
-  - component: {fileID: 951511212552825910}
+  - component: {fileID: 6294401220780105451}
+  - component: {fileID: 600159331318203963}
+  - component: {fileID: 7035528629886973850}
+  - component: {fileID: 7094106397479065949}
+  - component: {fileID: 534595196250857976}
+  - component: {fileID: 6125911507517676035}
+  - component: {fileID: 2178714888987483643}
+  - component: {fileID: 7948488332056760697}
   m_Layer: 0
   m_Name: Janitorial Cart
   m_TagString: Untagged
@@ -635,6 +643,50 @@ MonoBehaviour:
   DisplayName: Janitorial Cart
   Text: Neatly holds all of the janitor's equipment.
   MaxDistance: 0
+--- !u!114 &951511212552825910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0c449d3e5a4a2a4688d56873fce3f2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  boxOne: {fileID: 8155353539727309456, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
+  boxTwo: {fileID: 8155353539727309456, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
+  mop: {fileID: 3533485490934766563, guid: 516f5504002cb8142b8cf0111b514d27, type: 3}
+  mopBucket: {fileID: 963665549342937872, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
+    type: 3}
+  ragOne: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
+  ragTwo: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
+  ragThree: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
+  spaceCleaner: {fileID: 482575724292013721, guid: 2193154d46a9f7a439291e0a8cf94391,
+    type: 3}
+  soap: {fileID: 9002315518600615791, guid: 0eade332e5605794db10d9bb8a7e5c00, type: 3}
+--- !u!95 &4511136058155355368
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!114 &1747826808586102803
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -686,25 +738,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   containerDescriptor: {fileID: 1747826808586102803}
---- !u!95 &4511136058155355368
-Animator:
-  serializedVersion: 3
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5069778086634185365}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!114 &1777746915210031534
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -735,7 +768,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &951511212552825910
+--- !u!114 &6294401220780105451
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -744,22 +777,164 @@ MonoBehaviour:
   m_GameObject: {fileID: 5069778086634185365}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f0c449d3e5a4a2a4688d56873fce3f2d, type: 3}
+  m_Script: {fileID: 11500000, guid: 25696236470760b41b375e9b6939444c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  attachedContainer: {fileID: 600159331318203963}
+  containerSync: {fileID: 0}
+  containerInteractive: {fileID: 7035528629886973850}
+  containerItemDisplay: {fileID: 7094106397479065949}
+  containerUi: {fileID: 0}
+  openIcon: {fileID: 0}
+  takeIcon: {fileID: 0}
+  storeIcon: {fileID: 0}
+  viewIcon: {fileID: 0}
+  attachmentOffset: {x: 0, y: 0, z: 0}
+  containerName: box spot
+  onlyStoreWhenOpen: 0
+  openWhenContainerViewed: 0
+  size: {x: 8, y: 8}
+  hideItems: 0
+  attachItems: 1
+  startFilter: {fileID: 0}
+  initialized: 1
+  maxDistance: 5
+  isOpenable: 0
+  isInteractive: 1
+  hasUi: 0
+  hasCustomInteraction: 0
+  hasCustomDisplay: 1
+  displays:
+  - {fileID: 4138969924818735946}
+  - {fileID: 2592856586354829012}
+  numberDisplay: 2
+--- !u!114 &600159331318203963
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72bfc9c5e18140bc9dbf232d3a7c2ff6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  containerDescriptor: {fileID: 6294401220780105451}
+--- !u!114 &7035528629886973850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3c75d17834848bb4f83ee6e730a65519, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  boxOne: {fileID: 8155353539727309456, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
-  boxTwo: {fileID: 8155353539727309456, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
-  mop: {fileID: 3533485490934766563, guid: 516f5504002cb8142b8cf0111b514d27, type: 3}
-  mopBucket: {fileID: 963665549342937872, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-    type: 3}
-  ragOne: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
-  ragTwo: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
-  ragThree: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
-  spaceCleaner: {fileID: 482575724292013721, guid: 2193154d46a9f7a439291e0a8cf94391,
-    type: 3}
-  soap: {fileID: 9002315518600615791, guid: 0eade332e5605794db10d9bb8a7e5c00, type: 3}
+  OpenIcon: {fileID: 0}
+  containerDescriptor: {fileID: 6294401220780105451}
+--- !u!114 &7094106397479065949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25610b7ef51d43c7bc0bd2bc58036e61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  containerDescriptor: {fileID: 6294401220780105451}
+  Mirrored: 0
+--- !u!114 &534595196250857976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25696236470760b41b375e9b6939444c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  attachedContainer: {fileID: 6125911507517676035}
+  containerSync: {fileID: 0}
+  containerInteractive: {fileID: 2178714888987483643}
+  containerItemDisplay: {fileID: 7948488332056760697}
+  containerUi: {fileID: 0}
+  openIcon: {fileID: 0}
+  takeIcon: {fileID: 0}
+  storeIcon: {fileID: 0}
+  viewIcon: {fileID: 0}
+  attachmentOffset: {x: 0, y: 0, z: 0}
+  containerName: rag spot
+  onlyStoreWhenOpen: 0
+  openWhenContainerViewed: 0
+  size: {x: 6, y: 6}
+  hideItems: 0
+  attachItems: 1
+  startFilter: {fileID: 0}
+  initialized: 1
+  maxDistance: 5
+  isOpenable: 0
+  isInteractive: 1
+  hasUi: 0
+  hasCustomInteraction: 0
+  hasCustomDisplay: 1
+  displays:
+  - {fileID: 6037772964090764217}
+  - {fileID: 4994728017443307690}
+  - {fileID: 3177432156376954865}
+  numberDisplay: 3
+--- !u!114 &6125911507517676035
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72bfc9c5e18140bc9dbf232d3a7c2ff6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  containerDescriptor: {fileID: 534595196250857976}
+--- !u!114 &2178714888987483643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3c75d17834848bb4f83ee6e730a65519, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  OpenIcon: {fileID: 0}
+  containerDescriptor: {fileID: 534595196250857976}
+--- !u!114 &7948488332056760697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25610b7ef51d43c7bc0bd2bc58036e61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  containerDescriptor: {fileID: 534595196250857976}
+  Mirrored: 0
 --- !u!1 &5221473445564893971
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Furniture/Storage/Carts/Janitorial Cart.prefab
+++ b/Assets/Content/Furniture/Storage/Carts/Janitorial Cart.prefab
@@ -57,8 +57,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.00000014589105, y: 0.18803905, z: 0.453}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 5961226931208061903}
+  m_Children: []
   m_Father: {fileID: 8070487468840128646}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -88,8 +87,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -0.0035913184, y: 0.6424807, z: -0.24920487}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 5287313375294373533}
+  m_Children: []
   m_Father: {fileID: 8070487468840128646}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
@@ -119,8 +117,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.10460509, y: 1.0317378, z: -0.26266474}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 3145423783785747409}
+  m_Children: []
   m_Father: {fileID: 8070487468840128646}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -150,8 +147,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.126, y: 1.0038453, z: -0.044}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 3419055716234433023}
+  m_Children: []
   m_Father: {fileID: 8070487468840128646}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -348,8 +344,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -0.116, y: 0.22234817, z: -0.31}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 4828485990197208760}
+  m_Children: []
   m_Father: {fileID: 8070487468840128646}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
@@ -495,6 +490,7 @@ GameObject:
   - component: {fileID: 4511136058155355368}
   - component: {fileID: 1777746915210031534}
   - component: {fileID: 7882230928867587852}
+  - component: {fileID: 951511212552825910}
   m_Layer: 0
   m_Name: Janitorial Cart
   m_TagString: Untagged
@@ -654,6 +650,7 @@ MonoBehaviour:
   attachedContainer: {fileID: 3230899053323025513}
   containerSync: {fileID: 0}
   containerInteractive: {fileID: 1777746915210031534}
+  containerItemDisplay: {fileID: 0}
   containerUi: {fileID: 0}
   openIcon: {fileID: 0}
   takeIcon: {fileID: 0}
@@ -673,6 +670,9 @@ MonoBehaviour:
   isInteractive: 1
   hasUi: 0
   hasCustomInteraction: 0
+  hasCustomDisplay: 0
+  displays: []
+  numberDisplay: 0
 --- !u!114 &3230899053323025513
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -735,6 +735,31 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &951511212552825910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5069778086634185365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0c449d3e5a4a2a4688d56873fce3f2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  boxOne: {fileID: 8155353539727309456, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
+  boxTwo: {fileID: 8155353539727309456, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
+  mop: {fileID: 3533485490934766563, guid: 516f5504002cb8142b8cf0111b514d27, type: 3}
+  mopBucket: {fileID: 963665549342937872, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
+    type: 3}
+  ragOne: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
+  ragTwo: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
+  ragThree: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
+  spaceCleaner: {fileID: 482575724292013721, guid: 2193154d46a9f7a439291e0a8cf94391,
+    type: 3}
+  soap: {fileID: 9002315518600615791, guid: 0eade332e5605794db10d9bb8a7e5c00, type: 3}
 --- !u!1 &5221473445564893971
 GameObject:
   m_ObjectHideFlags: 0
@@ -761,8 +786,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.10460529, y: 1.0317378, z: -0.26266474}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 3333846988371109870}
+  m_Children: []
   m_Father: {fileID: 8070487468840128646}
   m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1050,8 +1074,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0.11516291, y: 0.22234817, z: -0.30999988}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 5415468539376512869}
+  m_Children: []
   m_Father: {fileID: 8070487468840128646}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
@@ -1081,8 +1104,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -0.0035913184, y: 0.81346804, z: -0.24920487}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 769594690166727665}
+  m_Children: []
   m_Father: {fileID: 8070487468840128646}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
@@ -1279,8 +1301,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -0.0035913184, y: 0.7281064, z: -0.24920487}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 9116304746198363606}
+  m_Children: []
   m_Father: {fileID: 8070487468840128646}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
@@ -1451,737 +1472,3 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!1001 &321094099935096379
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 2592856586354829012}
-    m_Modifications:
-    - target: {fileID: 1594633947765538537, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8155353539727309456, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_Name
-      value: cardboard box
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 4811199063769927608, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
-    - {fileID: 3734325509069202337, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
-  m_SourcePrefab: {fileID: 100100000, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
---- !u!4 &4828485990197208760 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-    type: 3}
-  m_PrefabInstance: {fileID: 321094099935096379}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &887597240161036262
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 4138969924818735946}
-    m_Modifications:
-    - target: {fileID: 1594633947765538537, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8155353539727309456, guid: 33f138fd77f12bf42ba03827596f66e1,
-        type: 3}
-      propertyPath: m_Name
-      value: cardboard box
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 3734325509069202337, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
-  m_SourcePrefab: {fileID: 100100000, guid: 33f138fd77f12bf42ba03827596f66e1, type: 3}
---- !u!4 &5415468539376512869 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5149579257445173379, guid: 33f138fd77f12bf42ba03827596f66e1,
-    type: 3}
-  m_PrefabInstance: {fileID: 887597240161036262}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1195560607535681340
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 4242083820894702211}
-    m_Modifications:
-    - target: {fileID: 963665549342937872, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_Name
-      value: MopBucket
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7662006264191504503, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 7745630569793271760, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e, type: 3}
-  m_SourcePrefab: {fileID: 100100000, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e, type: 3}
---- !u!4 &5961226931208061903 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4768736164552854771, guid: 7df6d6e44c7ebac4f9bba7a3e9543c8e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1195560607535681340}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1968046153696894811
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 6546710352939549053}
-    m_Modifications:
-    - target: {fileID: 482575724292013721, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_Name
-      value: Space Cleaner
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034264551424376892, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 18be5534ee7bf8a4fb2b3ef9d47128d3, type: 2}
-    - target: {fileID: 6214904123404750012, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8030495889000178033, guid: 2193154d46a9f7a439291e0a8cf94391,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2193154d46a9f7a439291e0a8cf94391, type: 3}
---- !u!4 &3145423783785747409 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3524398522829900938, guid: 2193154d46a9f7a439291e0a8cf94391,
-    type: 3}
-  m_PrefabInstance: {fileID: 1968046153696894811}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2891524827675572239
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 5467744687762280116}
-    m_Modifications:
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3533485490934766563, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_Name
-      value: mop
-      objectReference: {fileID: 0}
-    - target: {fileID: 6198522780239372186, guid: 516f5504002cb8142b8cf0111b514d27,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 516f5504002cb8142b8cf0111b514d27, type: 3}
---- !u!4 &3419055716234433023 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 527536392712956400, guid: 516f5504002cb8142b8cf0111b514d27,
-    type: 3}
-  m_PrefabInstance: {fileID: 2891524827675572239}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3994946018282237211
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 3177432156376954865}
-    m_Modifications:
-    - target: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_Name
-      value: rag
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7081313147279106833, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
---- !u!4 &769594690166727665 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-    type: 3}
-  m_PrefabInstance: {fileID: 3994946018282237211}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4854140057908716348
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 4994728017443307690}
-    m_Modifications:
-    - target: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_Name
-      value: rag
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7081313147279106833, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
---- !u!4 &9116304746198363606 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-    type: 3}
-  m_PrefabInstance: {fileID: 4854140057908716348}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &7273818831446229650
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 6132168452376365169}
-    m_Modifications:
-    - target: {fileID: 1526402662451169415, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9002315518600615791, guid: 0eade332e5605794db10d9bb8a7e5c00,
-        type: 3}
-      propertyPath: m_Name
-      value: soap
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0eade332e5605794db10d9bb8a7e5c00, type: 3}
---- !u!4 &3333846988371109870 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5383489977180743036, guid: 0eade332e5605794db10d9bb8a7e5c00,
-    type: 3}
-  m_PrefabInstance: {fileID: 7273818831446229650}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8412319447182700663
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 6037772964090764217}
-    m_Modifications:
-    - target: {fileID: 830238684080913657, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_Name
-      value: rag
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7081313147279106833, guid: f0b46690da49c3341a381a6e039846b2,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f0b46690da49c3341a381a6e039846b2, type: 3}
---- !u!4 &5287313375294373533 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4458212302184304362, guid: f0b46690da49c3341a381a6e039846b2,
-    type: 3}
-  m_PrefabInstance: {fileID: 8412319447182700663}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Engine/Inventory/ContainerDescriptor.cs
+++ b/Assets/Engine/Inventory/ContainerDescriptor.cs
@@ -87,6 +87,9 @@ namespace SS3D.Engine.Inventory
         /// <summary> If items in the container should be displayed at particular locations in the container</summary>
         public bool hasCustomDisplay;
 
+        /// <summary> If the attachment point of the item should be used when displaying items at custom transform of the container</summary>
+        public bool useAttachmentPoint;
+
         /// <summary> The list of transforms defining where the items are displayed.</summary>
         public Transform[] displays;
 

--- a/Assets/Engine/Inventory/ContainerItemDisplay.cs
+++ b/Assets/Engine/Inventory/ContainerItemDisplay.cs
@@ -56,38 +56,49 @@ namespace SS3D.Engine.Inventory
 
             Transform itemTransform = item.transform;
 
-            // Check if a custom attachment point should be used
-            Transform attachmentPoint = item.attachmentPoint;
-            if (Mirrored && item.attachmentPointAlt != null)
+            if (containerDescriptor.useAttachmentPoint)
             {
-                attachmentPoint = item.attachmentPointAlt;
-            }
+                // Check if a custom attachment point should be used
+                Transform attachmentPoint = item.attachmentPoint;
+                if (Mirrored && item.attachmentPointAlt != null)
+                {
+                    attachmentPoint = item.attachmentPointAlt;
+                }
 
-            if (attachmentPoint != null)
-            {
-                // Create new (temporary) point
-                // HACK: Required because rotation pivot can be different
-                GameObject temporaryPoint = new GameObject("TempPivotPoint");
-                
-                temporaryPoint.transform.SetParent(containerDescriptor.displays[index].transform, false);
-                temporaryPoint.transform.localPosition = Vector3.zero;
-                temporaryPoint.transform.rotation = attachmentPoint.root.rotation *  attachmentPoint.localRotation;
-                
-                // Assign parent
-                itemTransform.SetParent(temporaryPoint.transform, false);
-                // Assign the relative position between the attachment point and the object
-                itemTransform.localPosition = -attachmentPoint.localPosition;
-                //item.transform.rotation = displays[index].transform.rotation;
-                itemTransform.localRotation = Quaternion.identity;
+                if (attachmentPoint != null)
+                {
+                    // Create new (temporary) point
+                    // HACK: Required because rotation pivot can be different
+                    GameObject temporaryPoint = new GameObject("TempPivotPoint");
+
+                    temporaryPoint.transform.SetParent(containerDescriptor.displays[index].transform, false);
+                    temporaryPoint.transform.localPosition = Vector3.zero;
+                    temporaryPoint.transform.rotation = attachmentPoint.root.rotation * attachmentPoint.localRotation;
+
+                    // Assign parent
+                    itemTransform.SetParent(temporaryPoint.transform, false);
+                    // Assign the relative position between the attachment point and the object
+                    itemTransform.localPosition = -attachmentPoint.localPosition;
+                    //item.transform.rotation = displays[index].transform.rotation;
+                    itemTransform.localRotation = Quaternion.identity;
+                }
+                else
+                {
+                    itemTransform.SetParent(containerDescriptor.displays[index].transform, false);
+                    itemTransform.localPosition = new Vector3();
+                    itemTransform.localRotation = new Quaternion();
+                }
             }
             else
             {
                 itemTransform.SetParent(containerDescriptor.displays[index].transform, false);
-                itemTransform.localPosition = new Vector3();
-                itemTransform.localRotation = new Quaternion();
+                itemTransform.position = containerDescriptor.displays[index].transform.position;
+                itemTransform.rotation = containerDescriptor.displays[index].transform.rotation;
             }
 
+
             displayedItems[index] = item;
+
         }
         
         private void ContainerOnItemDetached(object sender, Item item)

--- a/Assets/Engine/Inventory/Editor/ContainerDescriptorEditor.cs
+++ b/Assets/Engine/Inventory/Editor/ContainerDescriptorEditor.cs
@@ -102,6 +102,8 @@ public class ContainerDescriptorEditor : Editor
 
             if (hasCustomDisplay)
             {
+                bool useAttachmentPoint = EditorGUILayout.Toggle(new GUIContent("use attachment point", "if the attachment point of the item should be used or not"), containerDescriptor.useAttachmentPoint);
+                HandleUseAttachmentPoint(useAttachmentPoint);
                 int numberDisplay = EditorGUILayout.IntField(new GUIContent("number of display", "the number of items to display in custom position"), containerDescriptor.numberDisplay);
                 HandleNumberDisplay(numberDisplay);
 
@@ -200,6 +202,13 @@ public class ContainerDescriptorEditor : Editor
         {
             RemoveCustomDisplay();
         }
+    }
+
+    private void HandleUseAttachmentPoint(bool useAttachmentPoint)
+    {
+        SerializedProperty sp = serializedObject.FindProperty("useAttachmentPoint");
+        sp.boolValue = useAttachmentPoint;
+        serializedObject.ApplyModifiedProperties();
     }
 
     private void HandleHasUi(bool hasUi)

--- a/Assets/JanitorialCart.cs
+++ b/Assets/JanitorialCart.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Mirror;
+
+public class JanitorialCart : NetworkBehaviour
+{
+    public GameObject boxOne;
+    public GameObject boxTwo;
+    public GameObject mop;
+    public GameObject mopBucket;
+    public GameObject ragOne;
+    public GameObject ragTwo;
+    public GameObject ragThree;
+    public GameObject spaceCleaner;
+    public GameObject soap;
+
+
+    void Start()
+    {
+        
+        Transform[] transforms = this.transform.GetComponentsInChildren<Transform>();
+        foreach(Transform transform in transforms)
+        {
+            GameObject cartItem;
+            switch (transform.name)
+            {
+                case "JanitorialCart_Spot_Box1":
+                    cartItem = Instantiate(boxOne, transform.position, transform.rotation);                 
+                    break;
+                case "JanitorialCart_Spot_Box2":
+                    cartItem = Instantiate(boxTwo, transform.position, transform.rotation); 
+                    break;
+                case "JanitorialCart_Spot_Mop":
+                    cartItem = Instantiate(mop, transform.position, transform.rotation);
+                    break;
+                case "JanitorialCart_Spot_MopBucket":
+                    cartItem = Instantiate(mopBucket, transform.position, transform.rotation);
+                    break;
+                case "JanitorialCart_Spot_Rag1":
+                    cartItem = Instantiate(ragOne, transform.position, transform.rotation);
+                    break;
+                case "JanitorialCart_Spot_Rag2":
+                    cartItem = Instantiate(ragTwo, transform.position, transform.rotation);
+                    break;
+                case "JanitorialCart_Spot_Rag3":
+                    cartItem = Instantiate(ragThree, transform.position, transform.rotation);
+                    break;
+                case "JanitorialCart_Spot_Tray1":
+                    cartItem = Instantiate(spaceCleaner, transform.position, transform.rotation);
+                    break;
+                case "JanitorialCart_Spot_Tray2":
+                    cartItem = Instantiate(soap, transform.position, transform.rotation);
+                    break;
+                default:
+                    cartItem = null;
+                    break;
+            }
+
+            if(cartItem != null)
+            {
+                cartItem.transform.parent = transform;
+                NetworkServer.Spawn(cartItem);
+            } 
+        }
+    }
+}

--- a/Assets/JanitorialCart.cs
+++ b/Assets/JanitorialCart.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
 
+/// <summary>
+/// Handles creating the items going on the janitorial cart at runtime.
+/// This is necessary as Mirror doesn't support nested Network Identities.
+/// </summary>
 public class JanitorialCart : NetworkBehaviour
 {
     public GameObject boxOne;
@@ -18,7 +22,7 @@ public class JanitorialCart : NetworkBehaviour
 
     void Start()
     {
-        
+        // Go through each transform on the cart that must have an item and instantiate the correct item at the correct position.
         Transform[] transforms = this.transform.GetComponentsInChildren<Transform>();
         foreach(Transform transform in transforms)
         {
@@ -57,6 +61,8 @@ public class JanitorialCart : NetworkBehaviour
                     break;
             }
 
+            // Set the item tranforms to be child of the transforms on the cart. 
+            // Spawn the item for all clients
             if(cartItem != null)
             {
                 cartItem.transform.parent = transform;

--- a/Assets/JanitorialCart.cs
+++ b/Assets/JanitorialCart.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
+using SS3D.Engine.Inventory;
 
 /// <summary>
 /// Handles creating the items going on the janitorial cart at runtime.
@@ -20,8 +21,20 @@ public class JanitorialCart : NetworkBehaviour
     public GameObject soap;
 
 
+
     void Start()
     {
+
+        GameObject boxOneInstance = null;
+        GameObject boxTwoInstance = null;
+        GameObject mopInstance = null;
+        GameObject mopBucketInstance = null;
+        GameObject ragOneInstance = null;
+        GameObject ragTwoInstance = null;
+        GameObject ragThreeInstance = null;
+        GameObject spaceCleanerInstance = null;
+        GameObject soapInstance = null;
+
         // Go through each transform on the cart that must have an item and instantiate the correct item at the correct position.
         Transform[] transforms = this.transform.GetComponentsInChildren<Transform>();
         foreach(Transform transform in transforms)
@@ -30,31 +43,40 @@ public class JanitorialCart : NetworkBehaviour
             switch (transform.name)
             {
                 case "JanitorialCart_Spot_Box1":
-                    cartItem = Instantiate(boxOne, transform.position, transform.rotation);                 
+                    cartItem = Instantiate(boxOne, transform.position, transform.rotation);
+                    boxOneInstance = cartItem;
                     break;
                 case "JanitorialCart_Spot_Box2":
-                    cartItem = Instantiate(boxTwo, transform.position, transform.rotation); 
+                    cartItem = Instantiate(boxTwo, transform.position, transform.rotation);
+                    boxTwoInstance = cartItem;
                     break;
                 case "JanitorialCart_Spot_Mop":
                     cartItem = Instantiate(mop, transform.position, transform.rotation);
+                    mopInstance = cartItem;
                     break;
                 case "JanitorialCart_Spot_MopBucket":
                     cartItem = Instantiate(mopBucket, transform.position, transform.rotation);
+                    mopBucketInstance = cartItem;
                     break;
                 case "JanitorialCart_Spot_Rag1":
                     cartItem = Instantiate(ragOne, transform.position, transform.rotation);
+                    ragOneInstance = cartItem;
                     break;
                 case "JanitorialCart_Spot_Rag2":
                     cartItem = Instantiate(ragTwo, transform.position, transform.rotation);
+                    ragTwoInstance = cartItem;
                     break;
                 case "JanitorialCart_Spot_Rag3":
                     cartItem = Instantiate(ragThree, transform.position, transform.rotation);
+                    ragThreeInstance = cartItem;
                     break;
                 case "JanitorialCart_Spot_Tray1":
                     cartItem = Instantiate(spaceCleaner, transform.position, transform.rotation);
+                    spaceCleanerInstance = cartItem;
                     break;
                 case "JanitorialCart_Spot_Tray2":
                     cartItem = Instantiate(soap, transform.position, transform.rotation);
+                    soapInstance = cartItem;
                     break;
                 default:
                     cartItem = null;
@@ -68,6 +90,29 @@ public class JanitorialCart : NetworkBehaviour
                 cartItem.transform.parent = transform;
                 NetworkServer.Spawn(cartItem);
             } 
+        }
+
+        var containerDescriptors = GetComponentsInChildren<ContainerDescriptor>();
+        foreach(ContainerDescriptor containerDescriptor in containerDescriptors)
+        {
+            switch (containerDescriptor.containerName)
+            {
+                case "box spot":
+                    Debug.Log("add boxes to box spot");
+                    if(boxOneInstance != null)
+                        containerDescriptor.attachedContainer.Container.AddItem(boxOneInstance.gameObject.GetComponent<Item>());
+                    if (boxTwoInstance != null)
+                        containerDescriptor.attachedContainer.Container.AddItem(boxTwoInstance.gameObject.GetComponent<Item>());
+                    break;
+                case "rag spot":
+                    if (ragOneInstance != null)
+                        containerDescriptor.attachedContainer.Container.AddItem(ragOneInstance.gameObject.GetComponent<Item>());
+                    if (ragTwoInstance != null)
+                        containerDescriptor.attachedContainer.Container.AddItem(ragTwoInstance.gameObject.GetComponent<Item>());
+                    if (ragThreeInstance != null)
+                        containerDescriptor.attachedContainer.Container.AddItem(ragThreeInstance.gameObject.GetComponent<Item>());
+                    break;
+            }
         }
     }
 }

--- a/Assets/JanitorialCart.cs.meta
+++ b/Assets/JanitorialCart.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0c449d3e5a4a2a4688d56873fce3f2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Since Mirror doesn't support nested network identities, we need to create the prefab by spawning items at runtime.

This Pull request adds a bit more than initially planned. 
When the cart spawns, items on it are a mess because of collisions, and I assume that's not what we want.
With the container rework, we can add two containers, one for the towels, and one for the boxes, so it's possible to put towels and boxes properly on the janicart. 
It also means they wouldn't be subject to wacky collisions effect unless we want them too. So most of the time they would stay where they are.

Also the attachment point was messing with the way items were displayed in a container. This adds a parameter to choose if the attachment point should be taken into account or not when placing the item in a container.