### PR TITLE
fix missing adjacency type values in assets

### DIFF
--- a/Assets/Content/Resources/Disposal/DisposalPipes.asset
+++ b/Assets/Content/Resources/Disposal/DisposalPipes.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 4
   nameString: DisposalPipes
-  genericType: pipe
-  specificType: 
+  genericType: 1
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 12a989ad41a83a3468d1ae9aff9628d3, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Disposal/Manifold3L.asset
+++ b/Assets/Content/Resources/Disposal/Manifold3L.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 4
   nameString: Manifold3L
-  genericType: 
-  specificType: 
+  genericType: 0
+  specificType: 0
   prefab: {fileID: 6937106039017095358, guid: 38905c1e96f82d8408d029a917a46a0f, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Disposal/Manifold4L.asset
+++ b/Assets/Content/Resources/Disposal/Manifold4L.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 4
   nameString: Manifold4L
-  genericType: 
-  specificType: 
+  genericType: 0
+  specificType: 0
   prefab: {fileID: 1381773157775214163, guid: b6511528502689241b2a5e8b6dc7bc42, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Airlock.asset
+++ b/Assets/Content/Resources/FurnitureBase/Airlock.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Airlock
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 1917799960222321674, guid: 8a78eb8d1c4b8874bada82a70bb176b0, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/AirlockCivilian.asset
+++ b/Assets/Content/Resources/FurnitureBase/AirlockCivilian.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: AirlockCivilian
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 1917799960222321674, guid: 1108c6dc8745ac5428f9a3173d952ca3, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/AirlockCivilianGlass.asset
+++ b/Assets/Content/Resources/FurnitureBase/AirlockCivilianGlass.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: AirlockCivilianGlass
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 1917799960222321674, guid: b876c19e1565c0343a613fa33b23713a, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/AirlockGlass.asset
+++ b/Assets/Content/Resources/FurnitureBase/AirlockGlass.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: AirlockGlass
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 1917799960222321674, guid: 8c6cba992e625014c8d6c0ab80642b8b, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/AirlockMaintenance.asset
+++ b/Assets/Content/Resources/FurnitureBase/AirlockMaintenance.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: AirlockMaintenance
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 1917799960222321674, guid: ccfb58f362163a247a36bc2e32324cd0, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/AirlockMaintenanceGlass.asset
+++ b/Assets/Content/Resources/FurnitureBase/AirlockMaintenanceGlass.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: AirlockMaintenanceGlass
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 1917799960222321674, guid: 435449d4ca1f3a44196fa8a29e3c2659, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/ChapelPew.asset
+++ b/Assets/Content/Resources/FurnitureBase/ChapelPew.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: ChapelPew
-  genericType: pew
-  specificType: 
+  genericType: 4
+  specificType: 0
   prefab: {fileID: 8036950609662249464, guid: 7f12c690436c54845a7f126a4adb17c7, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/ClassicAirlock.asset
+++ b/Assets/Content/Resources/FurnitureBase/ClassicAirlock.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: ClassicAirlock
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 3290821787637386385, guid: 316566ec0b0bc504ba51bbfeb22aaac1, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/DinerBooth.asset
+++ b/Assets/Content/Resources/FurnitureBase/DinerBooth.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: DinerBooth
-  genericType: booth
-  specificType: 
+  genericType: 5
+  specificType: 0
   prefab: {fileID: 8036950609662249464, guid: cb350e6bc218ee640a999561841f8306, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/PipesLayer4.asset
+++ b/Assets/Content/Resources/FurnitureBase/PipesLayer4.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: PipesLayer4
-  genericType: pipe
-  specificType: 
+  genericType: 1
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 48efd00c91c310e4bb965d025c63b3ba, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/AmbrosiaDeus.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/AmbrosiaDeus.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: AmbrosiaDeus
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: a3b9e8374f0fbde40a17fecc85059d5a, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/AmbrosiaGaia.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/AmbrosiaGaia.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: AmbrosiaGaia
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 5091107218957857814, guid: e4e35157d2824334c91b2e53faface6f, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/AmbrosiaVulgaris.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/AmbrosiaVulgaris.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: AmbrosiaVulgaris
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 612889519444900947, guid: fa1ebd6884058ae43aa2e54b24de026f, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/Banana.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/Banana.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Banana
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: 68261416c6e2373468da5f99909b420a, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/BluespaceBanana.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/BluespaceBanana.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: BluespaceBanana
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: a1a3f0f3db9908c4398892ab1216b5b8, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/Glowcap.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/Glowcap.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Glowcap
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: aff1849e835c89b48b4e488f3a29062d, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/Glowshroom.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/Glowshroom.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Glowshroom
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: 77341584f36c27348b6c272ab2cbe6cd, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/Holymelon.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/Holymelon.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Holymelon
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: 437d9a31d51d45f4c9daa1820f0f44c5, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/MeatWheat.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/MeatWheat.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: MeatWheat
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: 0d422a47b06117b4eb317a821c57b927, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/Mimana.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/Mimana.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Mimana
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: 7f6e55bace55a4b45a6e92e9e55664b4, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/Shadowshroom.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/Shadowshroom.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Shadowshroom
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: c1d6c9fa433b16e46b2a7a60ee876677, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/Watermelon.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/Watermelon.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Watermelon
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: 638bd05d277251342878ebd07fd745d2, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Plants/Wheat.asset
+++ b/Assets/Content/Resources/FurnitureBase/Plants/Wheat.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Wheat
-  genericType: plant
-  specificType: 
+  genericType: 2
+  specificType: 0
   prefab: {fileID: 8757431509704750092, guid: d9ac62d34e6747f44b9c80551c26cedb, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/Sofa.asset
+++ b/Assets/Content/Resources/FurnitureBase/Sofa.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: Sofa
-  genericType: sofa
-  specificType: 
+  genericType: 6
+  specificType: 0
   prefab: {fileID: 8036950609662249464, guid: d9c3fdfe3e319e049a5a8b2989868084, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/TableGlass.asset
+++ b/Assets/Content/Resources/FurnitureBase/TableGlass.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: TableGlass
-  genericType: table
-  specificType: glass
+  genericType: 7
+  specificType: 1
   prefab: {fileID: 2839728781945606427, guid: 4d48472d06930bd42a15897e6a1794ac, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/TablePoker.asset
+++ b/Assets/Content/Resources/FurnitureBase/TablePoker.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: TablePoker
-  genericType: table
-  specificType: poker
+  genericType: 7
+  specificType: 2
   prefab: {fileID: 3879826479501069436, guid: ebddb1721dcbe36499e4d093e5a7ff09, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/TableSteel.asset
+++ b/Assets/Content/Resources/FurnitureBase/TableSteel.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: TableSteel
-  genericType: table
-  specificType: steel
+  genericType: 7
+  specificType: 3
   prefab: {fileID: 8036950609662249464, guid: 6caa99f8281726e40a793826d5c047db, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/FurnitureBase/TableWood.asset
+++ b/Assets/Content/Resources/FurnitureBase/TableWood.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 10
   nameString: TableWood
-  genericType: table
-  specificType: wood
+  genericType: 7
+  specificType: 4
   prefab: {fileID: 3879826479501069436, guid: 5e8a02c5ce0073644ac01bdb55d72a70, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Pipes/PipesLayer1.asset
+++ b/Assets/Content/Resources/Pipes/PipesLayer1.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 5
   nameString: PipesLayer1
-  genericType: pipe
-  specificType: 
+  genericType: 1
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: de6f06ad18d50134295959f438ba9c5d, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Pipes/PipesLayer2.asset
+++ b/Assets/Content/Resources/Pipes/PipesLayer2.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 6
   nameString: PipesLayer2
-  genericType: pipe
-  specificType: 
+  genericType: 1
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 251dc2a5fbda518429c8205c3b62165f, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Pipes/PipesLayer3.asset
+++ b/Assets/Content/Resources/Pipes/PipesLayer3.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 7
   nameString: PipesLayer3
-  genericType: pipe
-  specificType: 
+  genericType: 1
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: adc07a7f0fee8304691f45a201509b13, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Plenum/Plenum.asset
+++ b/Assets/Content/Resources/Plenum/Plenum.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 0
   nameString: Plenum
-  genericType: plenum
-  specificType: 
+  genericType: 8
+  specificType: 0
   prefab: {fileID: 8028539322119499722, guid: 3b33b5cf16a677a4e85a110679cde32a, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/FancyCarpetRed.asset
+++ b/Assets/Content/Resources/Turf/FancyCarpetRed.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: FancyCarpetRed
-  genericType: floor
-  specificType: carpet
+  genericType: 9
+  specificType: 5
   prefab: {fileID: 3591147544166670882, guid: 9b8a1328991fc2846bc55a3d9a82e5c0, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/SteelCounter.asset
+++ b/Assets/Content/Resources/Turf/SteelCounter.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: SteelCounter
-  genericType: counter
-  specificType: 
+  genericType: 10
+  specificType: 0
   prefab: {fileID: 8036950609662249464, guid: 174d69d18a4b7a2479ca2980206b48cc, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/SteelGirder.asset
+++ b/Assets/Content/Resources/Turf/SteelGirder.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: SteelGirder
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 5989834269598487349, guid: 60695978170ac0c48af8fd7ac2c0a43c, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/SteelWall.asset
+++ b/Assets/Content/Resources/Turf/SteelWall.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: SteelWall
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 3591147544166670882, guid: 45d13347efae0f54882e0e56dd770bb1, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/SteelWallReinforced.asset
+++ b/Assets/Content/Resources/Turf/SteelWallReinforced.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: SteelWallReinforced
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 3591147544166670882, guid: d11a68992658b7741bd28ffdf04165ba, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/SteelWindow.asset
+++ b/Assets/Content/Resources/Turf/SteelWindow.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: SteelWindow
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 3591147544166670882, guid: d5d073d01dd3c1f4cbe43fb3128c89e4, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/SteelWindowReinforced.asset
+++ b/Assets/Content/Resources/Turf/SteelWindowReinforced.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: SteelWindowReinforced
-  genericType: wall
-  specificType: 
+  genericType: 3
+  specificType: 0
   prefab: {fileID: 3591147544166670882, guid: 6e6257fcfea4f46418ac01d93fd37115, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileBar.asset
+++ b/Assets/Content/Resources/Turf/TileBar.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileBar
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 75680e6a1df5ff547bdb5b8f116f766b, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileDirt1.asset
+++ b/Assets/Content/Resources/Turf/TileDirt1.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileDirt1
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 0ef9cea3bb74e6c4788f77e711f92d4d, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileDirt2.asset
+++ b/Assets/Content/Resources/Turf/TileDirt2.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileDirt2
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 93a060d37adff304d890e38c4258df7a, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileDirt3.asset
+++ b/Assets/Content/Resources/Turf/TileDirt3.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileDirt3
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 95ae84ac095094a47b60b475d1b9c649, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileDirt4.asset
+++ b/Assets/Content/Resources/Turf/TileDirt4.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileDirt4
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: ae51840668a4b6940a4920adca7f742a, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileDirt5.asset
+++ b/Assets/Content/Resources/Turf/TileDirt5.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileDirt5
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 26a2cfb56cd09c94c9793ff68f9863fa, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileDirt6.asset
+++ b/Assets/Content/Resources/Turf/TileDirt6.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileDirt6
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 47eb409053129394a8508cddd4d52dc2, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileGrass.asset
+++ b/Assets/Content/Resources/Turf/TileGrass.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileGrass
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 501391c27a7f94c4d8c937f00a9ceb9f, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileGrey.asset
+++ b/Assets/Content/Resources/Turf/TileGrey.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileGrey
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 7a47e5b68d8bab647b3f99ee3af524c7, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileGreyDark.asset
+++ b/Assets/Content/Resources/Turf/TileGreyDark.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileGreyDark
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 5554428447677395221, guid: 6873d7cf62d6ebc42966423161b799f1, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileKitchen.asset
+++ b/Assets/Content/Resources/Turf/TileKitchen.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileKitchen
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 5ecf13819099b014eb5f731155540586, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TilePlating.asset
+++ b/Assets/Content/Resources/Turf/TilePlating.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TilePlating
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 8686fbdb413e33b4395a775c4f2ba990, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileReinforced.asset
+++ b/Assets/Content/Resources/Turf/TileReinforced.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileReinforced
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 8597721773267636030, guid: df4cf328d472de046bcbc073cbda2868, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileWhite.asset
+++ b/Assets/Content/Resources/Turf/TileWhite.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileWhite
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 61201f10ccc2856459a9de99d9cdc52e, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Turf/TileWood.asset
+++ b/Assets/Content/Resources/Turf/TileWood.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 2
   nameString: TileWood
-  genericType: floor
-  specificType: 
+  genericType: 9
+  specificType: 0
   prefab: {fileID: 6767447678079105841, guid: 49f2097d4710d114a89821d9164dfce2, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/Cables.asset
+++ b/Assets/Content/Resources/Wire/Cables.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: Cables
-  genericType: cable
-  specificType: 
+  genericType: 11
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 92d3eb280886ba74cb1e19f4e01669a7, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresBlue.asset
+++ b/Assets/Content/Resources/Wire/WiresBlue.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresBlue
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 2b932aed8c9bdb54da3d5a0274fe9927, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresBrown.asset
+++ b/Assets/Content/Resources/Wire/WiresBrown.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresBrown
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: cc48c05d209320541af6b8785c1eec62, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresGreen.asset
+++ b/Assets/Content/Resources/Wire/WiresGreen.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresGreen
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 370739b7068119941b61a0c1474657e3, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresOrange.asset
+++ b/Assets/Content/Resources/Wire/WiresOrange.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresOrange
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 998af0a1729ef9649ae6cd1bb3f50b51, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresPink.asset
+++ b/Assets/Content/Resources/Wire/WiresPink.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresPink
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 9f1f481cfc054374dbed94aa620ab4f6, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresPurple.asset
+++ b/Assets/Content/Resources/Wire/WiresPurple.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresPurple
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 8cb996c23d77f3c44b887fdec07520f4, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresRed.asset
+++ b/Assets/Content/Resources/Wire/WiresRed.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresRed
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 14ef62e89f3613c4b9964b369e01c5f9, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresTeal.asset
+++ b/Assets/Content/Resources/Wire/WiresTeal.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresTeal
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 693d4d98b3a090b458d23261f6c77d94, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresWhite.asset
+++ b/Assets/Content/Resources/Wire/WiresWhite.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresWhite
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: 05582ec649a27b64c85729877d9e344d, type: 3}
   width: 1
   height: 1

--- a/Assets/Content/Resources/Wire/WiresYellow.asset
+++ b/Assets/Content/Resources/Wire/WiresYellow.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   layer: 3
   nameString: WiresYellow
-  genericType: wire
-  specificType: 
+  genericType: 12
+  specificType: 0
   prefab: {fileID: 2802364579275783218, guid: d211f90919bc28a4e8def76cb07197ba, type: 3}
   width: 1
   height: 1


### PR DESCRIPTION
## Summary

Something went wrong when merging the adjacency type enum commit amongst all the other changes. The enums were never added to the assets for some reason, thus breaking adjacency. This commit goes over each asset that had either a generic or specific type and sets them to the correct value.