### PR TITLE
Apply the PermissionSystem.IsAtLeast method

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Permissions/DisableIfNotAdmin.cs
+++ b/Assets/Scripts/SS3D/Systems/Permissions/DisableIfNotAdmin.cs
@@ -46,9 +46,7 @@ namespace SS3D.Systems.Permissions
                 return;
             }
 
-            permissionSystem.TryGetUserRole(_ckey, out ServerRoleTypes role);
-
-            if (role == ServerRoleTypes.Administrator)
+            if (permissionSystem.IsAtLeast(_ckey, ServerRoleTypes.Administrator))
             {
                 return;
             }

--- a/Assets/Scripts/SS3D/Systems/Permissions/PermissionSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Permissions/PermissionSystem.cs
@@ -161,7 +161,7 @@ namespace SS3D.Systems.Permissions
             SyncUserPermissions();
         }
 
-        public bool isAtLeast(string ckey, ServerRoleTypes permissionLevelCheck)
+        public bool IsAtLeast(string ckey, ServerRoleTypes permissionLevelCheck)
         {
             TryGetUserRole(ckey, out ServerRoleTypes userPermission);
 

--- a/Assets/Scripts/SS3D/Systems/Rounds/RoundSystemBase.cs
+++ b/Assets/Scripts/SS3D/Systems/Rounds/RoundSystemBase.cs
@@ -114,7 +114,7 @@ namespace SS3D.Systems.Rounds
             string userCkey = playerSystem.GetCkey(conn);
 
             // Checks if player can call a round start
-            if (permissionSystem.TryGetUserRole(userCkey, out ServerRoleTypes role) && role != requiredRole)
+            if (!permissionSystem.IsAtLeast(userCkey, requiredRole))
             {
                 string message = $"User {userCkey} doesn't have {requiredRole} permission";
                 Punpun.Say(this, message, Logs.ServerOnly);


### PR DESCRIPTION
## Summary

Replaces TryGetUserRole calls with IsAtLeast calls, as introduced in #1014.

## Technical Notes

Replaced calls are not strictly equivalent. Previously, a Server Owner (hierarchically greater than an Administrator) would not be able to start rounds or access Administrator controls. That bug is resolved with the use of the IsAtLeast method.

## Fixes (optional)

Completes the optional part of #1001.
