### PR TITLE
Remove BoxColliders from several aesthetic doors

### DIFF
--- a/Assets/Content/Furniture/Machines/Kitchen/Microwave/microwave.prefab
+++ b/Assets/Content/Furniture/Machines/Kitchen/Microwave/microwave.prefab
@@ -60,7 +60,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   sceneId: 0
   serverOnly: 0
-  m_AssetId: 
+  visible: 0
+  m_AssetId: f4ce32acbfd8b564b8f991806cf67769
   hasSpawned: 0
 --- !u!114 &3096095831774564904
 MonoBehaviour:
@@ -77,9 +78,20 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   clientAuthority: 0
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  sendInterval: 0.05
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  interpolatePosition: 1
+  interpolateRotation: 1
+  interpolateScale: 0
+  bufferTimeMultiplier: 1
+  bufferSizeLimit: 64
+  catchupThreshold: 4
+  catchupMultiplier: 0.1
+  showGizmos: 0
+  showOverlay: 0
+  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
 --- !u!33 &7378502613818069388
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -366,6 +378,7 @@ MonoBehaviour:
   attachedContainer: {fileID: 5055055840736840480}
   containerSync: {fileID: 0}
   containerInteractive: {fileID: 2622024214267529593}
+  containerItemDisplay: {fileID: 0}
   containerUi: {fileID: 0}
   openIcon: {fileID: 0}
   takeIcon: {fileID: 0}
@@ -385,6 +398,9 @@ MonoBehaviour:
   isInteractive: 1
   hasUi: 1
   hasCustomInteraction: 0
+  hasCustomDisplay: 0
+  displays: []
+  numberDisplay: 0
 --- !u!114 &5055055840736840480
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -458,7 +474,6 @@ GameObject:
   - component: {fileID: 1904681422242535889}
   - component: {fileID: 3590185774197269497}
   - component: {fileID: 5344617163524279920}
-  - component: {fileID: 3882256163096065417}
   m_Layer: 14
   m_Name: MicrowaveDoor
   m_TagString: Untagged
@@ -528,16 +543,3 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!65 &3882256163096065417
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6704569312823119817}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.46840656, y: 0.4195372, z: 0.07090191}
-  m_Center: {x: -0.23, y: 0.000000037252903, z: 0.0071481643}

--- a/Assets/Content/Furniture/Storage/Fridge/fridge.prefab
+++ b/Assets/Content/Furniture/Storage/Fridge/fridge.prefab
@@ -291,7 +291,6 @@ GameObject:
   - component: {fileID: 1143501564299038576}
   - component: {fileID: 2621842397224039768}
   - component: {fileID: 6889282342120757457}
-  - component: {fileID: 2328583508320183080}
   m_Layer: 14
   m_Name: FridgeDoor
   m_TagString: Untagged
@@ -360,16 +359,3 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!65 &2328583508320183080
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5240830354732226920}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.91609585, y: 1.7028121, z: 0.18759535}
-  m_Center: {x: 0.44432867, y: 0.0014936328, z: 0.06708368}

--- a/Assets/Content/Furniture/Storage/Lockers/Locker.prefab
+++ b/Assets/Content/Furniture/Storage/Lockers/Locker.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 1290862293046061209}
   - component: {fileID: 5649368739873476284}
   - component: {fileID: 3491127253892038410}
-  - component: {fileID: 7187836497830633180}
   m_Layer: 14
   m_Name: LockerDoor
   m_TagString: Untagged
@@ -80,19 +79,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!65 &7187836497830633180
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1187284634159131357}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.4809304, y: 1.5629163, z: 0.09296769}
-  m_Center: {x: -0.25684312, y: 0.0006606579, z: -0.00045208633}
 --- !u!1 &2876708453869312076
 GameObject:
   m_ObjectHideFlags: 0
@@ -307,6 +293,7 @@ MonoBehaviour:
   attachedContainer: {fileID: 459396616207099591}
   containerSync: {fileID: 5428126529737719714}
   containerInteractive: {fileID: 595497627058202982}
+  containerItemDisplay: {fileID: 0}
   containerUi: {fileID: 0}
   openIcon: {fileID: 0}
   takeIcon: {fileID: 0}
@@ -326,6 +313,9 @@ MonoBehaviour:
   isInteractive: 1
   hasUi: 1
   hasCustomInteraction: 0
+  hasCustomDisplay: 0
+  displays: []
+  numberDisplay: 0
 --- !u!114 &459396616207099591
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/Furniture/Storage/Lockers/LockerSecure.prefab
+++ b/Assets/Content/Furniture/Storage/Lockers/LockerSecure.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 1290862293046061209}
   - component: {fileID: 5649368739873476284}
   - component: {fileID: 3491127253892038410}
-  - component: {fileID: 7187836497830633180}
   m_Layer: 14
   m_Name: LockerDoor
   m_TagString: Untagged
@@ -81,19 +80,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!65 &7187836497830633180
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1187284634159131357}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.4809304, y: 1.5629163, z: 0.09296769}
-  m_Center: {x: -0.25684312, y: 0.0006606579, z: -0.00045208633}
 --- !u!1 &2518288170112121279
 GameObject:
   m_ObjectHideFlags: 0
@@ -467,6 +453,7 @@ MonoBehaviour:
   attachedContainer: {fileID: 6769492389543985728}
   containerSync: {fileID: 2332770887244154971}
   containerInteractive: {fileID: 5268824920572218968}
+  containerItemDisplay: {fileID: 0}
   containerUi: {fileID: 0}
   openIcon: {fileID: 21300000, guid: ce4cb1c9f32561c4db2ae13a08e28987, type: 3}
   takeIcon: {fileID: 21300000, guid: d1f34343e08a14e48a856e409c355f32, type: 3}
@@ -486,6 +473,9 @@ MonoBehaviour:
   isInteractive: 1
   hasUi: 1
   hasCustomInteraction: 0
+  hasCustomDisplay: 0
+  displays: []
+  numberDisplay: 0
 --- !u!114 &6769492389543985728
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary

Remove BoxCollider from several door objects inside of prefabs to prevent player from clipping into object upon interacting with the door.

## Pictures/Videos (optional)

Before commit; clipping issue:
https://streamable.com/clx47b

After commit; no clipping issue:
https://streamable.com/8cel8y

## Changes to Files

All had BoxColliders removed from respective door.

Assets/Content/Furniture/Machines/Kitchen/Microwave/microwave.prefab
Assets/Content/Furniture/Storage/Fridge/fridge.prefab
Assets/Content/Furniture/Storage/Lockers/Locker.prefab
Assets/Content/Furniture/Storage/Lockers/LockerSecure.prefab

## Technical Notes (optional)

As I mentioned in #816 :

>Video demonstration:
>https://streamable.com/clx47b
>
>The simplest solution to this problem would be to remove the collider for the fridge door, since that is what clips the player into the fridges mesh and doesn't prevent the door from clipping through the player when opening (as seen in the video above at 0:12.)

Even prior to removing the collider, players clipped through the door as it opened. So we can have a collider which offers no benefit and introduces a bug, or no collider which offers no benefit but also doesn't introduce a bug.

## Known issues

N/A

## Fixes (optional)

Closes #816
