### PR TITLE
Resolve item desync bug

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
@@ -111,7 +111,7 @@ namespace SS3D.Systems.Storage.Items
                 animator.keepAnimatorControllerStateOnDisable = true;
             }
 
-            if (_rigidbody != null && IsClient)
+            if (_rigidbody != null && IsClientOnly)
             {
                 _rigidbody.isKinematic = true;
             }

--- a/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
@@ -159,7 +159,8 @@ namespace SS3D.Systems.Storage.Items
         {
             if (_rigidbody != null)
             {
-                _rigidbody.isKinematic = false;
+                if (IsServer)
+                    _rigidbody.isKinematic = false;
             }
             var itemCollider = GetComponent<Collider>();
             if (itemCollider != null)

--- a/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
@@ -111,6 +111,11 @@ namespace SS3D.Systems.Storage.Items
                 animator.keepAnimatorControllerStateOnDisable = true;
             }
 
+            if (_rigidbody != null && IsClient)
+            {
+                _rigidbody.isKinematic = true;
+            }
+
             // Items can't have no size
             if (_size.x == 0)
             {

--- a/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Storage/Items/Item.cs
@@ -111,6 +111,7 @@ namespace SS3D.Systems.Storage.Items
                 animator.keepAnimatorControllerStateOnDisable = true;
             }
 
+            // Clients don't need to calculate physics for rigidbodies as this is handled by the server
             if (_rigidbody != null && IsClientOnly)
             {
                 _rigidbody.isKinematic = true;


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->

## Summary
Attempt at resolving the item desync bug.

Seems to be caused by having the not-kinematic option set by Item.cs when placing an item. Normally this is not an issue, but it seems to act in a strange manner in combination with a NetworkTransform on the client. When placed sideways, the rigidbody on an object causes a rotation sync which creates the position drift.

Please test more before merging since I had some difficulties reliably reproducing the issue.
<!-- Provide a general summary of your change here and in the title. -->

<!-- Follow with a more concise explanation of your change here. -->

<!-- What features does this change include/not include? -->


## Fixes
#1017 
<!-- List any issues or other PRs connected to this one. -->

<!-- If this PR CLOSES any issues/PRs, add "Closes" before the number (e.g. "Closes #123"). -->
