### PR TITLE
Rename entity game objects when spawned to help debugging

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Entities/EntitySpawnSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/EntitySpawnSystem.cs
@@ -193,7 +193,7 @@ namespace SS3D.Systems.Entities
             }
             // Rename the current PlayerControllable game object,
             // and send to the client the updated name of the other playerControllables already spawned.
-            UpdateNameOfHumanGameObject(ckey, controllable, humanNames);
+            RpcSetPlayerControllableName(ckey, controllable, humanNames);
        
             string message = $"Spawning player {soul.Ckey} on {controllable.name}";
             Punpun.Say(this, message, Logs.ServerOnly); 
@@ -211,7 +211,7 @@ namespace SS3D.Systems.Entities
         /// <param name="humanNames">The new names of the PlayerControllable game object. The order of the name in the list
         /// must be the same as the order of the PlayerControllable objects in _spawnedPlayers SyncList </param>
         [ObserversRpc]
-        private void UpdateNameOfHumanGameObject(string ckey, PlayerControllable controllable, List<string> humanNames)
+        private void RpcSetPlayerControllableName(string ckey, PlayerControllable controllable, List<string> humanNames)
         {
             int nameIndex = 0;
             
@@ -220,7 +220,7 @@ namespace SS3D.Systems.Entities
                 controllableAlreadySpawned.gameObject.name = humanNames.ElementAt(nameIndex);
                 nameIndex++;
             }
-            controllable.gameObject.name = "HumanTemp" + ckey;
+            controllable.gameObject.name = $"Player - {ckey}";
         }
 
         private void HandleSpawnedPlayersChanged(SyncListOperation op, int index, PlayerControllable old, PlayerControllable @new, bool asServer)


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->

## Summary
Rename HumanTemp game object, instantiated from the Human_Temporary prefab, with a name corresponding to their "soul" name. This has no other purpose than to facilitate debugging by giving a quick way to differentiate between two PlayerControllable game objects. 
Name changes are visible in editor.
This work whether client or host is run in the editor. 

![image](https://user-images.githubusercontent.com/14344825/211195070-444cdc6e-b217-4be3-88a8-2de9f64a2994.png)

