### PR TITLE
add test runner workflow for each commit

### DIFF
--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -1,0 +1,32 @@
+#https://game.ci/docs/github/test-runner
+name: Run Tests
+on: [push, workflow_dispatch]
+jobs:
+  run_tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Notify discord if tests fail
+        uses: rjstone/discord-webhook-notify@v1
+        if: failure()
+        with:
+          severity: error
+          details: Test runner failed!
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Test results
+          path: artifacts


### PR DESCRIPTION
* Create test runner workflow
* Add discord webhook secret (done by @cosmiccoincidence)

## Summary

This will execute all the edit and play mode tests within the project on every commit ~and pull request~. The results will be displayed within github actions. ~Ideally we'd have a discord bot post in the git-log channel when tests fail to make everyone aware, but that needs to be done separately from this.~ When a test execution fails, a discord message will also be displayed to let everyone know.

The discord message feature requires a new secret to be added to github, which @cosmiccoincidence has already done.

Actions executed by this workflow:
1. Clone the repository
2. Execute Edit and Play mode tests
3. Send discord message if tests fail
4. Upload test results as an artifact for reviewing

## Pictures/Videos
New workflow listed as Run Tests. If a test fails it marks the entire action as failed.
![tests1](https://user-images.githubusercontent.com/15195221/147513663-09f0cf76-5fd2-47a6-b569-17cd6d222eee.PNG)

Actions performed
![tests7](https://user-images.githubusercontent.com/15195221/147553017-9ed1c4dd-8430-47a8-8caa-d04305d27496.PNG)

Results view on a success
![tests3](https://user-images.githubusercontent.com/15195221/147513692-8f5aa103-b5ed-450e-8cf3-76e9f6c9f725.PNG)

Quick summary when looking at a run with failures
![tests4](https://user-images.githubusercontent.com/15195221/147513714-9a66bd3c-4576-46e0-b0c1-9b182835aaca.PNG)

Detailed test results on a failed run
![tests5](https://user-images.githubusercontent.com/15195221/147513722-2ceafe30-86fa-42a9-aa16-7337e58a5ba7.PNG)

Discord message on a failed run
![tests6](https://user-images.githubusercontent.com/15195221/147551924-33449d15-a41f-46c8-b175-5d76c0aa8df6.PNG)
