### PR TITLE
Resolve duplicate door frames

### DIFF
--- a/Assets/Content/Structures/Doors/Door.cs
+++ b/Assets/Content/Structures/Doors/Door.cs
@@ -149,12 +149,12 @@ namespace SS3D.Content.Structures.Fixtures
             // Door may have rotated in the editor
             doorDirection = GetComponent<PlacedTileObject>().GetDirection();
             Direction outFacing = TileHelper.GetNextDir(doorDirection);
-                
+
             bool isPresent = adjacents.Adjacent(outFacing) == 1;
-            CreateWallCaps(isPresent, outFacing);
+            CreateWallCaps(isPresent, TileHelper.GetOpposite(outFacing));
 
             isPresent = adjacents.Adjacent(TileHelper.GetOpposite(outFacing)) == 1;
-            CreateWallCaps(isPresent, TileHelper.GetOpposite(outFacing));
+            CreateWallCaps(isPresent, outFacing);
         }
 
         private void ValidateChildren()


### PR DESCRIPTION
## Summary
While not being able to replicate the issue where multiple door frames where present, I suspect this result of the door looking into the wrong direction for finding it's door frames and duplicating them when the map is loaded again. 

By changing the direction into the opposite, it connects correctly once again.



## Pictures
![afbeelding](https://user-images.githubusercontent.com/5231626/146071717-5e472afd-54ee-4585-9ef7-92ee1bb592cd.png)
Frames where located on the wrong side.

![afbeelding](https://user-images.githubusercontent.com/5231626/146072198-47a3ac77-486b-41b3-8e93-0109200c0402.png)
With the fix applied

![afbeelding](https://user-images.githubusercontent.com/5231626/146072624-0b58d5cf-02d1-4b03-8f1c-b37be6867240.png)
Correct number of door frames


## Fixes
Closes #851 
