### PR TITLE
Add ServerOrClient attribute

### DIFF
--- a/Assets/Scripts/SS3D/Attributes/ServerOrClientAttribute.cs
+++ b/Assets/Scripts/SS3D/Attributes/ServerOrClientAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+
+/// <summary>
+/// Informative only attribute, does not make any check.
+/// Use it to let contributors know that method can be called client or server side.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
+public class ServerOrClientAttribute : Attribute
+{
+
+}

--- a/Assets/Scripts/SS3D/Attributes/ServerOrClientAttribute.cs.meta
+++ b/Assets/Scripts/SS3D/Attributes/ServerOrClientAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a0caffb27e2a904482818f04149c52e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -28,10 +28,9 @@ namespace SS3D.Systems.Interactions
         private Camera _camera;
         private RadialInteractionView _radialView;
 
-        [Client]
-        protected override void OnStart()
+        public override void OnStartClient()
         {
-            base.OnStart();
+            base.OnStartClient();
 
             _radialView = SystemLocator.Get<RadialInteractionView>();
             _camera = SystemLocator.Get<CameraSystem>().PlayerCamera.GetComponent<Camera>();

--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -36,12 +36,12 @@ namespace SS3D.Systems.Interactions
             _camera = SystemLocator.Get<CameraSystem>().PlayerCamera.GetComponent<Camera>();
         }
 
-        [Client]
+        [ServerOrClient]
         protected override void HandleUpdate(in float deltaTime)
         {
             base.HandleUpdate(in deltaTime);
 
-            if (!IsOwner || _camera == null || EventSystem.current.IsPointerOverGameObject())
+            if (IsServerOnly || !IsOwner || _camera == null || EventSystem.current.IsPointerOverGameObject())
             {
                 return;
             }

--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -28,6 +28,7 @@ namespace SS3D.Systems.Interactions
         private Camera _camera;
         private RadialInteractionView _radialView;
 
+        [Client]
         protected override void OnStart()
         {
             base.OnStart();
@@ -36,6 +37,7 @@ namespace SS3D.Systems.Interactions
             _camera = SystemLocator.Get<CameraSystem>().PlayerCamera.GetComponent<Camera>();
         }
 
+        [Client]
         protected override void HandleUpdate(in float deltaTime)
         {
             base.HandleUpdate(in deltaTime);
@@ -61,11 +63,13 @@ namespace SS3D.Systems.Interactions
             }
         }
 
+        [Client]
         private void ProcessPrimaryClick()
         {
             RunPrimaryInteraction();
         }
 
+        [Client]
         private void ProcessSecondaryClick()
         {
             Ray ray = _camera.ScreenPointToRay(Input.mousePosition);
@@ -74,6 +78,7 @@ namespace SS3D.Systems.Interactions
             ViewTargetInteractions(viableInteractions, interactionEvent, ray);
         }
 
+        [Client]
         private void ProcessUse()
         {
             // Activate item in selected hand
@@ -93,6 +98,7 @@ namespace SS3D.Systems.Interactions
         /// <summary>
         /// Runs the most prioritised action
         /// </summary>
+        [Client]
         private void RunPrimaryInteraction()
         {
             Ray ray = _camera.ScreenPointToRay(Input.mousePosition);
@@ -116,6 +122,7 @@ namespace SS3D.Systems.Interactions
         /// <param name="viableInteractions"></param>
         /// <param name="interactionEvent"></param>
         /// <param name="ray"></param>
+        [Client]
         private void ViewTargetInteractions(List<InteractionEntry> viableInteractions, InteractionEvent interactionEvent, Ray ray)
         {
             List<IInteraction> interactions = viableInteractions.Select(entry => entry.Interaction).ToList();
@@ -238,6 +245,7 @@ namespace SS3D.Systems.Interactions
         /// <param name="ray">The ray to use in ray casting</param>
         /// <param name="interactionEvent">The produced interaction event</param>
         /// <returns>A list of possible interactions</returns>
+        [ServerOrClient]
         private List<InteractionEntry> GetViableInteractions(Ray ray, out InteractionEvent interactionEvent)
         {
             // Get source that's currently interacting (eg. hand, tool)
@@ -272,6 +280,7 @@ namespace SS3D.Systems.Interactions
         /// <param name="source">The source of the interaction</param>
         /// <param name="targetGameObject">The game objects the interaction targets are on</param>
         /// <returns>A list of all valid interaction targets</returns>
+        [ServerOrClient]
         private List<IInteractionTarget> GetTargetsFromGameObject(IInteractionSource source, GameObject targetGameObject)
         {
             List<IInteractionTarget> targets = new();
@@ -293,6 +302,7 @@ namespace SS3D.Systems.Interactions
         /// <param name="targets">The interaction targets</param>
         /// <param name="interactionEvent">The interaction event data</param>
         /// <returns>A list of all possible interaction entries</returns>
+        [ServerOrClient]
         private List<InteractionEntry> GetInteractionsFromTargets(IInteractionSource source, List<IInteractionTarget> targets, InteractionEvent interactionEvent)
         {
             List<InteractionEntry> interactions = new();
@@ -329,6 +339,7 @@ namespace SS3D.Systems.Interactions
             return interactionsFromTargets;
         }
 
+        [ServerOrClient]
         private IInteractionSource GetActiveInteractionSource()
         {
             IToolHolder toolHolder = GetComponent<IToolHolder>();


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->

## Summary

The ServerOrClient attribute simply allows to explicitly state that a given method can be called both by server and by a client.
This improve readability by a lot, at least for me.
It doesn't affect the code in any other way.

This PR also apply the attribute in the InteractionController code, and it adds client and server attributes on other methods lacking them (and which should be only called from client or server).
