### PR TITLE
Fixed issue where dispensing items did not work with a dedicated server.

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Furniture/DispenseProductInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/DispenseProductInteraction.cs
@@ -45,7 +45,7 @@ namespace SS3D.Systems.Furniture
 
             if (target is VendingMachine vendingMachine)
             {
-                vendingMachine.CmdDispenseProduct();
+                vendingMachine.DispenseProduct();
             }
             return false;
         }

--- a/Assets/Scripts/SS3D/Systems/Furniture/VendingMachine.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/VendingMachine.cs
@@ -43,7 +43,7 @@ namespace SS3D.Systems.Furniture
         /// Dispenses the vending machine product at the dispensing transform position with a random rotation.
         /// </summary>
         [Server]
-        private void DispenseProduct()
+        public void DispenseProduct()
         {
             ItemSystem itemSystem = SystemLocator.Get<ItemSystem>();
             Quaternion quaternion = Quaternion.Euler(new Vector3(Random.Range(0, 360), Random.Range(0, 360), Random.Range(0, 360)));


### PR DESCRIPTION
## Summary

Dispensing items now functions when playing with a dedicated server.

## Technical Notes

Interactions run on the server; however, the dispense product interaction Start method called CmdDispenseProduct (a ServerRPC which can only run on clients). This method simply calls DispenseProduct, which is a server-side method only. Therefore, only a host (i.e. Client and Server) could run the interaction. Issue resolved by calling DispenseProduct directly from the Start method.

## Fixes

Closes #1031
