### PR TITLE
remove outdated orientation enum

### DIFF
--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyBitmap.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyBitmap.cs
@@ -61,15 +61,6 @@ namespace SS3D.Engine.Tile.TileRework.Connections
                 return south > 0 ? east > 0 ? Direction.SouthEast : Direction.SouthWest : west > 0 ? Direction.NorthWest : Direction.NorthEast;
             }
 
-            /**
-             * Gets Vertical if north or south are connected, otherwise gets horizontal
-             */
-            
-            public Orientation GetFirstOrientation()
-            {
-                return (Orientation)(east | west | (1 - (north | south)));
-            }
-
             public override string ToString()
             {
                 return

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/AdvancedAdjacency.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/AdvancedAdjacency.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using SS3D.Engine.Tile.TileRework.Connections;
+using SS3D.Engine.Tiles;
+using SS3D.Engine.Tiles.Connections;
 using UnityEngine;
 
-namespace SS3D.Engine.Tiles.Connections
+namespace SS3D.Engine.Tile.TileRework.Connections.AdjacencyTypes
 {
     /// <summary>
     /// Adjacency type used for objects that do require complex connections.
@@ -72,7 +71,7 @@ namespace SS3D.Engine.Tiles.Connections
                     break;
                 case AdjacencyShape.I:
                     mesh = i;
-                    rotation = TileHelper.AngleBetween(Orientation.Vertical, cardinalInfo.GetFirstOrientation());
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.north == 1 ? Direction.North : Direction.East);
                     break;
                 case AdjacencyShape.LNone:
                     mesh = lNone;
@@ -107,7 +106,7 @@ namespace SS3D.Engine.Tiles.Connections
                     break;
                 case AdjacencyShape.XOpposite:
                     mesh = xOpposite;
-                    rotation = TileHelper.AngleBetween(Orientation.Vertical, diagonals.GetFirstOrientation());
+                    rotation = TileHelper.AngleBetween(Direction.North, diagonals.north == 1 ? Direction.North : Direction.East);
                     break;
                 case AdjacencyShape.XSide:
                     mesh = xSide;

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/OffsetAdjacency.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/OffsetAdjacency.cs
@@ -86,7 +86,7 @@ namespace SS3D.Engine.Tile.TileRework.Connections.AdjacencyTypes
                 case AdjacencyShape.I:
                     mesh = i;
                     orientation = OffsetOrientation.i;
-                    rotation = TileHelper.AngleBetween(Orientation.Vertical, cardinalInfo.GetFirstOrientation());
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.north == 1 ? Direction.North : Direction.East);
                     break;
                 case AdjacencyShape.LNorthWest:
                     mesh = lNW;

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/SimpleAdjacency.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/SimpleAdjacency.cs
@@ -45,7 +45,7 @@ namespace SS3D.Engine.Tile.TileRework.Connections.AdjacencyTypes
                     break;
                 case AdjacencyShape.I:
                     mesh = i;
-                    rotation = TileHelper.AngleBetween(Orientation.Vertical, cardinalInfo.GetFirstOrientation());
+                    rotation = TileHelper.AngleBetween(Direction.North, cardinalInfo.north == 1 ? Direction.North : Direction.East);
                     break;
                 case AdjacencyShape.L:
                     mesh = l;

--- a/Assets/Engine/Tile/TileRework/Tile.cs
+++ b/Assets/Engine/Tile/TileRework/Tile.cs
@@ -40,12 +40,6 @@ namespace SS3D.Engine.Tiles
         NorthWest = 7,
     }
 
-    public enum Orientation
-    {
-        Vertical = 0, // North-South
-        Horizontal = 1 // East-West
-    }
-
     public static class TileHelper
     {
         private static TileLayer[] tileLayers;
@@ -115,11 +109,6 @@ namespace SS3D.Engine.Tiles
         public static float AngleBetween(Direction from, Direction to)
         {
             return ((int)to - (int)from) * 45.0f;
-        }
-
-        public static float AngleBetween(Orientation from, Orientation to)
-        {
-            return ((int)to - (int)from) * 90.0f;
         }
 
         public static Direction GetRelativeDirection(Direction to, Direction from)


### PR DESCRIPTION
## Summary
* removes Orientation (vertical/horizontal) from Tile.cs
* updates adjacency classes using Orientation for rotation calculations to use Direction instead

## Fixes (optional)
closes #866