### PR TITLE
Fix the bug not allowing to switch active hands by clicking on the UI.

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Storage/UI/ItemDisplay.cs
+++ b/Assets/Scripts/SS3D/Systems/Storage/UI/ItemDisplay.cs
@@ -67,9 +67,13 @@ namespace SS3D.Systems.Storage.UI
         
         public void OnPointerClick(PointerEventData eventData)
         {
-            // WOW Unity, this is some amazing UI stuff
-            IPointerClickHandler pointerDownHandler = transform.parent.GetComponentInParent<IPointerClickHandler>();
-            pointerDownHandler?.OnPointerClick(eventData);
+            // Somehow, itemdisplay hides the other IPointerClickHandler in it's parent, so the event OnpointerClick is never
+            // called, for exemple in SingleItemContainerSlot. That's why we need to call the events on the parent from there.
+            var pointerDownHandlers = transform.parent.GetComponentsInParent<IPointerClickHandler>();
+            foreach (var pointerHandler in pointerDownHandlers)
+            {
+                pointerHandler?.OnPointerClick(eventData);
+            }
         }
 
         public void OnBeginDrag(PointerEventData eventData)

--- a/Assets/Scripts/SS3D/Systems/Storage/UI/SingleItemContainerSlot.cs
+++ b/Assets/Scripts/SS3D/Systems/Storage/UI/SingleItemContainerSlot.cs
@@ -76,12 +76,7 @@ namespace SS3D.Systems.Storage.UI
         public void OnPointerClick(PointerEventData eventData)
         {
             Inventory.ClientInteractWithSingleSlot(_container);
-
-            // When receiving a click on one of the hands of the UI, change the current active hand with the one clicked.
-            if (eventData.pointerPress.name is "HandRight(Clone)" or "HandLeft(Clone)")
-            {
-                Inventory.ActivateHand(_container);
-            }
+            Inventory.ActivateHand(_container);
         }
 		
 		public GameObject GetCurrentGameObjectInSlot()


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->

## Summary

It's currently not possible to switch between hands by clicking on the UI. It was possible before.
 This PR corrects this issue.


## Technical Notes (optional)

- Removed the condition on the name of `eventData.pointerPress.name`. This always return "itemImage" since it's the 
game object in front of the UI.
- The current code only get one IPointerClickHandler in the parent, but there's three of them, hence it was never calling two of them. The PR solves this by calling OnPointerClick on all IPointerClickHandler in the parent.


