### PR TITLE
Item rendering improvements

### DIFF
--- a/Assets/Art/Shaders/ItemPreview.shader
+++ b/Assets/Art/Shaders/ItemPreview.shader
@@ -1,0 +1,81 @@
+Shader "Unlit/ItemPreview" 
+{
+    Properties
+    {
+        _MainTex ("Base (RGB)", 2D) = "white" {}
+        _EmissionMap ("Emission Map", 2D) = "black" {}
+        [HDR]_EmissionColor ("Emission Color", Color) = (0,0,0,0)
+
+    }
+
+    SubShader
+    {
+        Pass
+        {
+            Tags{ "RenderType" = "Opaque" "Queue" = "Opaque" }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            #pragma multi_compile_fog
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                float3 normal : NORMAL;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                half3 worldNormal : TEXCOORD1;
+                float4 worldPos : TEXCOORD2;
+                float3 viewDir : TEXCOORD3;
+                UNITY_FOG_COORDS(1)
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            sampler2D _EmissionMap;
+            float4 _EmissionColor;
+
+            v2f vert (appdata_t v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                o.worldNormal = UnityObjectToWorldNormal(v.normal);
+                o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+                o.viewDir = WorldSpaceViewDir(v.vertex);
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                float3 viewDir = normalize(i.viewDir);
+                fixed4 texColor = tex2D(_MainTex, i.texcoord);
+                fixed4 emission = tex2D(_EmissionMap, i.texcoord) * _EmissionColor;
+
+                float3 lightVector = (float3(-0.258, 0.22, 0.966));
+
+                float NdotL = dot(i.worldNormal, lightVector);
+                float light = (smoothstep(0, 0.75, NdotL) * 0.7 + 0.3);
+
+
+//                float4 rimDot = (1 - dot(viewDir, i.worldNormal));
+//                rimDot = (rimDot * rimDot * rimDot) * 0.15;
+
+                fixed3 color =+ texColor.rgb * light + emission;
+                fixed4 outcolor;
+                outcolor.rgb = color.rgb;
+                outcolor.a = texColor.a;
+                return outcolor;
+            }
+        ENDCG
+        }
+    }
+}

--- a/Assets/Art/Shaders/ItemPreview.shader
+++ b/Assets/Art/Shaders/ItemPreview.shader
@@ -63,13 +63,14 @@ Shader "Unlit/ItemPreview"
                 float3 lightVector = (float3(-0.258, 0.22, 0.966));
 
                 float NdotL = dot(i.worldNormal, lightVector);
-                float light = (smoothstep(0, 0.75, NdotL) * 0.7 + 0.3);
+                float light = (smoothstep(0, 0.75, NdotL) * 0.525 + 0.475);
+                float4 shadow = float4(0,0,0.04f,0) * (1 - light);
 
 
 //                float4 rimDot = (1 - dot(viewDir, i.worldNormal));
 //                rimDot = (rimDot * rimDot * rimDot) * 0.15;
 
-                fixed3 color =+ texColor.rgb * light + emission;
+                fixed3 color = texColor.rgb * light + shadow + emission;
                 fixed4 outcolor;
                 outcolor.rgb = color.rgb;
                 outcolor.a = texColor.a;

--- a/Assets/Art/Shaders/ItemPreview.shader.meta
+++ b/Assets/Art/Shaders/ItemPreview.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 278a1e571d5dd4543a3231e51bd9ecce
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/World/Palette05Emission.mat
+++ b/Assets/Content/World/Palette05Emission.mat
@@ -98,7 +98,7 @@ Material:
     - _DistortionEnabled: 1
     - _DistortionStrength: 4.8
     - _DistortionStrengthScaled: 0.48000002
-    - _DstBlend: 10
+    - _DstBlend: 0
     - _Emission: -26.74
     - _EmissionEnabled: 1
     - _EnableExternalAlpha: 0
@@ -110,7 +110,7 @@ Material:
     - _InvFade: 1
     - _LightingEnabled: 0
     - _Metallic: 0
-    - _Mode: 6
+    - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _QueueOffset: 0
@@ -121,11 +121,11 @@ Material:
     - _SoftParticlesFarFadeDistance: 1
     - _SoftParticlesNearFadeDistance: 0
     - _SpecularHighlights: 0
-    - _SrcBlend: 2
+    - _SrcBlend: 1
     - _Surface: 1
     - _UVSec: 0
     - _WorkflowMode: 0
-    - _ZWrite: 0
+    - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 0.85882354}
     - _CameraFadeParams: {r: 0, g: Infinity, b: 0, a: 0}

--- a/Assets/Engine/Inventory/Item.cs
+++ b/Assets/Engine/Inventory/Item.cs
@@ -125,7 +125,7 @@ namespace SS3D.Engine.Inventory
             RuntimePreviewGenerator.BackgroundColor = new Color(0, 0, 0, 0);
             RuntimePreviewGenerator.OrthographicMode = true;
 
-            Texture2D texture = RuntimePreviewGenerator.GenerateModelPreview(this.transform, 128, 128, false);
+            Texture2D texture = RuntimePreviewGenerator.GenerateModelPreviewWithShader(this.transform, Shader.Find("Unlit/ItemPreview"), null, 128, 128, false);
             sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(0.5f, 0.5f), 100);
             sprite.name = transform.name;
         }

--- a/Assets/Engine/Inventory/UI/ItemDisplay.cs
+++ b/Assets/Engine/Inventory/UI/ItemDisplay.cs
@@ -25,6 +25,8 @@ namespace SS3D.Engine.Inventory.UI
         private Vector3 startMousePosition;
         private Vector3 startPosition;
         private Image slotImage;
+        private Outline outlineInner;
+        private Outline outlineOuter;
 
 
         public Item Item
@@ -40,6 +42,18 @@ namespace SS3D.Engine.Inventory.UI
         public void Start()
         {
             slotImage = GetComponent<Image>();
+            if(!outlineInner)
+            {
+                outlineInner = ItemImage.gameObject.AddComponent<Outline>();
+                outlineInner.effectColor = new Color(0, 0, 0, 0.4f);
+                outlineInner.effectDistance = new Vector2(0.6f, 0.6f);
+            }
+            if(!outlineOuter)
+            {
+                outlineInner = ItemImage.gameObject.AddComponent<Outline>();
+                outlineInner.effectColor = new Color(0, 0, 0, 0.2f);
+                outlineInner.effectDistance = new Vector2(0.8f, 0.8f);
+            }
             if (item != null)
             {
                 UpdateDisplay();

--- a/Assets/Engine/Utilities/RuntimePreviewGenerator.cs
+++ b/Assets/Engine/Utilities/RuntimePreviewGenerator.cs
@@ -374,9 +374,15 @@ namespace SS3D.Engine.Utilities
 
 				renderCamera.targetTexture = null;
 
-				result = new Texture2D(width, height, m_backgroundColor.a < 1f ? TextureFormat.RGBA32 : TextureFormat.RGB24, false);
-				result.ReadPixels(new Rect(0, 0, width, height), 0, 0, false);
+				int textureLimitBackup = QualitySettings.masterTextureLimit; //workaround for mipmap generation;
+				QualitySettings.masterTextureLimit = 0;
+	
+				result = new Texture2D(width, height, m_backgroundColor.a < 1f ? TextureFormat.RGBA32 : TextureFormat.RGB24, true);
+				result.ReadPixels(new Rect(0, 0, width, height), 0, 0, true);
+				result.filterMode = FilterMode.Trilinear;
 				result.Apply(false, m_markTextureNonReadable);
+	
+				QualitySettings.masterTextureLimit = textureLimitBackup;
 
 				RenderTexture.active = temp;
 				RenderTexture.ReleaseTemporary(renderTex);


### PR DESCRIPTION
Improve the rendering for item previews in the inventory.

## Summary
Add item preview shader with fake lighting.
Enable mipmaps and filtering for item previews.
Add an outline effect to item display slots.
Fix emission transparency bug.

## Pictures/Videos
![items_3_old](https://user-images.githubusercontent.com/38957910/146490948-14f7b0b9-ca68-4e9a-868d-34a00d53fee0.PNG)
![items_3_new](https://user-images.githubusercontent.com/38957910/146490949-9b23976e-1b6b-4b02-a973-56108034c133.PNG)

## Known issues

Emission could still use some work.
Transparent items aren't supported properly yet.
The laser gun sprite has some kind of rendering issue, not caused by this PR.
