### PR TITLE
refactor adjacency shape logic into its own service

### DIFF
--- a/Assets/Content/Structures/Doors/Door.cs
+++ b/Assets/Content/Structures/Doors/Door.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System;
+using SS3D.Engine.Tile.TileRework.Connections;
 using UnityEditor;
 using SS3D.Engine.Tiles;
 using SS3D.Engine.Tiles.Connections;

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyBitmap.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyBitmap.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using SS3D.Engine.Tiles;
 
-namespace SS3D.Engine.Tiles.Connections
+namespace SS3D.Engine.Tile.TileRework.Connections
 {
     /// <summary>
     /// Bitmap used for calculating and storing adjacencies.
@@ -19,26 +17,13 @@ namespace SS3D.Engine.Tiles.Connections
 
             public CardinalInfo(byte bitmap)
             {
-                north = Adjacent(bitmap, Direction.North);
-                east = Adjacent(bitmap, Direction.East);
-                south = Adjacent(bitmap, Direction.South);
-                west = Adjacent(bitmap, Direction.West);
+                north = AdjacencyShapeResolver.Adjacent(bitmap, Direction.North);
+                east = AdjacencyShapeResolver.Adjacent(bitmap, Direction.East);
+                south = AdjacencyShapeResolver.Adjacent(bitmap, Direction.South);
+                west = AdjacencyShapeResolver.Adjacent(bitmap, Direction.West);
 
                 numConnections = north + east + south + west;
             }
-
-            // Checks if there are no cardinal connections
-            public bool IsO() => numConnections == 0;
-            // Checks for one connection
-            public bool IsU() => numConnections == 1;
-            // Checks for two opposite connections
-            public bool IsI() => numConnections == 2 && north == south;
-            // Checks for two adjacent connections
-            public bool IsL() => numConnections == 2 && north != south;
-            // Checks for three connections
-            public bool IsT() => numConnections == 3;
-            // Checks for four connections
-            public bool IsX() => numConnections == 4;
 
             /**
              * Gets the direction of the only positive connection.
@@ -76,7 +61,6 @@ namespace SS3D.Engine.Tiles.Connections
                 return south > 0 ? east > 0 ? Direction.SouthEast : Direction.SouthWest : west > 0 ? Direction.NorthWest : Direction.NorthEast;
             }
 
-            
             /**
              * Gets Vertical if north or south are connected, otherwise gets horizontal
              */
@@ -84,6 +68,12 @@ namespace SS3D.Engine.Tiles.Connections
             public Orientation GetFirstOrientation()
             {
                 return (Orientation)(east | west | (1 - (north | south)));
+            }
+
+            public override string ToString()
+            {
+                return
+                    $"North: {north}, East: {east}, South: {south}, West: {west}, Connection count: {numConnections}";
             }
         }
 
@@ -99,11 +89,6 @@ namespace SS3D.Engine.Tiles.Connections
             output |= (byte)((value ? 1 : 0) << (int)direction);
 
             return output;
-        }
-
-        public static int Adjacent(byte bitmap, Direction direction)
-        {
-            return (bitmap >> (int)direction) & 0x1;
         }
 
         public byte Connections { get; set; } = 0;
@@ -138,7 +123,7 @@ namespace SS3D.Engine.Tiles.Connections
          */
         public int Adjacent(Direction direction)
         {
-            return Adjacent(Connections, direction);
+            return AdjacencyShapeResolver.Adjacent(Connections, direction);
         }
     }
 }

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyShape.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyShape.cs
@@ -1,0 +1,37 @@
+﻿namespace SS3D.Engine.Tile.TileRework.Connections
+{
+    public enum AdjacencyShape
+    {
+        //Simple
+        O,
+        U,
+        I,
+        L,
+        T,
+        X,
+        //Complex
+        LNone,
+        LSingle,
+        TNone,
+        TSingleLeft,
+        TSingleRight,
+        TDouble,
+        XNone,
+        XSingle,
+        XOpposite,
+        XSide,
+        XTriple,
+        XQuad,
+        //Offset
+        UNorth,
+        USouth,
+        LNorthEast,
+        LNorthWest,
+        LSouthEast,
+        LSouthWest,
+        TNorthEastWest,
+        TNorthSouthWest,
+        TNorthSouthEast,
+        TSouthWestEast,
+    }
+}

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyShape.cs.meta
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyShape.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7cb0f445b91e43df8515dbf8772ca37b
+timeCreated: 1639945183

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyShapeResolver.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyShapeResolver.cs
@@ -1,0 +1,171 @@
+﻿using SS3D.Engine.Tiles;
+using UnityEngine;
+
+namespace SS3D.Engine.Tile.TileRework.Connections
+{
+    /// <summary>
+    /// Class used for picking the correct connector shape based on adjacent tiles.
+    /// </summary>
+    public static class AdjacencyShapeResolver
+    {
+        public static AdjacencyShape GetSimpleShape(AdjacencyBitmap.CardinalInfo cardinalInfo)
+        {
+            int connectionCount = cardinalInfo.numConnections;
+            if (connectionCount == 0)
+            {
+                return AdjacencyShape.O;
+            }
+
+            if (connectionCount == 1)
+            {
+                return AdjacencyShape.U;
+            }
+
+            //When two connections, checks if they're opposite or adjacent
+            if (connectionCount == 2)
+            {
+                return cardinalInfo.north == cardinalInfo.south ? AdjacencyShape.I : AdjacencyShape.L;
+            }
+
+            if (connectionCount == 3)
+            {
+                return AdjacencyShape.T;
+            }
+
+            if (cardinalInfo.numConnections == 4)
+            {
+                return AdjacencyShape.X;
+            }
+
+            Debug.LogError($"Could not resolve Simple Adjacency Shape for given Cardinal Info - {cardinalInfo}");
+            return AdjacencyShape.O;
+        }
+
+        //TODO: Simplify when diagonal support for CardinalInfo is added. Probably will be able to get rid of all the bitfields
+        public static AdjacencyShape GetAdvancedShape(AdjacencyBitmap.CardinalInfo cardinalInfo, byte connections)
+        {
+            int connectionCount = cardinalInfo.numConnections;
+            if (connectionCount == 0)
+            {
+                return AdjacencyShape.O;
+            }
+
+            if (connectionCount == 1)
+            {
+                return AdjacencyShape.U;
+            }
+
+            //When two connections and they're opposite
+            if (connectionCount == 2 && cardinalInfo.north == cardinalInfo.south)
+            {
+                return AdjacencyShape.I;
+            }
+
+            //When two connections and they're adjacent
+            if (connectionCount == 2 && cardinalInfo.north != cardinalInfo.south)
+            {
+                // Determine lSolid or lCorner by finding whether the area between the two connections is filled
+                // We check for if any of the following bitfields matches the connection bitfield
+                // N+NE+E = 0/1/2, E+SE+S = 2/3/4, S+SW+W = 4/5/6, W+NW+N = 6/7/0
+                bool isFilled = (connections & 0b00000111) == 0b00000111 ||
+                                (connections & 0b00011100) == 0b00011100 ||
+                                (connections & 0b01110000) == 0b01110000 ||
+                                (connections & 0b11000001) == 0b11000001;
+                return isFilled ? AdjacencyShape.LSingle : AdjacencyShape.LNone;
+            }
+
+            if (connectionCount == 3)
+            {
+                // We make another bitfield (noticing a pattern?). 0x0 means no fills, 0x1 means right corner filled, 0x2 means left corner filled,
+                // therefore both corners filled = 0x3.
+                int corners = ((1 - cardinalInfo.north) * 2 | (1 - cardinalInfo.east)) *
+                              Adjacent(connections, Direction.SouthWest)
+                              + ((1 - cardinalInfo.east) * 2 | (1 - cardinalInfo.south)) *
+                              Adjacent(connections, Direction.NorthWest)
+                              + ((1 - cardinalInfo.south) * 2 | (1 - cardinalInfo.west)) *
+                              Adjacent(connections, Direction.NorthEast)
+                              + ((1 - cardinalInfo.west) * 2 | (1 - cardinalInfo.north)) *
+                              Adjacent(connections, Direction.SouthEast);
+                return corners == 0 ? AdjacencyShape.TNone
+                    : corners == 1 ? AdjacencyShape.TSingleLeft
+                    : corners == 2 ? AdjacencyShape.TSingleRight
+                    : AdjacencyShape.TDouble;
+            }
+
+            //This sneaky piece of code uses the cardinal info to store diagonals by rotating everything -45 degrees
+            //NE -> N, SW -> S, etc.
+            var diagonals = new AdjacencyBitmap.CardinalInfo((byte) (connections >> 1));
+
+            switch (diagonals.numConnections)
+            {
+                case 0:
+                    return AdjacencyShape.XNone;
+                case 1:
+                    return AdjacencyShape.XSingle;
+                case 2:
+                    return diagonals.north == diagonals.south ? AdjacencyShape.XOpposite : AdjacencyShape.XSide;
+                case 3:
+                    return AdjacencyShape.XTriple;
+                case 4:
+                    return AdjacencyShape.XQuad;
+                default:
+                    Debug.LogError(
+                        $"Could not resolve Advanced Adjacency Shape for given Cardinal Info - {cardinalInfo} and Connections map - {connections}");
+                    return AdjacencyShape.XQuad;
+            }
+        }
+
+        public static AdjacencyShape GetOffsetShape(AdjacencyBitmap.CardinalInfo cardinalInfo)
+        {
+            int connectionCount = cardinalInfo.numConnections;
+            if (connectionCount == 0)
+            {
+                return AdjacencyShape.O;
+            }
+            
+            if (connectionCount == 1)
+            {
+                return cardinalInfo.north > 0 || cardinalInfo.east > 0 ? AdjacencyShape.UNorth : AdjacencyShape.USouth;
+            }
+            
+            //When two connections and they're opposite
+            if (connectionCount == 2 && cardinalInfo.north == cardinalInfo.south)
+            {
+                return AdjacencyShape.I;
+            }
+            
+            //When two connections and they're adjacent
+            if (connectionCount == 2 && cardinalInfo.north != cardinalInfo.south)
+            {
+                Direction sides = cardinalInfo.GetCornerDirection();
+                return sides == Direction.NorthEast ? AdjacencyShape.LNorthWest
+                    : sides == Direction.SouthEast ? AdjacencyShape.LNorthEast
+                    : sides == Direction.SouthWest ? AdjacencyShape.LSouthEast
+                    : AdjacencyShape.LSouthWest;
+            }
+
+            if (connectionCount == 3)
+            {
+                Direction notside = cardinalInfo.GetOnlyNegative();
+                return notside == Direction.North ? AdjacencyShape.TNorthSouthEast
+                    : notside == Direction.East ? AdjacencyShape.TSouthWestEast
+                    : notside == Direction.South ? AdjacencyShape.TNorthSouthWest
+                    : AdjacencyShape.TNorthEastWest;
+            }
+
+            if (connectionCount == 4)
+            {
+                return AdjacencyShape.X;
+            }
+            
+            Debug.LogError(
+                $"Could not resolve Offset Adjacency Shape for given Cardinal Info - {cardinalInfo}");
+            return AdjacencyShape.X;
+        }
+
+        public static int Adjacent(byte bitmap, Direction direction)
+        {
+            return (bitmap >> (int) direction) & 0x1;
+        }
+    }
+}

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyShapeResolver.cs.meta
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyShapeResolver.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a6d29063e42746969eae7600441d2f9b
+timeCreated: 1639944930

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/AdvancedAdjacency.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/AdvancedAdjacency.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using SS3D.Engine.Tile.TileRework.Connections;
 using UnityEngine;
 
 namespace SS3D.Engine.Tiles.Connections
@@ -56,118 +57,119 @@ namespace SS3D.Engine.Tiles.Connections
 
             float rotation = 0.0f;
             Mesh mesh;
-            if (cardinalInfo.IsO())
+
+            AdjacencyShape shape = AdjacencyShapeResolver.GetAdvancedShape(cardinalInfo, adjacents.Connections);
+            //TODO: remove once CardinalInfo diagonals implemented
+            var diagonals = new AdjacencyBitmap.CardinalInfo((byte)(adjacents.Connections >> 1));
+            switch (shape)
             {
-                mesh = o;
+                case AdjacencyShape.O:
+                    mesh = o;
+                    break;
+                case AdjacencyShape.U:
+                    mesh = u;
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyPositive());
+                    break;
+                case AdjacencyShape.I:
+                    mesh = i;
+                    rotation = TileHelper.AngleBetween(Orientation.Vertical, cardinalInfo.GetFirstOrientation());
+                    break;
+                case AdjacencyShape.LNone:
+                    mesh = lNone;
+                    rotation = TileHelper.AngleBetween(Direction.NorthEast, cardinalInfo.GetCornerDirection());
+                    break;
+                case AdjacencyShape.LSingle:
+                    mesh = lSingle;
+                    rotation = TileHelper.AngleBetween(Direction.NorthEast, cardinalInfo.GetCornerDirection());
+                    break;
+                case AdjacencyShape.TNone:
+                    mesh = tNone;
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyNegative());
+                    break;
+                case AdjacencyShape.TSingleLeft:
+                    mesh = tSingleLeft;
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyNegative());
+                    break;
+                case AdjacencyShape.TSingleRight:
+                    mesh = tSingleRight;
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyNegative());
+                    break;
+                case AdjacencyShape.TDouble:
+                    mesh = tDouble;
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyNegative());
+                    break;
+                case AdjacencyShape.XNone:
+                    mesh = xNone;
+                    break;
+                case AdjacencyShape.XSingle:
+                    mesh = xSingle;
+                    rotation = TileHelper.AngleBetween(Direction.North, diagonals.GetOnlyPositive());
+                    break;
+                case AdjacencyShape.XOpposite:
+                    mesh = xOpposite;
+                    rotation = TileHelper.AngleBetween(Orientation.Vertical, diagonals.GetFirstOrientation());
+                    break;
+                case AdjacencyShape.XSide:
+                    mesh = xSide;
+                    rotation = TileHelper.AngleBetween(Direction.NorthWest, diagonals.GetCornerDirection());
+                    break;
+                case AdjacencyShape.XTriple:
+                    mesh = xTriple;
+                    rotation = TileHelper.AngleBetween(Direction.East, diagonals.GetOnlyNegative());
+                    break;
+                case AdjacencyShape.XQuad:
+                    mesh = xQuad;
+                    break;
+                default:
+                    Debug.LogError($"Received unexpected shape from advanced shape resolver: {shape}");
+                    mesh = o;
+                    break;
             }
-            else if (cardinalInfo.IsU())
+
+            //If someone knows of a more elegant way to do the same without switching the same variable twice, I'd like to hear it :)
+            if (opaque)
             {
-                mesh = u;
-                rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyPositive());
-
-                if (opaque)
+                switch (shape)
                 {
-                    viewObstacles[0].SetActive(false);
-                    viewObstacles[1].SetActive(false);
-                    viewObstacles[2].SetActive(true);
-                    viewObstacles[3].SetActive(false);
-                }
-            }
-            else if (cardinalInfo.IsI())
-            {
-                mesh = i;
-                rotation = TileHelper.AngleBetween(Orientation.Vertical, cardinalInfo.GetFirstOrientation());
-
-                if (opaque)
-                {
-                    viewObstacles[0].SetActive(false);
-                    viewObstacles[1].SetActive(false);
-                    viewObstacles[2].SetActive(true);
-                    viewObstacles[3].SetActive(true);
-                }
-            }
-            else if (cardinalInfo.IsL())
-            {
-                // Determine lSolid or lCorner by finding whether the area between the two connections is filled
-                // We check for if any of the following bitfields matches the connection bitfield
-                // N+NE+E = 0/1/2, E+SE+S = 2/3/4, S+SW+W = 4/5/6, W+NW+N = 6/7/0
-                bool isFilled = (adjacents.Connections & 0b00000111) == 0b00000111 || (adjacents.Connections & 0b00011100) == 0b00011100 || (adjacents.Connections & 0b01110000) == 0b01110000 || (adjacents.Connections & 0b11000001) == 0b11000001;
-                mesh = isFilled ? lSingle : lNone;
-                rotation = TileHelper.AngleBetween(Direction.NorthEast, cardinalInfo.GetCornerDirection());
-
-                if (opaque)
-                {
-                    viewObstacles[0].SetActive(false);
-                    viewObstacles[1].SetActive(true);
-                    viewObstacles[2].SetActive(true);
-                    viewObstacles[3].SetActive(false);
-                }
-            }
-            else if (cardinalInfo.IsT())
-            {
-                // We make another bitfield (noticing a pattern?). 0x0 means no fills, 0x1 means right corner filled, 0x2 means left corner filled,
-                // therefore both corners filled = 0x3.
-                int corners = ((1 - cardinalInfo.north) * 2 | (1 - cardinalInfo.east)) * adjacents.Adjacent(Direction.SouthWest)
-                            + ((1 - cardinalInfo.east) * 2 | (1 - cardinalInfo.south)) * adjacents.Adjacent(Direction.NorthWest)
-                            + ((1 - cardinalInfo.south) * 2 | (1 - cardinalInfo.west)) * adjacents.Adjacent(Direction.NorthEast)
-                            + ((1 - cardinalInfo.west) * 2 | (1 - cardinalInfo.north)) * adjacents.Adjacent(Direction.SouthEast);
-                mesh = corners == 0 ? tNone
-                    : corners == 1 ? tSingleLeft
-                    : corners == 2 ? tSingleRight
-                    : tDouble;
-
-                rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyNegative());
-
-                if (opaque)
-                {
-                    viewObstacles[0].SetActive(true);
-                    viewObstacles[1].SetActive(true);
-                    viewObstacles[2].SetActive(corners >= 3);
-                    viewObstacles[3].SetActive(true);
-                }
-            }
-            else
-            {
-                // This sneaky piece of code uses the cardinal info to store diagonals by rotating everything -45 degrees
-                // NE -> N, SW -> S, etc.
-                var diagonals = new AdjacencyBitmap.CardinalInfo((byte)(adjacents.Connections >> 1));
-
-                switch (diagonals.numConnections)
-                {
-                    case 0:
-                        mesh = xNone;
+                    case AdjacencyShape.U:
+                        viewObstacles[0].SetActive(false);
+                        viewObstacles[1].SetActive(false);
+                        viewObstacles[2].SetActive(true);
+                        viewObstacles[3].SetActive(false);
                         break;
-                    case 1:
-                        mesh = xSingle;
-                        rotation = TileHelper.AngleBetween(Direction.North, diagonals.GetOnlyPositive());
+                    case AdjacencyShape.I:
+                        viewObstacles[0].SetActive(false);
+                        viewObstacles[1].SetActive(false);
+                        viewObstacles[2].SetActive(true);
+                        viewObstacles[3].SetActive(true);
                         break;
-                    case 2:
-                        if (diagonals.north == diagonals.south)
-                        {
-                            mesh = xOpposite;
-                            rotation = TileHelper.AngleBetween(Orientation.Vertical, diagonals.GetFirstOrientation());
-                        }
-                        else
-                        {
-                            mesh = xSide;
-                            rotation = TileHelper.AngleBetween(Direction.NorthWest, diagonals.GetCornerDirection());
-                        }
+                    case AdjacencyShape.LNone:
+                    case AdjacencyShape.LSingle:
+                        viewObstacles[0].SetActive(false);
+                        viewObstacles[1].SetActive(true);
+                        viewObstacles[2].SetActive(true);
+                        viewObstacles[3].SetActive(false);
                         break;
-                    case 3:
-                        mesh = xTriple;
-                        rotation = TileHelper.AngleBetween(Direction.East, diagonals.GetOnlyNegative());
+                    case AdjacencyShape.TNone:
+                    case AdjacencyShape.TSingleLeft:
+                    case AdjacencyShape.TSingleRight:
+                        viewObstacles[0].SetActive(true);
+                        viewObstacles[1].SetActive(true);
+                        viewObstacles[2].SetActive(false);
+                        viewObstacles[3].SetActive(true);
                         break;
-                    default:
-                        mesh = xQuad;
+                    case AdjacencyShape.TDouble:
+                    case AdjacencyShape.XNone:
+                    case AdjacencyShape.XSingle:
+                    case AdjacencyShape.XOpposite:
+                    case AdjacencyShape.XSide:
+                    case AdjacencyShape.XTriple:
+                    case AdjacencyShape.XQuad:
+                        viewObstacles[0].SetActive(true);
+                        viewObstacles[1].SetActive(true);
+                        viewObstacles[2].SetActive(true);
+                        viewObstacles[3].SetActive(true);
                         break;
-
-                }
-                if (opaque)
-                {
-                    viewObstacles[0].SetActive(true);
-                    viewObstacles[1].SetActive(true);
-                    viewObstacles[2].SetActive(true);
-                    viewObstacles[3].SetActive(true);
                 }
             }
 

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/OffsetAdjacency.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/OffsetAdjacency.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+using SS3D.Engine.Tiles;
+using SS3D.Engine.Tiles.Connections;
 using UnityEngine;
 
-namespace SS3D.Engine.Tiles.Connections
+namespace SS3D.Engine.Tile.TileRework.Connections.AdjacencyTypes
 {
     /// <summary>
     /// Adjacency type used for objects that are not centred on a tile. Examples that use this are pipes (not the middle layer)
@@ -27,7 +27,6 @@ namespace SS3D.Engine.Tiles.Connections
             tSWE,
             x
         }
-
 
         [Tooltip("A mesh where no edges are connected")]
         public Mesh o;
@@ -67,68 +66,77 @@ namespace SS3D.Engine.Tiles.Connections
             float rotation = 0.0f;
             Mesh mesh;
 
-            if (cardinalInfo.IsO())
+            AdjacencyShape shape = AdjacencyShapeResolver.GetOffsetShape(cardinalInfo);
+            switch (shape)
             {
-                mesh = o;
-                orientation = OffsetOrientation.o;
-            }
-            else if (cardinalInfo.IsU())
-            {
-                if (cardinalInfo.north > 0 || cardinalInfo.east > 0)
-                {
+                case AdjacencyShape.O:
+                    mesh = o;
+                    orientation = OffsetOrientation.o;
+                    break;
+                case AdjacencyShape.UNorth:
                     mesh = uNorth;
                     orientation = OffsetOrientation.uNorth;
                     rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyPositive());
-                }
-                else
-                {
+                    break;
+                case AdjacencyShape.USouth:
                     mesh = uSouth;
                     orientation = OffsetOrientation.uSouth;
                     rotation = TileHelper.AngleBetween(Direction.South, cardinalInfo.GetOnlyPositive());
-                }
-            }
-            else if (cardinalInfo.IsI())
-            {
-                mesh = i;
-                orientation = OffsetOrientation.i;
-                rotation = TileHelper.AngleBetween(Orientation.Vertical, cardinalInfo.GetFirstOrientation());
-            }
-            else if (cardinalInfo.IsL())
-            {
-                Direction sides = cardinalInfo.GetCornerDirection();
-                mesh = sides == Direction.NorthEast ? lNW
-                    : sides == Direction.SouthEast ? lNE
-                    : sides == Direction.SouthWest ? lSE
-                    : lSW;
-
-                orientation = sides == Direction.NorthEast ? OffsetOrientation.lNW
-                    : sides == Direction.SouthEast ? OffsetOrientation.lSE
-                    : sides == Direction.SouthWest ? OffsetOrientation.lSW
-                    : OffsetOrientation.lNW;
-
-                rotation = 90;
-            }
-            else if (cardinalInfo.IsT())
-            {
-                Direction notside = cardinalInfo.GetOnlyNegative();
-                mesh = notside == Direction.North ? tNSE
-                    : notside == Direction.East ? tSWE
-                    : notside == Direction.South ? tNSW
-                    : tNEW;
-
-                orientation = notside == Direction.North ? OffsetOrientation.tSWE
-                    : notside == Direction.East ? OffsetOrientation.tNSW
-                    : notside == Direction.South ? OffsetOrientation.tNEW
-                    : OffsetOrientation.tNSE;
-
-                rotation = 90;
-            }
-            else // Must be X
-            {
-                mesh = x;
-                orientation = OffsetOrientation.x;
-
-                rotation = 90;
+                    break;
+                case AdjacencyShape.I:
+                    mesh = i;
+                    orientation = OffsetOrientation.i;
+                    rotation = TileHelper.AngleBetween(Orientation.Vertical, cardinalInfo.GetFirstOrientation());
+                    break;
+                case AdjacencyShape.LNorthWest:
+                    mesh = lNW;
+                    orientation = OffsetOrientation.lNW;
+                    rotation = 90;
+                    break;
+                case AdjacencyShape.LNorthEast:
+                    mesh = lNE;
+                    orientation = OffsetOrientation.lSE;
+                    rotation = 90;
+                    break;
+                case AdjacencyShape.LSouthEast:
+                    mesh = lSE;
+                    orientation = OffsetOrientation.lSW;
+                    rotation = 90;
+                    break;
+                case AdjacencyShape.LSouthWest:
+                    mesh = lSW;
+                    orientation = OffsetOrientation.lNW;
+                    rotation = 90;
+                    break;
+                case AdjacencyShape.TNorthSouthEast:
+                    mesh = tNSE;
+                    orientation = OffsetOrientation.tSWE;
+                    rotation = 90;
+                    break;
+                case AdjacencyShape.TSouthWestEast:
+                    mesh = tSWE;
+                    orientation = OffsetOrientation.tNSW;
+                    rotation = 90;
+                    break;
+                case AdjacencyShape.TNorthSouthWest:
+                    mesh = tNSW;
+                    orientation = OffsetOrientation.tNEW;
+                    rotation = 90;
+                    break;
+                case AdjacencyShape.TNorthEastWest:
+                    mesh = tNEW;
+                    orientation = OffsetOrientation.tNSE;
+                    rotation = 90;
+                    break;
+                case AdjacencyShape.X:
+                    mesh = x;
+                    orientation = OffsetOrientation.x;
+                    rotation = 90;
+                    break;
+                default:
+                    Debug.LogError($"Received unexpected shape from offset shape resolver: {shape}");
+                    mesh = o;
+                    break;
             }
 
             return new MeshDirectionInfo { mesh = mesh, rotation = rotation };

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/SimpleAdjacency.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/SimpleAdjacency.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+using SS3D.Engine.Tiles;
+using SS3D.Engine.Tiles.Connections;
 using UnityEngine;
 
-namespace SS3D.Engine.Tiles.Connections
+namespace SS3D.Engine.Tile.TileRework.Connections.AdjacencyTypes
 {
     /// <summary>
     /// Adjacency type used for objects that do not require complex connections.
@@ -33,30 +33,36 @@ namespace SS3D.Engine.Tiles.Connections
             float rotation = 0.0f;
             Mesh mesh;
 
-            if (cardinalInfo.IsO())
-                mesh = o;
-            else if (cardinalInfo.IsU())
+            AdjacencyShape shape = AdjacencyShapeResolver.GetSimpleShape(cardinalInfo);
+            switch (shape)
             {
-                mesh = u;
-                rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyPositive());
+                case AdjacencyShape.O:
+                    mesh = o;
+                    break;
+                case AdjacencyShape.U:
+                    mesh = u;
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyPositive());
+                    break;
+                case AdjacencyShape.I:
+                    mesh = i;
+                    rotation = TileHelper.AngleBetween(Orientation.Vertical, cardinalInfo.GetFirstOrientation());
+                    break;
+                case AdjacencyShape.L:
+                    mesh = l;
+                    rotation = TileHelper.AngleBetween(Direction.NorthEast, cardinalInfo.GetCornerDirection());
+                    break;
+                case AdjacencyShape.T:
+                    mesh = t;
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyNegative());
+                    break;
+                case AdjacencyShape.X:
+                    mesh = x;
+                    break;
+                default:
+                    Debug.LogError($"Received unexpected shape from simple shape resolver: {shape}");
+                    mesh = o;
+                    break;
             }
-            else if (cardinalInfo.IsI())
-            {
-                mesh = i;
-                rotation = TileHelper.AngleBetween(Orientation.Vertical, cardinalInfo.GetFirstOrientation());
-            }
-            else if (cardinalInfo.IsL())
-            {
-                mesh = l;
-                rotation = TileHelper.AngleBetween(Direction.NorthEast, cardinalInfo.GetCornerDirection());
-            }
-            else if (cardinalInfo.IsT())
-            {
-                mesh = t;
-                rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.GetOnlyNegative());
-            }
-            else // Must be X
-                mesh = x;
 
             return new MeshDirectionInfo { mesh = mesh, rotation = rotation };
         }

--- a/Assets/Engine/Tile/TileRework/Connections/MultiAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/MultiAdjacencyConnector.cs
@@ -1,9 +1,10 @@
 ﻿using Mirror;
-using System.Collections;
-using System.Collections.Generic;
+using SS3D.Engine.Tile.TileRework.Connections.AdjacencyTypes;
+using SS3D.Engine.Tiles;
+using SS3D.Engine.Tiles.Connections;
 using UnityEngine;
 
-namespace SS3D.Engine.Tiles.Connections
+namespace SS3D.Engine.Tile.TileRework.Connections
 {
     /// <summary>
     /// Main adjacency connector class that should fulfill the majority of the use cases. This class ensures that similar objects will have their meshes seamlessly connect to each other.
@@ -233,7 +234,7 @@ namespace SS3D.Engine.Tiles.Connections
                 // Check for specific
                 isConnected &= (placedObject.GetSpecificType() == specificType || specificType == "");
 
-                isConnected &= (AdjacencyBitmap.Adjacent(blockedConnections, dir) == 0);
+                isConnected &= (AdjacencyShapeResolver.Adjacent(blockedConnections, dir) == 0);
             }
             bool isUpdated = adjacents.UpdateDirection(dir, isConnected, true);
             SyncAdjacentConnections(adjacents.Connections, adjacents.Connections);

--- a/Assets/Engine/Tile/TileRework/Editor/AdjacencyEditor.cs
+++ b/Assets/Engine/Tile/TileRework/Editor/AdjacencyEditor.cs
@@ -1,9 +1,9 @@
-﻿using SS3D.Engine.Tiles.Connections;
-using System;
+﻿using SS3D.Engine.Tile.TileRework.Connections;
+using SS3D.Engine.Tiles;
 using UnityEditor;
 using UnityEngine;
 
-namespace SS3D.Engine.Tiles.Editor.TileMapEditor
+namespace SS3D.Engine.Tile.TileRework.Editor
 {
     /// <summary>
     /// Custom editor used for setting blocked connections.
@@ -106,7 +106,7 @@ namespace SS3D.Engine.Tiles.Editor.TileMapEditor
 
             for (Direction direction = Direction.North; direction <= Direction.NorthWest; direction++)
             {
-                result[(int)direction] = AdjacencyBitmap.Adjacent(bitmap, direction) != 0;
+                result[(int)direction] = AdjacencyShapeResolver.Adjacent(bitmap, direction) != 0;
             }
 
             return result;


### PR DESCRIPTION
## Summary

* Created new AdjacencyShape enum to store possible "shapes" connectors can take
* Created AdjacencyShapeResolver, a service class meant containing all logic related to deciding which shape to use
* Refactored relevant classes to use the new service
* Minor namespace and style fixes in files that were touched

## Technical Notes (optional)
This allows for easier management of future shapes used in new types of connectors. Additionally, it makes further refactors to AdjacencyBitmap and other adjacency classes easier.

## Fixes (optional)
Closes #864
