### PR TITLE
[WIP] Examine in interaction and containers on child object

### DIFF
--- a/Assets/Engine/Examine/Examinator.cs
+++ b/Assets/Engine/Examine/Examinator.cs
@@ -81,7 +81,7 @@ namespace SS3D.Engine.Examine
                 lastCameraRotation = rotation;
                 CalculateExamine();
                 // Update examinable right away (information might have changed)
-                OnExaminableChanged(selector.CurrentExaminable);
+                OnExaminableChanged(selector.CurrentSelectable);
             }
         }
 
@@ -100,6 +100,8 @@ namespace SS3D.Engine.Examine
 	        {
 		        // If it's over something, get all the assosciated data and update the UI.
 		        IExaminable[] examinables = examinable.GetComponents<IExaminable>();
+                if (examinables == null) return;
+
 		        UpdateExamine(examinables);
 	        }
 	        else

--- a/Assets/Engine/Examine/IExaminable.cs
+++ b/Assets/Engine/Examine/IExaminable.cs
@@ -2,7 +2,7 @@
 
 namespace SS3D.Engine.Examine
 {
-    public interface IExaminable
+    public interface IExaminable : ISelectable
     {
 		IExamineRequirement GetRequirements();
 		IExamineData GetData();

--- a/Assets/Engine/Examine/ISelectable.cs
+++ b/Assets/Engine/Examine/ISelectable.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace SS3D.Engine.Examine
+{
+    public interface ISelectable
+    {
+        
+    }
+}

--- a/Assets/Engine/Examine/ISelectable.cs.meta
+++ b/Assets/Engine/Examine/ISelectable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 466ab6a4d27208d4ea46fa91513448b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Engine/Interactions/IInteractionTarget.cs
+++ b/Assets/Engine/Interactions/IInteractionTarget.cs
@@ -1,9 +1,11 @@
-﻿namespace SS3D.Engine.Interactions
+﻿using SS3D.Engine.Examine;
+
+namespace SS3D.Engine.Interactions
 {
     /// <summary>
     /// A target which can be interacted with
     /// </summary>
-    public interface IInteractionTarget
+    public interface IInteractionTarget : ISelectable
     {
         /// <summary>
         /// Generates possible interactions (not checked for CanExecute)

--- a/Assets/Engine/Interactions/InteractionHandler.cs
+++ b/Assets/Engine/Interactions/InteractionHandler.cs
@@ -325,10 +325,18 @@ namespace SS3D.Engine.Interactions
         /// <returns>A list of all valid interaction targets</returns>
         private List<IInteractionTarget> GetTargetsFromGameObject(IInteractionSource source, GameObject gameObject)
         {
+           
             List<IInteractionTarget> targets = new List<IInteractionTarget>();
             // Get all target components which are not disabled and the source can interact with
             targets.AddRange(gameObject.GetComponents<IInteractionTarget>().Where(x =>
                 (x as MonoBehaviour)?.enabled != false && source.CanInteractWithTarget(x)));
+
+            ContainerDescriptor containerDescriptor = gameObject.GetComponent<ContainerDescriptor>();
+            if (containerDescriptor != null && containerDescriptor.isInteractive)
+            {
+                targets.Add(containerDescriptor.containerInteractive);
+            }
+
             if (targets.Count < 1)
             {
                 targets.Add(new InteractionTargetGameObject(gameObject));

--- a/Assets/Engine/Interactions/InteractionHandler.cs
+++ b/Assets/Engine/Interactions/InteractionHandler.cs
@@ -36,9 +36,9 @@ namespace SS3D.Engine.Interactions
 
         public void Update()
         {
-            if (selector.CurrentExaminable != null)
+            if (selector.CurrentSelectable != null)
             {
-                lastGameObjectPointed = selector.CurrentExaminable;
+                lastGameObjectPointed = selector.CurrentSelectable;
             }
 
             // Ensure that mouse isn't over ui (game objects aren't tracked by the eventsystem, so ispointer would return false

--- a/Assets/Engine/Interactions/InteractionHandler.cs
+++ b/Assets/Engine/Interactions/InteractionHandler.cs
@@ -6,6 +6,7 @@ using SS3D.Engine.Inventory;
 using SS3D.Engine.Inventory.Extensions;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using SS3D.Engine.Examine;
 
 namespace SS3D.Engine.Interactions
 {
@@ -24,14 +25,22 @@ namespace SS3D.Engine.Interactions
         private GameObject menuPrefab = null;
 
         private Camera camera;
+        private CompositeItemSelector selector;
+        private GameObject lastGameObjectPointed;
 
         private void Start()
         {
             camera = CameraManager.singleton.playerCamera;
+            selector = camera.GetComponent<CompositeItemSelector>();
         }
 
         public void Update()
         {
+            if (selector.CurrentExaminable != null)
+            {
+                lastGameObjectPointed = selector.CurrentExaminable;
+            }
+
             // Ensure that mouse isn't over ui (game objects aren't tracked by the eventsystem, so ispointer would return false
             if (!isLocalPlayer || camera == null || EventSystem.current.IsPointerOverGameObject())
             {
@@ -300,8 +309,7 @@ namespace SS3D.Engine.Interactions
             if (Physics.Raycast(ray, out RaycastHit hit, float.PositiveInfinity, selectionMask, QueryTriggerInteraction.Ignore))
             {
                 point = hit.point;
-                GameObject targetGo = hit.transform.gameObject;
-                targets = GetTargetsFromGameObject(source, targetGo);
+                targets = GetTargetsFromGameObject(source, lastGameObjectPointed);
             }
             
             interactionEvent = new InteractionEvent(source, targets[0], point);

--- a/Assets/Engine/Inventory/ContainerDescriptor.cs
+++ b/Assets/Engine/Inventory/ContainerDescriptor.cs
@@ -5,6 +5,7 @@ using SS3D.Engine.Inventory.UI;
 using UnityEngine.Assertions;
 using Mirror;
 using SS3D.Content;
+using SS3D.Engine.Examine;
 
 namespace SS3D.Engine.Inventory
 {
@@ -17,7 +18,7 @@ namespace SS3D.Engine.Inventory
     /// needs to acces them directly, not through accessors or properties. ContainerDescriptorEditor should be declared as friend of 
     /// ContainerDescriptor and most attributes should be private.
     /// </summary>
-    public class ContainerDescriptor : MonoBehaviour
+    public class ContainerDescriptor : MonoBehaviour, ISelectable
     {
         // References toward all container related scripts.
         public AttachedContainer attachedContainer;
@@ -98,7 +99,7 @@ namespace SS3D.Engine.Inventory
         private float CheckObserversInterval = 1f;
 
         private float lastObserverCheck;
-        
+
         public void Awake()
         {
             // create a new container of Size size

--- a/Assets/Engine/Inventory/Editor/ContainerDescriptorEditor.cs
+++ b/Assets/Engine/Inventory/Editor/ContainerDescriptorEditor.cs
@@ -310,10 +310,19 @@ public class ContainerDescriptorEditor : Editor
     {
         SerializedProperty sp = serializedObject.FindProperty("containerInteractive");
         GameObject networkedParent = GetParentNetworkIdentity(containerDescriptor.gameObject);
-        sp.objectReferenceValue = networkedParent.AddComponent<ContainerInteractive>();
+        if (networkedParent != null)
+        {
+            sp.objectReferenceValue = networkedParent.AddComponent<ContainerInteractive>();
+        }
+        else
+        {
+            sp.objectReferenceValue = containerDescriptor.gameObject.AddComponent<ContainerInteractive>();
+        }
+
         serializedObject.ApplyModifiedProperties();
         containerDescriptor.containerInteractive.containerDescriptor = containerDescriptor;
     }
+
 
     private void RemoveInteractive()
     {
@@ -352,15 +361,25 @@ public class ContainerDescriptorEditor : Editor
         {
             SerializedProperty sp = serializedObject.FindProperty("containerSync");
             GameObject g = GetParentNetworkIdentity(containerDescriptor.gameObject);
-            sp.objectReferenceValue = g.AddComponent<ContainerSync>();
-            serializedObject.ApplyModifiedProperties();           
+
+            if (g != null)
+            {
+                sp.objectReferenceValue = g.AddComponent<ContainerSync>();
+            }
+            else
+            {
+                sp.objectReferenceValue = containerDescriptor.gameObject.AddComponent<ContainerSync>();
+            }
+
+            serializedObject.ApplyModifiedProperties();
         }
         
     }
 
     private GameObject GetParentNetworkIdentity(GameObject g)
     {
-        return g.GetComponentInParent<NetworkIdentity>().gameObject;
+        var networkIdentity = g.GetComponentInParent<NetworkIdentity>();
+        return networkIdentity ? networkIdentity.gameObject : null;
     }
 
     private void RemoveSync()

--- a/Assets/Engine/Inventory/Editor/ContainerDescriptorEditor.cs
+++ b/Assets/Engine/Inventory/Editor/ContainerDescriptorEditor.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 using SS3D.Engine.Inventory;
 using SS3D.Content.Furniture.Storage;
 using SS3D.Engine.Interactions;
-
+using Mirror;
 using System.Collections.Generic;
 
 [CustomEditor(typeof(ContainerDescriptor))]
@@ -65,16 +65,21 @@ public class ContainerDescriptorEditor : Editor
             HandleOnlyStoreWhenOpen(onlyStoreWhenOpen);       
         }
         else if(containerDescriptor.hasUi)
-        {  
-            // check if the gameObject has a open animation
-            foreach (AnimatorControllerParameter controllerParameter in containerDescriptor.gameObject.GetComponent<Animator>().parameters)
+        {
+            var animator = containerDescriptor.gameObject.GetComponent<Animator>();
+            if (animator != null)
             {
-                if (controllerParameter.name == "Open")
+                // check if the gameObject has a open animation
+                foreach (AnimatorControllerParameter controllerParameter in containerDescriptor.gameObject.GetComponent<Animator>().parameters)
                 {
-                    bool openWhenContainerViewed = EditorGUILayout.Toggle(new GUIContent("open when container viewed", "Set if the open animation should run when the container UI is opened"), containerDescriptor.openWhenContainerViewed);
-                    HandleOpenWhenContainerViewed(openWhenContainerViewed);
+                    if (controllerParameter.name == "Open")
+                    {
+                        bool openWhenContainerViewed = EditorGUILayout.Toggle(new GUIContent("open when container viewed", "Set if the open animation should run when the container UI is opened"), containerDescriptor.openWhenContainerViewed);
+                        HandleOpenWhenContainerViewed(openWhenContainerViewed);
+                    }
                 }
-            }      
+            }
+  
         }
 
         if (containerDescriptor.hasUi)
@@ -304,7 +309,8 @@ public class ContainerDescriptorEditor : Editor
     private void AddInteractive()
     {
         SerializedProperty sp = serializedObject.FindProperty("containerInteractive");
-        sp.objectReferenceValue = containerDescriptor.gameObject.AddComponent<ContainerInteractive>();
+        GameObject networkedParent = GetParentNetworkIdentity(containerDescriptor.gameObject);
+        sp.objectReferenceValue = networkedParent.AddComponent<ContainerInteractive>();
         serializedObject.ApplyModifiedProperties();
         containerDescriptor.containerInteractive.containerDescriptor = containerDescriptor;
     }
@@ -341,13 +347,20 @@ public class ContainerDescriptorEditor : Editor
 
     private void AddSync()
     {
-        if(containerDescriptor.gameObject.GetComponent<ContainerSync>() == null)
+        // put the containersync on the highest game object in the hierarchy with a network identity
+        if(containerDescriptor.gameObject.GetComponentInParent<ContainerSync>() == null)
         {
             SerializedProperty sp = serializedObject.FindProperty("containerSync");
-            sp.objectReferenceValue = containerDescriptor.gameObject.AddComponent<ContainerSync>();
+            GameObject g = GetParentNetworkIdentity(containerDescriptor.gameObject);
+            sp.objectReferenceValue = g.AddComponent<ContainerSync>();
             serializedObject.ApplyModifiedProperties();           
         }
         
+    }
+
+    private GameObject GetParentNetworkIdentity(GameObject g)
+    {
+        return g.GetComponentInParent<NetworkIdentity>().gameObject;
     }
 
     private void RemoveSync()
@@ -358,7 +371,8 @@ public class ContainerDescriptorEditor : Editor
             var containerDescriptors = g.GetComponents<ContainerDescriptor>();
             if (containerDescriptors != null && containerDescriptors.Length == 0)
             {
-                DestroyImmediate(g.GetComponent<ContainerSync>());
+                GameObject networkedParent = GetParentNetworkIdentity(g);
+                DestroyImmediate(networkedParent.GetComponent<ContainerSync>());
             }
         }
     }


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->

## Summary

Unlike raycasts, the examine system allows us to select any items visible on screen and to interact with them. This is particularly useful for items behind invisible colliders such as items in containers, or pipe in the ground.
Items in containers are not interactive yet because they are freezed, making items interactive in containers will be part of a PR coming soon.

Interactive game object don't have to implement the IExaminable interface anymore, they just have to implement the ISelectable. This allows us to interact with objects that can't be examined.

This PR also allows containers to be put on child objects, this was not possible before because a network identity was necessary on the child object as well, and Mirror doesn't allow two network identity in the same game object hierarchy.


## Pictures/Videos (optional)

The video shows a soda vendor with a maintenance panel. The maintenance panel has a containerDescriptor script on it,
no scripts implementing Iexaminable. We can see that when clicking directly on the maintenance panel, the container shows up. When clicking anywhere else on the vendor, a soda is thrown. This proves that child objects can be independantly interacted with, using the examine system, without the need for a script implementing Iexaminable.

https://www.youtube.com/watch?v=Chu1868J1Cs

## Changes to Files

<!-- List any major asset/script/scene changes and why/how they were changed. -->

## Technical Notes (optional)

Script such as containerSync and containerInteractive, both implementing NetworkBehaviour, are now created on the closest parent gameObject with a networkIdentity. If none are found, they are created on the current gameobject and a network identity is created as well.

An Interface Iselectable is defined, simply to allow for other scripts than the one implementing IExaminable to be picked up
by the compositeItemSelector script.

## Fixes (optional)

closes #841
