### PR TITLE
Fix player list on dedicated server

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Lobby/UI/PlayerUsernameListView.cs
+++ b/Assets/Scripts/SS3D/Systems/Lobby/UI/PlayerUsernameListView.cs
@@ -36,9 +36,9 @@ namespace SS3D.Systems.Lobby.UI
             AddHandle(ReadyPlayersChanged.AddListener(HandleReadyPlayersChanged));
         }
 
-        public override void OnStartClient()
+        public override void OnStartNetwork()
         {
-            base.OnStartClient();
+            base.OnStartNetwork();
             SubscribeToEvents();
         }
 


### PR DESCRIPTION
## Summary

Player list enabled on dedicated server by subscribing to relevant events.

## Fixes

Closes #993 
