### PR TITLE
Pickup Icon

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
@@ -196,7 +196,7 @@ namespace SS3D.Systems.Storage.Items
 
         public virtual IInteraction[] CreateTargetInteractions(InteractionEvent interactionEvent)
         {
-            return new IInteraction[] { new PickupInteraction { Icon = _sprite } };
+            return new IInteraction[] { new PickupInteraction { Icon = null } };
         }
 
         // this creates the base interactions for an item, in this case, the drop interaction


### PR DESCRIPTION
## Summary

Ensures that the Pickup icon is always used for pickup in lieu of the item sprite.

## Fixes (optional)

Closes #1004
