### PR TITLE
Resolved bug where menu did not automatically close on embarkation.

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Screens/GameScreensController.cs
+++ b/Assets/Scripts/SS3D/Systems/Screens/GameScreensController.cs
@@ -1,9 +1,8 @@
 using Coimbra.Services.Events;
 using SS3D.Core;
 using SS3D.Core.Behaviours;
-using SS3D.Systems.Entities;
 using SS3D.Systems.Entities.Events;
-using SS3D.Systems.PlayerControl;
+using SS3D.Systems.Rounds.Events;
 using SS3D.Systems.Screens.Events;
 using UnityEngine;
 
@@ -13,6 +12,7 @@ namespace SS3D.Systems.Screens
     {
         [SerializeField] private bool _blockNone;
         [SerializeField] private bool _menuOpen;
+        private PlayerSpawnedState _spawnedState;
 
         protected override void OnStart()
         {
@@ -20,22 +20,42 @@ namespace SS3D.Systems.Screens
 
             _menuOpen = true;
             _blockNone = true;
+            _spawnedState = PlayerSpawnedState.IsNotSpawned;
 
             ChangeGameScreenEvent.AddListener(HandleChangeGameScreen);
             SpawnedPlayersUpdated.AddListener(HandleSpawnedPlayersUpdated);
+            RoundStateUpdated.AddListener(HandleRoundStateUpdated);
         }
 
         private void HandleSpawnedPlayersUpdated(ref EventContext context, in SpawnedPlayersUpdated e)
         {
             bool isPlayerSpawned = e.SpawnedPlayers.Find(controllable => controllable.Owner == LocalConnection);
 
-            if (!isPlayerSpawned)
+            if (!isPlayerSpawned && _spawnedState == PlayerSpawnedState.ConfirmedSpawned)
             {
-                _menuOpen = true;
+                LockToMenuScreen();
             }
 
-            _blockNone = !isPlayerSpawned;
+            if (isPlayerSpawned)
+            {
+                GivePlayerAccessToGame();
+            }
+
             UpdateScreen();
+        }
+
+        private void HandleRoundStateUpdated(ref EventContext context, in RoundStateUpdated e)
+        {
+            switch (e.RoundState)
+            {
+                case Rounds.RoundState.Ongoing:
+                case Rounds.RoundState.Ending:
+                    break;
+                default:
+                    LockToMenuScreen();
+                    UpdateScreen();
+                    break;
+            }
         }
 
         private void HandleChangeGameScreen(ref EventContext context, in ChangeGameScreenEvent e)
@@ -45,6 +65,7 @@ namespace SS3D.Systems.Screens
             if (screenType == ScreenType.None)
             {
                 _menuOpen = false;
+                MarkNewlySpawnedPlayerAsAwaitingConfirmation();
             }
 
             if (screenType == ScreenType.Lobby)
@@ -76,6 +97,49 @@ namespace SS3D.Systems.Screens
             ChangeGameScreenEvent changeGameScreenEvent = new(newScreen);
 
             changeGameScreenEvent.Invoke(this);
+        }
+
+        /// <summary>
+        /// Prevents the player from leaving the menu screen.
+        /// </summary>
+        private void LockToMenuScreen()
+        {
+            _blockNone = true;
+            _menuOpen = true;
+            _spawnedState = PlayerSpawnedState.IsNotSpawned;
+        }
+
+        /// <summary>
+        /// Gives the player the ability to toggle in and out of the
+        /// menu, and records that they have been added to the Spawned
+        /// Players list.
+        /// </summary>
+        private void GivePlayerAccessToGame()
+        {
+            _blockNone = false;
+            _spawnedState = PlayerSpawnedState.ConfirmedSpawned;
+        }
+
+        /// <summary>
+        /// Identifies that the entity may have spawned recently, and
+        /// may not yet been reflected in the Spawned Players list.
+        /// </summary>
+        private void MarkNewlySpawnedPlayerAsAwaitingConfirmation()
+        {
+            if (_spawnedState == PlayerSpawnedState.IsNotSpawned)
+            {
+                _spawnedState = PlayerSpawnedState.AwaitingConfirmationOfSpawn;
+            }
+        }
+
+        /// <summary>
+        /// Internal enum to describe player spawn state.
+        /// </summary>
+        private enum PlayerSpawnedState
+        {
+            IsNotSpawned,
+            AwaitingConfirmationOfSpawn,
+            ConfirmedSpawned
         }
     }
 }


### PR DESCRIPTION
## Summary

When attempting to join, the menu screen sometimes does not close. This PR resolves that bug.

## Changes to Files

All changes are local to **GameScreensController.cs**.

## Technical Notes

### Bug description
Through testing, the bug was identified to manifest at round start when multiple ready players joined simultaneously. This bug always occurred in all but one of the connected players (i.e. if there were eight players joining at round start, seven of them would not have their menu automatically close).

### Root cause

 - The **LocalPlayerObjectChange** event is invoked during player spawning (as part of synchronising the Mind in **Entity.cs**), and triggers a series of methods and events which lead to the menu screen being closed. Note that this method is called before the **SpawnedPlayersUpdated** event is invoked.

 - The HandleSpawnedPlayersUpdated method in **GameScreensController.cs** is called every time the **SpawnedPlayersUpdated** event is invoked. Note that it is called every time the SpawnedPlayers list is updated and provides the entire list of spawned players. So for eight ready players at round start, each of them would receive eight **SpawnedPlayersUpdated** events. The first event would only list one entity, the second event lists two entities, the final event list all of them etc.

 - The HandleSpawnedPlayersUpdated method contained the following code block. Because it runs multiple times, it will make the menu reappear for any player that is not in the SpawnedPlayers list *every* time it is run (i.e. only the first player to spawn will not have the menu reopened).
```cs
            bool isPlayerSpawned = e.SpawnedPlayers.Find(controllable => controllable.Owner == LocalConnection);
            if (!isPlayerSpawned)
            {
                _menuOpen = true;
            }
```

### Resolution

Added state to capture where the player is in the spawning process. The HandleSpawnedPlayersUpdated method will now not force the player back to the menu until after they have originally appeared in the SpawnedPlayers list. Therefore, whenever they are forced back to the menu is a 'genuine' despawn.

## Fixes

Closes #1019
