### PR TITLE
update tile object so generic and specific types to enums

### DIFF
--- a/Assets/Content/Items/Functional/Tools/Construction/Crowbar.cs
+++ b/Assets/Content/Items/Functional/Tools/Construction/Crowbar.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using SS3D.Content.Systems.Interactions;
 using SS3D.Engine.Interactions;
 using SS3D.Engine.Inventory;
+using SS3D.Engine.Tile.TileRework;
 using SS3D.Engine.Tiles;
 using UnityEngine;
 
@@ -15,7 +16,7 @@ namespace SS3D.Content.Items.Functional.Tools.Generic
 
 	// nope
 	// should be removed later once we rework construction
-        public TileObjectSO WallToConstruct;
+        public TileObjectSo WallToConstruct;
 
 	// Delay to create/destroy stuff
         public float Delay;

--- a/Assets/Content/Items/Functional/Tools/Construction/Welders/Welder.cs
+++ b/Assets/Content/Items/Functional/Tools/Construction/Welders/Welder.cs
@@ -5,6 +5,7 @@ using Mirror;
 using SS3D.Content.Systems.Interactions;
 using SS3D.Engine.Interactions;
 using SS3D.Engine.Inventory;
+using SS3D.Engine.Tile.TileRework;
 using SS3D.Engine.Tiles;
 
 namespace SS3D.Content.Items.Functional.Tools
@@ -21,13 +22,13 @@ namespace SS3D.Content.Items.Functional.Tools
         [SerializeField]
 
 	// for the temporary construction stuff
-        private TileObjectSO commonWall = null;
+        private TileObjectSo commonWall = null;
         [SerializeField]
-        private TileObjectSO reinforcedWall = null;
+        private TileObjectSo reinforcedWall = null;
         [SerializeField]
-        private TileObjectSO commonFloor = null;
+        private TileObjectSo commonFloor = null;
         [SerializeField]
-        private TileObjectSO reinforcedFloor = null;
+        private TileObjectSo reinforcedFloor = null;
 
 	// the prefab for the loading bar that is spawned when we start an interaction
         public GameObject LoadingBarPrefab;
@@ -38,14 +39,14 @@ namespace SS3D.Content.Items.Functional.Tools
         public Sprite turnOnIcon;
         public Sprite constructIcon;
 
-        private Dictionary<TileObjectSO, TileObjectSO> reinforceDict;
+        private Dictionary<TileObjectSo, TileObjectSo> reinforceDict;
 
         public bool CanIgnite => GetState();
 
         public override void Start()
         {
             base.Start();
-            reinforceDict = new Dictionary<TileObjectSO, TileObjectSO> {{commonWall, reinforcedWall}, {commonFloor, reinforcedFloor}};
+            reinforceDict = new Dictionary<TileObjectSo, TileObjectSo> {{commonWall, reinforcedWall}, {commonFloor, reinforcedFloor}};
             GenerateNewIcon();
         }
 

--- a/Assets/Content/Items/Functional/Tools/Construction/Wrench.cs
+++ b/Assets/Content/Items/Functional/Tools/Construction/Wrench.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using SS3D.Content.Systems.Interactions;
 using SS3D.Engine.Interactions;
 using SS3D.Engine.Inventory;
+using SS3D.Engine.Tile.TileRework;
 using SS3D.Engine.Tiles;
 using UnityEngine;
 
@@ -14,7 +15,7 @@ namespace SS3D.Content.Items.Functional.Tools.Generic
         public GameObject LoadingBarPrefab;
 
 	// nope
-        public TileObjectSO ObjectToConstruct;
+        public TileObjectSo ObjectToConstruct;
         public Direction ObjectDirection;
         public float Delay;
         public LayerMask ObstacleMask;

--- a/Assets/Content/Structures/Doors/Door.cs
+++ b/Assets/Content/Structures/Doors/Door.cs
@@ -1,4 +1,5 @@
-﻿using SS3D.Engine.Tile.TileRework.Connections;
+﻿using SS3D.Engine.Tile.TileRework;
+using SS3D.Engine.Tile.TileRework.Connections;
 using SS3D.Engine.Tile.TileRework.Connections.AdjacencyTypes;
 using SS3D.Engine.Tiles;
 using SS3D.Engine.Tiles.Connections;
@@ -90,9 +91,9 @@ namespace SS3D.Content.Structures.Doors
         private bool UpdateSingleConnection(Direction direction, PlacedTileObject placedObject)
         {
             SetPerpendicularBlocked(true);
-            bool isConnected = (placedObject && placedObject.HasAdjacencyConnector() && placedObject.GetGenericType() == "wall");
+            bool isConnected = (placedObject && placedObject.HasAdjacencyConnector() && placedObject.GetGenericType() == TileObjectGenericType.Wall);
 
-            return adjacencyMap.SetConnection(direction, new AdjacencyData("", "", isConnected));
+            return adjacencyMap.SetConnection(direction, new AdjacencyData(TileObjectGenericType.None, TileObjectSpecificType.None, isConnected));
         }
 
         /// <summary>

--- a/Assets/Content/Systems/Construction/ConstructionMaterial.cs
+++ b/Assets/Content/Systems/Construction/ConstructionMaterial.cs
@@ -8,6 +8,7 @@ using SS3D.Engine.Interactions;
 using SS3D.Engine.Interactions.Extensions;
 using SS3D.Engine.Inventory;
 using SS3D.Engine.Inventory.Extensions;
+using SS3D.Engine.Tile.TileRework;
 using SS3D.Engine.Tiles;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -211,7 +212,7 @@ namespace SS3D.Content.Systems.Construction
             public float buildTime;
             
             // Turf data
-            public TileObjectSO ObjectToConstruct;
+            public TileObjectSo ObjectToConstruct;
             // public bool constructOverTurf;
 
             public ConstructionUiData ToUi(string materialName)

--- a/Assets/Content/Systems/Construction/ItemConstructionInteraction.cs
+++ b/Assets/Content/Systems/Construction/ItemConstructionInteraction.cs
@@ -4,11 +4,12 @@ using SS3D.Engine.Interactions.Extensions;
 using SS3D.Engine.Tiles;
 using System.Collections;
 using System.Collections.Generic;
+using SS3D.Engine.Tile.TileRework;
 using UnityEngine;
 
 public class ItemConstructionInteraction : ConstructionInteraction
 {
-    public TileObjectSO ObjectToConstruct;
+    public TileObjectSo ObjectToConstruct;
     public Direction ObjectDirection;
 
     public override string GetName(InteractionEvent interactionEvent)

--- a/Assets/Content/Systems/Construction/TurfConstructionInteraction.cs
+++ b/Assets/Content/Systems/Construction/TurfConstructionInteraction.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using SS3D.Content.Systems.Interactions;
 using SS3D.Engine.Interactions;
 using SS3D.Engine.Interactions.Extensions;
+using SS3D.Engine.Tile.TileRework;
 using SS3D.Engine.Tiles;
 using UnityEngine;
 
@@ -13,7 +14,7 @@ public class TurfConstructionInteraction : ConstructionInteraction
     /// <summary>
     /// The turf to construct
     /// </summary>
-    public TileObjectSO ObjectToConstruct;
+    public TileObjectSo ObjectToConstruct;
     /// <summary>
     /// If the turf can be constructed if there already is a turf
     /// </summary>

--- a/Assets/Content/Systems/Interactions/ConstructionInteraction.cs
+++ b/Assets/Content/Systems/Interactions/ConstructionInteraction.cs
@@ -1,5 +1,6 @@
 ﻿using SS3D.Engine.Interactions;
 using SS3D.Engine.Interactions.Extensions;
+using SS3D.Engine.Tile.TileRework;
 using SS3D.Engine.Tiles;
 using UnityEngine;
 

--- a/Assets/Content/Systems/Interactions/WallConstructionInteraction.cs
+++ b/Assets/Content/Systems/Interactions/WallConstructionInteraction.cs
@@ -1,5 +1,6 @@
 ﻿using SS3D.Engine.Interactions;
 using SS3D.Engine.Interactions.Extensions;
+using SS3D.Engine.Tile.TileRework;
 using SS3D.Engine.Tiles;
 using UnityEngine;
 
@@ -7,12 +8,12 @@ namespace SS3D.Content.Systems.Interactions
 {
     public class WallConstructionInteraction : ConstructionInteraction
     {
-        public TileObjectSO WallToConstruct { get; set; }
+        public TileObjectSo WallToConstruct { get; set; }
 
         public override string GetName(InteractionEvent interactionEvent)
         {
             PlacedTileObject tileObject = (interactionEvent.Target as IGameObjectProvider)?.GameObject?.GetComponentInParent<PlacedTileObject>();
-            if (tileObject != null && tileObject.GetGenericType() == "wall")
+            if (tileObject != null && tileObject.GetGenericType() == TileObjectGenericType.Wall)
             {
                 return "Deconstruct";
             }
@@ -43,7 +44,7 @@ namespace SS3D.Content.Systems.Interactions
             // var tile = targetPlacedObject.Tile;
 
             // Deconstruct
-            if (targetPlacedObject != null && targetPlacedObject.GetGenericType() == "wall")
+            if (targetPlacedObject != null && targetPlacedObject.GetGenericType() == TileObjectGenericType.Wall)
             {
                 tileManager.ClearTileObject(TileLayer.Turf, targetPlacedObject.transform.position);
             }

--- a/Assets/Engine/Examine/CompositeItemSelector.cs
+++ b/Assets/Engine/Examine/CompositeItemSelector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using SS3D.Engine.Tile.TileRework;
 using SS3D.Engine.Tiles;
 using UnityEngine;
 using UnityEngine.EventSystems;

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyMap.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyMap.cs
@@ -18,14 +18,14 @@ namespace SS3D.Engine.Tile.TileRework.Connections
         public AdjacencyMap()
         {
             connections = new [] {
-                new AdjacencyData ("", "", false),
-                new AdjacencyData ("", "", false),
-                new AdjacencyData ("", "", false),
-                new AdjacencyData ("", "", false),
-                new AdjacencyData ("", "", false),
-                new AdjacencyData ("", "", false),
-                new AdjacencyData ("", "", false),
-                new AdjacencyData ("", "", false),
+                new AdjacencyData (TileObjectGenericType.None, TileObjectSpecificType.None, false),
+                new AdjacencyData (TileObjectGenericType.None, TileObjectSpecificType.None, false),
+                new AdjacencyData (TileObjectGenericType.None, TileObjectSpecificType.None, false),
+                new AdjacencyData (TileObjectGenericType.None, TileObjectSpecificType.None, false),
+                new AdjacencyData (TileObjectGenericType.None, TileObjectSpecificType.None, false),
+                new AdjacencyData (TileObjectGenericType.None, TileObjectSpecificType.None, false),
+                new AdjacencyData (TileObjectGenericType.None, TileObjectSpecificType.None, false),
+                new AdjacencyData (TileObjectGenericType.None, TileObjectSpecificType.None, false),
             };
         }
 
@@ -113,7 +113,7 @@ namespace SS3D.Engine.Tile.TileRework.Connections
             AdjacencyData[] adjacencyData = new AdjacencyData[8];
             for (int i = 0; i < bits.Length; i++)
             {
-                adjacencyData[i] = new AdjacencyData("", "", bits[i]);
+                adjacencyData[i] = new AdjacencyData(TileObjectGenericType.None, TileObjectSpecificType.None, bits[i]);
             }
 
             connections = adjacencyData;

--- a/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/AdjacencyDataStructs.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/AdjacencyTypes/AdjacencyDataStructs.cs
@@ -16,15 +16,15 @@ namespace SS3D.Engine.Tile.TileRework.Connections.AdjacencyTypes
     /// </summary>
     public struct AdjacencyData
     {
-        public AdjacencyData(string genericType, string specificType, bool exists)
+        public AdjacencyData(TileObjectGenericType genericType, TileObjectSpecificType specificType, bool exists)
         {
             GenericType = genericType;
             SpecificType = specificType;
             Exists = exists;
         }
 
-        public string GenericType;
-        public string SpecificType;
+        public TileObjectGenericType GenericType;
+        public TileObjectSpecificType SpecificType;
         public bool Exists;
 
         public override bool Equals(object other)

--- a/Assets/Engine/Tile/TileRework/Connections/IAdjacencyConnector.cs
+++ b/Assets/Engine/Tile/TileRework/Connections/IAdjacencyConnector.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using SS3D.Engine.Tile.TileRework;
 using UnityEngine;
 
 namespace SS3D.Engine.Tiles.Connections

--- a/Assets/Engine/Tile/TileRework/Editor/AdjacencyEditor.cs
+++ b/Assets/Engine/Tile/TileRework/Editor/AdjacencyEditor.cs
@@ -88,7 +88,7 @@ namespace SS3D.Engine.Tile.TileRework.Editor
                             // Set their opposite side blocked
                             AdjacencyMap adjacencyMap = new AdjacencyMap();
                             adjacencyMap.DeserializeFromByte((byte)neighbourProperty.intValue);
-                            adjacencyMap.SetConnection(TileHelper.GetOpposite((Direction) i), new AdjacencyData("", "", blocked[i]));
+                            adjacencyMap.SetConnection(TileHelper.GetOpposite((Direction) i), new AdjacencyData(TileObjectGenericType.None, TileObjectSpecificType.None, blocked[i]));
                             neighbourProperty.intValue = adjacencyMap.SerializeToByte();
 
                             // Apply the changes
@@ -122,7 +122,7 @@ namespace SS3D.Engine.Tile.TileRework.Editor
             AdjacencyMap adjacencyMap = new AdjacencyMap();
             for (Direction direction = Direction.North; direction <= Direction.NorthWest; direction++)
             {
-                adjacencyMap.SetConnection(direction, new AdjacencyData("", "", blocked[(int)direction]));
+                adjacencyMap.SetConnection(direction, new AdjacencyData(TileObjectGenericType.None, TileObjectSpecificType.None, blocked[(int)direction]));
             }
 
             return adjacencyMap.SerializeToByte();

--- a/Assets/Engine/Tile/TileRework/Editor/TileDragHandler.cs
+++ b/Assets/Engine/Tile/TileRework/Editor/TileDragHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using SS3D.Engine.Tile.TileRework;
 using UnityEditor;
 using UnityEngine;
 
@@ -10,7 +11,7 @@ namespace SS3D.Engine.Tiles.Editor.TileMapEditor
      */
     public class TileDragHandler
     {
-        public TileDragHandler(TileManager tileManager, TileMapEditor mapEditor, TileMap map, int subLayerIndex, TileObjectSO tileObjectSO, Direction selectedDir, Vector3Int snappedPosition)
+        public TileDragHandler(TileManager tileManager, TileMapEditor mapEditor, TileMap map, int subLayerIndex, TileObjectSo tileObjectSO, Direction selectedDir, Vector3Int snappedPosition)
         {
             this.tileManager = tileManager;
             this.mapEditor = mapEditor;
@@ -227,7 +228,7 @@ namespace SS3D.Engine.Tiles.Editor.TileMapEditor
         private readonly TileMapEditor mapEditor;
         private readonly TileMap map;
         private readonly int subLayerIndex;
-        private readonly TileObjectSO tileObjectSO;
+        private readonly TileObjectSo tileObjectSO;
         private readonly Direction selectedDir;
         private readonly Vector3Int startPosition;
         private Vector3Int curPosition;

--- a/Assets/Engine/Tile/TileRework/Editor/TileMapEditor.cs
+++ b/Assets/Engine/Tile/TileRework/Editor/TileMapEditor.cs
@@ -3,6 +3,7 @@ using SS3D.Engine.Tiles.Connections;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using SS3D.Engine.Tile.TileRework;
 using UnityEditor;
 using UnityEngine;
 
@@ -21,9 +22,9 @@ namespace SS3D.Engine.Tiles.Editor.TileMapEditor
         private string searchString = "";
         private Vector2 scrollPositionTile;
         private Vector2 scrollPositionSelection;
-        private List<TileObjectSO> assetList = new List<TileObjectSO>();
+        private List<TileObjectSo> assetList = new List<TileObjectSo>();
         private List<GUIContent> assetIcons = new List<GUIContent>();
-        private List<TileObjectSO> assetDisplayList = new List<TileObjectSO>();
+        private List<TileObjectSo> assetDisplayList = new List<TileObjectSo>();
         private List<GUIContent> assetDisplayIcons = new List<GUIContent>();
         private int assetIndex;
         private bool loadingTextures = false;
@@ -46,7 +47,7 @@ namespace SS3D.Engine.Tiles.Editor.TileMapEditor
         private double lastPlacementTime;
         private bool deleteTiles = false;
         private TileLayer selectedLayer;
-        private TileObjectSO selectedObjectSO;
+        private TileObjectSo selectedObjectSO;
         private bool enablePlacement = false;
         private Direction selectedDir = Direction.North;
         private GameObject ghostObject;
@@ -615,12 +616,12 @@ namespace SS3D.Engine.Tiles.Editor.TileMapEditor
             assetList.Clear();
             assetIcons.Clear();
 
-            string[] guids = AssetDatabase.FindAssets(string.Format("t:{0}", typeof(TileObjectSO)));
+            string[] guids = AssetDatabase.FindAssets(string.Format("t:{0}", typeof(TileObjectSo)));
 
             for (int i = 0; i < guids.Length; i++)
             {
                 string assetPath = AssetDatabase.GUIDToAssetPath(guids[i]);
-                TileObjectSO asset = AssetDatabase.LoadAssetAtPath<TileObjectSO>(assetPath);
+                TileObjectSo asset = AssetDatabase.LoadAssetAtPath<TileObjectSo>(assetPath);
 
                 Texture2D texture;
                 texture = AssetPreview.GetAssetPreview(asset.prefab);

--- a/Assets/Engine/Tile/TileRework/Editor/TileObjectMigrator.cs
+++ b/Assets/Engine/Tile/TileRework/Editor/TileObjectMigrator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using SS3D.Engine.Tile.TileRework;
 using UnityEditor;
 using UnityEngine;
 
@@ -10,12 +11,12 @@ namespace SS3D.Engine.Tiles.Editor.TileMapEditor
         // [MenuItem("RE:SS3D Editor Tools/Migrate")]
         public static void Migrate()
         {
-            string[] guids = AssetDatabase.FindAssets(string.Format("t:{0}", typeof(TileObjectSO)));
+            string[] guids = AssetDatabase.FindAssets(string.Format("t:{0}", typeof(TileObjectSo)));
 
             for (int i = 0; i < guids.Length; i++)
             {
                 string assetPath = AssetDatabase.GUIDToAssetPath(guids[i]);
-                TileObjectSO asset = AssetDatabase.LoadAssetAtPath<TileObjectSO>(assetPath);
+                TileObjectSo asset = AssetDatabase.LoadAssetAtPath<TileObjectSo>(assetPath);
 
                 if (asset.nameString == asset.prefab.name)
                     continue;

--- a/Assets/Engine/Tile/TileRework/PlacedTileObject.cs
+++ b/Assets/Engine/Tile/TileRework/PlacedTileObject.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 using Mirror;
+using SS3D.Engine.Tiles;
 using SS3D.Engine.Tiles.Connections;
-using UnityEditor;
+using UnityEngine;
 
-namespace SS3D.Engine.Tiles
+namespace SS3D.Engine.Tile.TileRework
 {
     /// <summary>
     /// Class that is attached to every GameObject placed on the TileMap. 
@@ -33,7 +32,7 @@ namespace SS3D.Engine.Tiles
         /// <param name="dir"></param>
         /// <param name="tileObjectSO"></param>
         /// <returns></returns>
-        public static PlacedTileObject Create(Vector3 worldPosition, Vector2Int origin, Direction dir, TileObjectSO tileObjectSO)
+        public static PlacedTileObject Create(Vector3 worldPosition, Vector2Int origin, Direction dir, TileObjectSo tileObjectSO)
         {
 
             GameObject placedGameObject = EditorAndRuntime.InstantiatePrefab(tileObjectSO.prefab);
@@ -60,7 +59,7 @@ namespace SS3D.Engine.Tiles
             return placedObject;
         }
 
-        private TileObjectSO tileObjectSO;
+        private TileObjectSo tileObjectSO;
         private Vector2Int origin;
         private Direction dir;
         private IAdjacencyConnector adjacencyConnector;
@@ -71,7 +70,7 @@ namespace SS3D.Engine.Tiles
         /// <param name="tileObjectSO"></param>
         /// <param name="origin"></param>
         /// <param name="dir"></param>
-        public void Setup(TileObjectSO tileObjectSO, Vector2Int origin, Direction dir)
+        public void Setup(TileObjectSo tileObjectSO, Vector2Int origin, Direction dir)
         {
             this.tileObjectSO = tileObjectSO;
             this.origin = origin;
@@ -147,20 +146,24 @@ namespace SS3D.Engine.Tiles
                 adjacencyConnector.UpdateSingle(dir, placedNeighbour);
         }
 
-        public string GetGenericType()
+        public TileObjectGenericType GetGenericType()
         {
             if (tileObjectSO != null)
+            {
                 return tileObjectSO.genericType;
-            else
-                return string.Empty;
+            }
+
+            return TileObjectGenericType.None;
         }
 
-        public string GetSpecificType()
+        public TileObjectSpecificType GetSpecificType()
         {
             if (tileObjectSO != null)
+            {
                 return tileObjectSO.specificType;
-            else
-                return string.Empty;
+            }
+
+            return TileObjectSpecificType.None;
         }
 
         public string GetName()

--- a/Assets/Engine/Tile/TileRework/TileManager.cs
+++ b/Assets/Engine/Tile/TileRework/TileManager.cs
@@ -3,11 +3,12 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using SS3D.Engine.Tile.TileRework;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using static SS3D.Engine.Tiles.TileMap;
-using static SS3D.Engine.Tiles.TileRestrictions;
+using static SS3D.Engine.Tile.TileRework.TileRestrictions;
 
 namespace SS3D.Engine.Tiles
 {
@@ -43,7 +44,7 @@ namespace SS3D.Engine.Tiles
         public bool IsInitialized { get; private set; }
         public static event System.Action TileManagerLoaded;
 
-        private static TileObjectSO[] tileObjectSOs;
+        private static TileObjectSo[] tileObjectSOs;
         private string saveFileName = "tilemaps";
 
         private List<TileMap> mapList;
@@ -68,13 +69,13 @@ namespace SS3D.Engine.Tiles
                 // Finding all TileObjectSOs differs whether we are in the editor or playing
 #if UNITY_EDITOR
                 // We have to ensure that all objects used are loaded beforehand
-                string[] guids = AssetDatabase.FindAssets(string.Format("t:{0}", typeof(TileObjectSO)));
+                string[] guids = AssetDatabase.FindAssets(string.Format("t:{0}", typeof(TileObjectSo)));
 
-                List<TileObjectSO> listTileObjectSO = new List<TileObjectSO>();
+                List<TileObjectSo> listTileObjectSO = new List<TileObjectSo>();
                 for (int i = 0; i < guids.Length; i++)
                 {
                     string assetPath = AssetDatabase.GUIDToAssetPath(guids[i]);
-                    listTileObjectSO.Add(AssetDatabase.LoadAssetAtPath<TileObjectSO>(assetPath));
+                    listTileObjectSO.Add(AssetDatabase.LoadAssetAtPath<TileObjectSo>(assetPath));
                 }
                 tileObjectSOs = listTileObjectSO.ToArray();
 #else
@@ -213,7 +214,7 @@ namespace SS3D.Engine.Tiles
         /// <param name="tileObjectSO"></param>
         /// <param name="position"></param>
         /// <param name="dir"></param>
-        public void SetTileObject(TileMap map, int subLayerIndex, TileObjectSO tileObjectSO, Vector3 position, Direction dir)
+        public void SetTileObject(TileMap map, int subLayerIndex, TileObjectSo tileObjectSO, Vector3 position, Direction dir)
         {
             if (CanBuild(map, subLayerIndex, tileObjectSO, position, dir, false))
                 map.SetTileObject(subLayerIndex, tileObjectSO, position, dir);
@@ -225,7 +226,7 @@ namespace SS3D.Engine.Tiles
         /// <param name="tileObjectSO"></param>
         /// <param name="position"></param>
         /// <param name="dir"></param>
-        public void SetTileObject(TileObjectSO tileObjectSO, Vector3 position, Direction dir)
+        public void SetTileObject(TileObjectSo tileObjectSO, Vector3 position, Direction dir)
         {
             if (tileObjectSO.layer == TileLayer.HighWallMount || tileObjectSO.layer == TileLayer.LowWallMount)
                 Debug.LogError("Simplified function SetTileObject() is used. Do not use this function with layers where a sub index is required!");
@@ -267,7 +268,7 @@ namespace SS3D.Engine.Tiles
         /// <param name="position"></param>
         /// <param name="dir"></param>
         /// <returns></returns>
-        public bool CanBuild(TileMap selectedMap, int subLayerIndex, TileObjectSO tileObjectSO, Vector3 position, Direction dir, bool overrideAllowed)
+        public bool CanBuild(TileMap selectedMap, int subLayerIndex, TileObjectSo tileObjectSO, Vector3 position, Direction dir, bool overrideAllowed)
         {
             bool canBuild = true;
             foreach (TileMap map in mapList)
@@ -301,7 +302,7 @@ namespace SS3D.Engine.Tiles
         /// <param name="position"></param>
         /// <param name="dir"></param>
         /// <returns></returns>
-        public bool CanBuild(TileObjectSO tileObjectSO, Vector3 position, Direction dir)
+        public bool CanBuild(TileObjectSo tileObjectSO, Vector3 position, Direction dir)
         {
             if (tileObjectSO.layer == TileLayer.HighWallMount || tileObjectSO.layer == TileLayer.LowWallMount)
                 Debug.LogError("Simplified function CanBuild() is used. Do not use this function with layers where a sub index is required!");
@@ -339,9 +340,9 @@ namespace SS3D.Engine.Tiles
         /// </summary>
         /// <param name="tileObjectSOName"></param>
         /// <returns></returns>
-        public TileObjectSO GetTileObjectSO(string tileObjectSOName)
+        public TileObjectSo GetTileObjectSO(string tileObjectSOName)
         {
-            TileObjectSO tileObjectSO = tileObjectSOs.FirstOrDefault(tileObject => tileObject.nameString == tileObjectSOName);
+            TileObjectSo tileObjectSO = tileObjectSOs.FirstOrDefault(tileObject => tileObject.nameString == tileObjectSOName);
             if (tileObjectSO == null)
                 Debug.LogError("TileObjectSO was not found: " + tileObjectSOName);
             return tileObjectSO;
@@ -384,7 +385,7 @@ namespace SS3D.Engine.Tiles
         {
             if (tileObjectSOs == null)
             {
-                tileObjectSOs = Resources.FindObjectsOfTypeAll<TileObjectSO>();
+                tileObjectSOs = Resources.FindObjectsOfTypeAll<TileObjectSo>();
             }
 
             if (softLoad)

--- a/Assets/Engine/Tile/TileRework/TileMap.cs
+++ b/Assets/Engine/Tile/TileRework/TileMap.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using SS3D.Engine.Tile.TileRework;
 using UnityEditor;
 using UnityEngine;
-using static SS3D.Engine.Tiles.TileRestrictions;
+using static SS3D.Engine.Tile.TileRework.TileRestrictions;
 
 namespace SS3D.Engine.Tiles
 {
@@ -202,7 +203,7 @@ namespace SS3D.Engine.Tiles
         /// <param name="position">World position to place the object</param>
         /// <param name="dir">Direction the object is facing</param>
         /// <returns></returns>
-        public bool CanBuild(int subLayerIndex, TileObjectSO tileObjectSO, Vector3 position, Direction dir, CheckRestrictions checkRestrictions)
+        public bool CanBuild(int subLayerIndex, TileObjectSo tileObjectSO, Vector3 position, Direction dir, CheckRestrictions checkRestrictions)
         {
             // Get the right chunk
             TileChunk chunk = GetOrCreateChunk(position);
@@ -260,7 +261,7 @@ namespace SS3D.Engine.Tiles
         /// <param name="tileObjectSO">Object to place</param>
         /// <param name="position">World position to place the object</param>
         /// <param name="dir">Direction the object is facing</param
-        public void SetTileObject(int subLayerIndex, TileObjectSO tileObjectSO, Vector3 position, Direction dir)
+        public void SetTileObject(int subLayerIndex, TileObjectSo tileObjectSO, Vector3 position, Direction dir)
         {
             TileLayer layer = tileObjectSO.layer;
             GameObject layerObject = GetOrCreateLayerObject(layer);
@@ -315,7 +316,7 @@ namespace SS3D.Engine.Tiles
         /// <param name="placedObject"></param>
         /// <param name="position"></param>
         /// <param name="dir"></param>
-        public void LoadTileObject(int subLayerIndex, TileObjectSO tileObjectSO, PlacedTileObject placedObject, Vector3 position, Direction dir)
+        public void LoadTileObject(int subLayerIndex, TileObjectSo tileObjectSO, PlacedTileObject placedObject, Vector3 position, Direction dir)
         {
             TileLayer layer = tileObjectSO.layer;
             GameObject layerObject = GetOrCreateLayerObject(layer);
@@ -526,7 +527,7 @@ namespace SS3D.Engine.Tiles
                         {
                             if (softLoad)
                             {
-                                TileObjectSO tileObjectSO = tileManager.GetTileObjectSO(objectName);
+                                TileObjectSo tileObjectSO = tileManager.GetTileObjectSO(objectName);
 
                                 // Find the object and set it up again...
                                 Vector3 position = TileHelper.GetWorldPosition(tileObjectSaveObject.x, tileObjectSaveObject.y, chunk.tileSize, chunk.originPosition);

--- a/Assets/Engine/Tile/TileRework/TileObject.cs
+++ b/Assets/Engine/Tile/TileRework/TileObject.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using SS3D.Engine.Tile.TileRework;
 using UnityEngine;
 
 namespace SS3D.Engine.Tiles

--- a/Assets/Engine/Tile/TileRework/TileObjectSo.cs
+++ b/Assets/Engine/Tile/TileRework/TileObjectSo.cs
@@ -1,26 +1,25 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using SS3D.Engine.Tiles;
 using UnityEngine;
 
-namespace SS3D.Engine.Tiles
+namespace SS3D.Engine.Tile.TileRework
 {
     /// <summary>
     /// Scriptable object that should be used for every tile object.
     /// </summary>
-    [CreateAssetMenu(fileName = "TileObjectSO", menuName = "TileMap/TileObjectSO", order = 0)]
-    public class TileObjectSO : ScriptableObject
+    [CreateAssetMenu(fileName = "TileObjectSo", menuName = "TileMap/TileObjectSo", order = 0)]
+    public class TileObjectSo : ScriptableObject
     {
         public TileLayer layer;
         
         [Tooltip("A name for the object. Make sure it is unique.")]
         public string nameString;
-
-        //TODO: Replace genericType and specificType with enums as we need to perform operations on them in logic. Need to update all SO's and make sure tilemap editor does not break.
+        
         [Tooltip("Specify the generic type. Used for finding matching adjacencies.")]
-        public string genericType;
+        public TileObjectGenericType genericType;
 
         [Tooltip("Specify the specific type. Used for setting which generics can connect (e.g. wooden tables only connect to each other).")]
-        public string specificType;
+        public TileObjectSpecificType specificType;
 
         public GameObject prefab;
         public int width = 1;

--- a/Assets/Engine/Tile/TileRework/TileObjectType.cs
+++ b/Assets/Engine/Tile/TileRework/TileObjectType.cs
@@ -1,0 +1,29 @@
+﻿namespace SS3D.Engine.Tile.TileRework
+{
+    public enum TileObjectGenericType
+    {
+        None,
+        Pipe,
+        Plant,
+        Wall,
+        Pew,
+        Booth,
+        Sofa,
+        Table,
+        Plenum,
+        Floor,
+        Counter,
+        Cable,
+        Wire
+    }
+    
+    public enum TileObjectSpecificType
+    {
+        None,
+        Glass,
+        Poker,
+        Steel,
+        Wood,
+        Carpet
+    }
+}

--- a/Assets/Engine/Tile/TileRework/TileObjectType.cs.meta
+++ b/Assets/Engine/Tile/TileRework/TileObjectType.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5ce688b3aa71460cb2c54a9d31193b25
+timeCreated: 1640639978

--- a/Assets/Tests/AdjacencyShapeResolverTest.cs
+++ b/Assets/Tests/AdjacencyShapeResolverTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using NUnit.Framework;
+using SS3D.Engine.Tile.TileRework;
 using SS3D.Engine.Tile.TileRework.Connections;
 using SS3D.Engine.Tile.TileRework.Connections.AdjacencyTypes;
 using SS3D.Engine.Tiles;
@@ -8,8 +9,8 @@ namespace SS3D.Tests
 {
     public class AdjacencyShapeResolverTest
     {
-        private readonly AdjacencyData existingConnection = new AdjacencyData("", "", true);
-        private readonly AdjacencyData missingConnection = new AdjacencyData("", "", false);
+        private readonly AdjacencyData existingConnection = new AdjacencyData(TileObjectGenericType.None, TileObjectSpecificType.None, true);
+        private readonly AdjacencyData missingConnection = new AdjacencyData(TileObjectGenericType.None, TileObjectSpecificType.None, false);
 
         [Test]
         public void SimpleShapeShouldReturn0WhenNoConnections()


### PR DESCRIPTION
## Summary

* create enums for TileObjectGenericType and TileObjectSpecificType
* update all scriptable objects (used by tilemap editor) with their relevant enum values
* update other scripts that rely on TileObjectSo to correctly handle the new enum type
* various minor code style, naming convention and namespace updates on touched files

This has minor improvements on memory usage, but the main purpose of this was to allow for proper logic and comparisons within code for upcoming adjacency types. Strings entered by hand are error prone to typos and unreliable for logic in general. Tested map loading/saving just in case and tilemap editor with walls, tables and wires.

I got all the enum values from the scriptable objects in Assets/Content/Resources as that is what the tilemap editor uses to populate the menus. If some values are missing, blame whoever put the relevant SO in the wrong folder 🤷 

## Fixes

Closes #877.
