### PR TITLE
Bugfix: SpawnedPlayers returns unique players on client 

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Entities/MindSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/MindSystem.cs
@@ -14,7 +14,7 @@ namespace SS3D.Systems.Entities
     public class MindSystem : NetworkSystem
     {
         [SerializeField]
-        private Mind _mindPrefab;
+        private GameObject _mindPrefab;
 
         [SerializeField]
         private Mind _emptyMind;
@@ -73,7 +73,7 @@ namespace SS3D.Systems.Entities
                 return false;
             }
 
-            Mind mind = Instantiate(_mindPrefab);
+            Mind mind = Instantiate(_mindPrefab).GetComponent<Mind>();
             ServerManager.Spawn(mind.GameObjectCache, soul.Owner);
 
             mind.SetSoul(soul);

--- a/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/CommandsContainer.cs
+++ b/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/CommandsContainer.cs
@@ -67,6 +67,18 @@ namespace SS3D.Systems.IngameConsoleSystem
             }
             return ret;
         }
+        [ShortDescription("Show all entities that have spawned in-game")]
+        [LongDescription("Show all entities that have spawned in-game")]
+        public static string EntityList()
+        {
+            string ret = "";
+            var entities = SystemLocator.Get<EntitySystem>().SpawnedPlayers;
+            foreach (Entity entity in entities)
+            {
+                ret += entity.Ckey + "\t";
+            }
+            return ret;
+        }
         [ShortDescription("Change user permission")]
         [LongDescription("changeperms (user ckey) (required role)")]
         public static string ChangePerms(string ckey, string role)


### PR DESCRIPTION


<!-- The notes within these arrows are for you but can be deleted. -->

## Summary

When run as client-only, EntitySystem.SpawnedPlayers was erroneously returning duplicates of a single ckey, rather than unique ckeys for each spawned player. This PR resolves that issue.

## Technical Notes

The root cause of the duplicate ckeys was the Mind. Server-side, there exists an Empty Mind, as well as a Mind for each player: "Empty Mind", "Mind - hostinguser", "Mind - john" etc. However, client-side, there only ever existed a single mind at a time, which would be renamed to the most recently joined Mind. For example, in the scene hierarchy the client initially sees "Empty Mind", but this object changes to "Mind - john" when john connects. Thus all entities on a client scene contain a reference to the same Mind, which naturally then has a reference to the same Soul and the same ckey.

The above symptoms suggested that there was something wrong with spawning Minds over the network. Changing the _mindPrefab to a standard GameObject (rather than a Mind) fixed that issue, although I am still not certain exactly why that issue existed in the first place.

## Changes to Files
- Changed MindSystem._mindPrefab from Mind to GameObject, to allow for correct spawning over the network
- Reset above variable in the MindSystem inspector in Lobby scene
- Added EntityList command to CommandsContainer for ease of testing and review

## Fixes

Closes #988
