### PR TITLE
Fixes Memory Leak caused by Event Listeners

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -122,8 +122,9 @@ namespace SS3D.Systems.Interactions
             
             if (interactions.Count <= 0) { return; }
 
-            void handleInteractionSelected(IInteraction interaction)
+            void handleInteractionSelected(IInteraction interaction, RadialInteractionButton _)
             {
+                _radialView.OnInteractionSelected -= handleInteractionSelected;
                 string interactionName = interaction.GetName(interactionEvent);
 
                 CmdRunInteraction(ray, interactionName);
@@ -168,7 +169,7 @@ namespace SS3D.Systems.Interactions
 
                 _radialView.SetInteractions(interactions, interactionEvent, mousePosition);
 
-                void handleInteractionSelected(IInteraction interaction)
+                void handleInteractionSelected(IInteraction interaction, RadialInteractionButton _)
                 {
                     int index = entries.FindIndex(x => x.Interaction == interaction);
                     string interactionName = interaction.GetName(interactionEvent);

--- a/Assets/Scripts/SS3D/Systems/Interactions/RadialInteractionButton.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/RadialInteractionButton.cs
@@ -18,8 +18,13 @@ namespace SS3D.Systems.Interactions
 
         private IInteraction _interaction;
 
+        public IInteraction Interaction
+        {
+            get { return _interaction; }
+        }
+
         public Button.ButtonClickedEvent Pressed => _button.onClick;
-        public event Action<IInteraction> OnInteractionSelected;
+        public event Action<IInteraction, RadialInteractionButton> OnInteractionSelected;
         public event Action<GameObject, IInteraction> OnHovered;
 
         private const float MinimumThreshold = 0.5f;
@@ -51,7 +56,7 @@ namespace SS3D.Systems.Interactions
 
         private void HandleButtonPressed()
         {
-            OnInteractionSelected?.Invoke(_interaction);
+            OnInteractionSelected?.Invoke(_interaction, this);
         }
 
         public void Reset()

--- a/Assets/Scripts/SS3D/Systems/Interactions/RadialInteractionView.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/RadialInteractionView.cs
@@ -14,7 +14,7 @@ namespace SS3D.Systems.Interactions
     /// </summary>
     public sealed class RadialInteractionView : Core.Behaviours.System
     {
-        public event Action<IInteraction> OnInteractionSelected;
+        public event Action<IInteraction, RadialInteractionButton> OnInteractionSelected;
 
         [Header("UI")]
         [SerializeField] private CanvasGroup _canvasGroup;
@@ -73,10 +73,12 @@ namespace SS3D.Systems.Interactions
             _selectedObject = button;
         }
 
-        private void HandleInteractionButtonPressed(IInteraction interaction)
+        private void HandleInteractionButtonPressed(IInteraction interaction, RadialInteractionButton radialInteractionButton)
         {
+            radialInteractionButton.OnInteractionSelected -= HandleInteractionButtonPressed;
+
             Disappear();
-            OnInteractionSelected?.Invoke(interaction);
+            OnInteractionSelected?.Invoke(interaction, radialInteractionButton);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
There were some memory leak issues caused by Event Listener in the Interaction UI, basically, every time a interaction happened it would create more and more listeners, it was exponential since it was creating listeners both on the Radial Menu and the Interactions Controller, so each time a new listeners was created in one, another was created in the other as well.

## Changes to Files

Small changes to: InteractionController, RadialInteractionButton and RadialInteractionView

## Technical Notes (optional)

Since the listeners were attached to classes that were saved into local variables and therefore didn't have a later reference that could easily be used, I changed the event itself to also send a reference to the RadialInteractionButton, in the places where it wasn't needed(InteractionController), I just used saved it to a discarded "_" variable
