### PR TITLE
Fix chat "hacking"

### DIFF
--- a/Assets/Engine/Chat/ChatRegister.cs
+++ b/Assets/Engine/Chat/ChatRegister.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Mirror;
@@ -32,7 +32,14 @@ namespace SS3D.Engine.Chat
         [Command]
         public void CmdSendMessage(ChatMessage chatMessage)
         {
-            if(restrictedChannels.Contains(chatMessage.Channel.Name)) return;
+            if (restrictedChannels.Contains(chatMessage.Channel.Name)) return;
+            else
+            {
+                // Tags should be escaped only in unrestricted channels thus preserving the ability
+                // to stylize in restricted channels.
+                chatMessage.Text = chatMessage.Text.Replace("<", "<nobr><</nobr>");
+            }
+
             
             chatMessage.Sender = gameObject.name;
             //TODO: this could be avoided if chat messages were stored on some centrally networked object and each client would pull from them. I could not get it to work though.

--- a/Assets/Engine/Chat/ChatWindow.cs
+++ b/Assets/Engine/Chat/ChatWindow.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using TMPro;
@@ -192,13 +192,9 @@ namespace SS3D.Engine.Chat
                 return;
             }
 
-            //Add the no parse tag so users can't edit their text
-            StringBuilder newText = new StringBuilder();
-            newText.Append("<noparse>").Append(text).Append("</noparse>");
-
             ChatMessage chatMessage = new ChatMessage();
             chatMessage.Channel = currentTabData.Channels[channelDropDown.value];
-            chatMessage.Text = newText.ToString();
+            chatMessage.Text = text;
             inputField.text = "";
             if(chatRegister.RestrictedChannels.Contains(chatMessage.Channel.Name)){
                 return; //do not allow talking in restricted channels

--- a/Assets/Engine/Chat/ChatWindow.cs
+++ b/Assets/Engine/Chat/ChatWindow.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using TMPro;
@@ -33,7 +33,8 @@ namespace SS3D.Engine.Chat
             LoadChannelSelector(tabData);
         }
 
-        public RectTransform GetTabRow() {
+        public RectTransform GetTabRow()
+        {
             return tabRow;
         }
 
@@ -64,7 +65,7 @@ namespace SS3D.Engine.Chat
 
                 channelDropDown.options.Add(
                     new TMP_Dropdown.OptionData(
-                        string.Format("<color=#{0}>[{1}]</color>", 
+                        string.Format("<color=#{0}>[{1}]</color>",
                             ColorUtility.ToHtmlStringRGBA(channel.Color),
                             channel.Abbreviation)
                     )
@@ -126,7 +127,7 @@ namespace SS3D.Engine.Chat
 
         private void LoadTabChatLog(ChatTabData tabData)
         {
-            List<ChatMessage> relevantMessages = chatRegister.GetRelevantMessages(tabData); 
+            List<ChatMessage> relevantMessages = chatRegister.GetRelevantMessages(tabData);
             StringBuilder sb = new StringBuilder();
             foreach (ChatMessage message in relevantMessages)
             {
@@ -149,7 +150,7 @@ namespace SS3D.Engine.Chat
             }
 
             ChatTab newTab = tabRow.GetChild(0).GetComponent<ChatTab>();
-        
+
             if (newTab)
             {
                 LoadTab(newTab.Data);
@@ -196,7 +197,8 @@ namespace SS3D.Engine.Chat
             chatMessage.Channel = currentTabData.Channels[channelDropDown.value];
             chatMessage.Text = text;
             inputField.text = "";
-            if(chatRegister.RestrictedChannels.Contains(chatMessage.Channel.Name)){
+            if (chatRegister.RestrictedChannels.Contains(chatMessage.Channel.Name))
+            {
                 return; //do not allow talking in restricted channels
             }
 
@@ -205,8 +207,8 @@ namespace SS3D.Engine.Chat
 
         public void OnDrag(PointerEventData eventData)
         {
-            RectTransform moveTransform = (RectTransform) transform;
-            moveTransform.position += (Vector3) eventData.delta;
+            RectTransform moveTransform = (RectTransform)transform;
+            moveTransform.position += (Vector3)eventData.delta;
         }
 
         public bool PlayerIsTyping()
@@ -214,8 +216,10 @@ namespace SS3D.Engine.Chat
             return (EventSystem.current.currentSelectedGameObject != null);
         }
 
-        public void FinishTyping(){
-            if ((Input.GetKey(KeyCode.Return) || Input.GetKey(KeyCode.KeypadEnter)) ) {
+        public void FinishTyping()
+        {
+            if ((Input.GetKey(KeyCode.Return) || Input.GetKey(KeyCode.KeypadEnter)))
+            {
                 SendMessage();
             }
 
@@ -225,7 +229,7 @@ namespace SS3D.Engine.Chat
         public void FocusInputField()
         {
             inputField.Select();
-        
+
         }
     }
 


### PR DESCRIPTION
## Summary

Players are able to use tags to change the style of their chat messages. This PR fixes it.

## Pictures/Videos (optional)

![image](https://user-images.githubusercontent.com/12456395/141428405-97d3a9ad-eb23-4f60-a2da-3630ef518151.png)

## Changes to Files

`Assets/Engine/Chat/ChatRegister.cs` add escaping of tags to server side
`Assets/Engine/Chat/ChatWindow.cs` remove `<noparse>` wrapping of the player's message and format code to match guidelines

## Technical Notes (optional)

Escaping implemented by replacing all `<` of the message with `<nobr><</nobr>`. That breaks all tags in the message without affecting visible text of the message. Also the escaping of the message is now on the server side so players with modified clients can't bypass the protection.

## Fixes (optional)

Closes #806 
