### PR TITLE
Lobby: Update player list when players leave.

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Lobby/UI/PlayerUsernameListView.cs
+++ b/Assets/Scripts/SS3D/Systems/Lobby/UI/PlayerUsernameListView.cs
@@ -49,15 +49,14 @@ namespace SS3D.Systems.Lobby.UI
 
         private void HandleOnlineSoulsChanged(ref EventContext context, in OnlineSoulsChanged e)
         {
-            Soul soul = e.Changed;
+            string ckey = e.ChangedCkey;
 
-            if (soul == null)
+            if (ckey == null)
             {
                 return;
             }
 
             ChangeType changeType = e.ChangeType;
-            string ckey = soul.Ckey;
 
             switch (changeType)
             {

--- a/Assets/Scripts/SS3D/Systems/PlayerControl/Events/OnlineSoulsChanged.cs
+++ b/Assets/Scripts/SS3D/Systems/PlayerControl/Events/OnlineSoulsChanged.cs
@@ -9,14 +9,14 @@ namespace SS3D.Systems.PlayerControl.Events
         public readonly List<Soul> OnlineSouls;
 
         public ChangeType ChangeType;
-        public readonly Soul Changed;
+        public readonly Soul ChangedSoul;
         public readonly string ChangedCkey;
 
         public OnlineSoulsChanged(List<Soul> onlineSouls, ChangeType changeType, Soul changed, string ckey)
         {
             OnlineSouls = onlineSouls;
             ChangeType = changeType;
-            Changed = changed;
+            ChangedSoul = changed;
             ChangedCkey = ckey;
         }
     }

--- a/Assets/Scripts/SS3D/Systems/PlayerControl/Events/OnlineSoulsChanged.cs
+++ b/Assets/Scripts/SS3D/Systems/PlayerControl/Events/OnlineSoulsChanged.cs
@@ -10,12 +10,14 @@ namespace SS3D.Systems.PlayerControl.Events
 
         public ChangeType ChangeType;
         public readonly Soul Changed;
+        public readonly string ChangedCkey;
 
-        public OnlineSoulsChanged(List<Soul> onlineSouls, ChangeType changeType, Soul changed)
+        public OnlineSoulsChanged(List<Soul> onlineSouls, ChangeType changeType, Soul changed, string ckey)
         {
             OnlineSouls = onlineSouls;
             ChangeType = changeType;
             Changed = changed;
+            ChangedCkey = ckey;
         }
     }
 }

--- a/Assets/Scripts/SS3D/Systems/PlayerControl/PlayerSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/PlayerControl/PlayerSystem.cs
@@ -91,7 +91,7 @@ namespace SS3D.Systems.PlayerControl
                     break;
             }
 
-            OnlineSoulsChanged serverSoulsChanged = new(_onlineSouls.Values.ToList(), changeType, value);
+            OnlineSoulsChanged serverSoulsChanged = new(_onlineSouls.Values.ToList(), changeType, value, key);
             serverSoulsChanged.Invoke(this);
         }
 

--- a/Assets/Scripts/SS3D/Systems/Rounds/ReadyPlayersSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Rounds/ReadyPlayersSystem.cs
@@ -118,7 +118,7 @@ namespace SS3D.Systems.Rounds
         [Server]
         private void HandleUserLeftServer(ref EventContext context, in OnlineSoulsChanged e)
         {
-            RemoveReadyPlayer(e.Changed, e.ChangeType);
+            RemoveReadyPlayer(e.ChangedSoul, e.ChangeType);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Allows player list in Lobby to be updated when players leave.

## Technical Notes (optional)

Added string argument to OnlineSoulsChanged event, to prevent nullification of soul limiting client-side functionality.

## Fixes

Closes #994 