### PR TITLE
Replace Input Manager in TileMapCreator with Input Actions. 

### DIFF
--- a/Assets/Content/Input/Controls.inputactions
+++ b/Assets/Content/Input/Controls.inputactions
@@ -581,6 +581,94 @@
                     "isPartOfComposite": false
                 }
             ]
+        },
+        {
+            "name": "Tile Creator",
+            "id": "f09dab6d-d07b-4287-8d9b-d0063c3232e3",
+            "actions": [
+                {
+                    "name": "Toggle Menu",
+                    "type": "Button",
+                    "id": "33c0c58f-fde8-4c73-ac8f-b8bfb2d98356",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Place",
+                    "type": "Button",
+                    "id": "fb428f7f-c99e-4c81-b825-65cea417ee0d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Replace",
+                    "type": "Button",
+                    "id": "f49d6ece-3eb7-4e55-9e29-a95eadff8a64",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Rotate",
+                    "type": "Button",
+                    "id": "3d66fa43-e646-40a5-9c1c-a7cd6fbf765b",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "9da0c76e-68b2-4fec-a5d3-fcd559c221bf",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Place",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "78cc14e5-d0e3-4503-949c-e1a9a26f70db",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Replace",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "90e9bf7e-63bd-45ae-8d5f-8bf929ac9883",
+                    "path": "<Keyboard>/r",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Rotate",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "25bca2ed-74c2-46ad-bc12-12738567e0e8",
+                    "path": "<Keyboard>/b",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Toggle Menu",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
         }
     ],
     "controlSchemes": []

--- a/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/ConsolePanelView.cs
+++ b/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/ConsolePanelView.cs
@@ -38,7 +38,7 @@ namespace SS3D.Systems.IngameConsoleSystem
         /// <summary>
         /// Contains actions enabled states before opening the console
         /// </summary>
-        private Dictionary<string, bool> _actionsStates;
+        private Dictionary<InputAction, bool> _actionsStates;
 
         private Controls.ConsoleActions _consoleControls;
 
@@ -86,11 +86,11 @@ namespace SS3D.Systems.IngameConsoleSystem
             _targetPointMax = _targetPointMin + new Vector2(0, _consolePanel.rect.height);
             _inputField.DeactivateInputField();
 
-            foreach (KeyValuePair<string, bool> _actionState in _actionsStates)
+            foreach (KeyValuePair<InputAction, bool> _actionState in _actionsStates)
             {
                 if (_actionState.Value)
                 {
-                    _controls.FindAction(_actionState.Key).Enable();
+                    _actionState.Key.Enable();
                 }
             }
             _consoleControls.Disable();
@@ -109,7 +109,7 @@ namespace SS3D.Systems.IngameConsoleSystem
             _actionsStates = new();
             foreach (InputAction action in _controls)
             {
-                _actionsStates.Add(action.name, action.enabled);
+                _actionsStates.Add(action, action.enabled);
             }
             _controls.Disable();
             _consoleControls.Enable();

--- a/Assets/Scripts/SS3D/Systems/Input/Controls.cs
+++ b/Assets/Scripts/SS3D/Systems/Input/Controls.cs
@@ -603,6 +603,94 @@ public partial class @Controls : IInputActionCollection2, IDisposable
                     ""isPartOfComposite"": false
                 }
             ]
+        },
+        {
+            ""name"": ""Tile Creator"",
+            ""id"": ""f09dab6d-d07b-4287-8d9b-d0063c3232e3"",
+            ""actions"": [
+                {
+                    ""name"": ""Toggle Menu"",
+                    ""type"": ""Button"",
+                    ""id"": ""33c0c58f-fde8-4c73-ac8f-b8bfb2d98356"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Place"",
+                    ""type"": ""Button"",
+                    ""id"": ""fb428f7f-c99e-4c81-b825-65cea417ee0d"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Replace"",
+                    ""type"": ""Button"",
+                    ""id"": ""f49d6ece-3eb7-4e55-9e29-a95eadff8a64"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Rotate"",
+                    ""type"": ""Button"",
+                    ""id"": ""3d66fa43-e646-40a5-9c1c-a7cd6fbf765b"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                }
+            ],
+            ""bindings"": [
+                {
+                    ""name"": """",
+                    ""id"": ""9da0c76e-68b2-4fec-a5d3-fcd559c221bf"",
+                    ""path"": ""<Mouse>/leftButton"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Place"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""78cc14e5-d0e3-4503-949c-e1a9a26f70db"",
+                    ""path"": ""<Keyboard>/leftShift"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Replace"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""90e9bf7e-63bd-45ae-8d5f-8bf929ac9883"",
+                    ""path"": ""<Keyboard>/r"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Rotate"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""25bca2ed-74c2-46ad-bc12-12738567e0e8"",
+                    ""path"": ""<Keyboard>/b"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Toggle Menu"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                }
+            ]
         }
     ],
     ""controlSchemes"": []
@@ -638,6 +726,12 @@ public partial class @Controls : IInputActionCollection2, IDisposable
         m_Other_SecondaryClick = m_Other.FindAction("Secondary Click", throwIfNotFound: true);
         m_Other_ToggleMenu = m_Other.FindAction("Toggle Menu", throwIfNotFound: true);
         m_Other_SpawnCans = m_Other.FindAction("Spawn Cans", throwIfNotFound: true);
+        // Tile Creator
+        m_TileCreator = asset.FindActionMap("Tile Creator", throwIfNotFound: true);
+        m_TileCreator_ToggleMenu = m_TileCreator.FindAction("Toggle Menu", throwIfNotFound: true);
+        m_TileCreator_Place = m_TileCreator.FindAction("Place", throwIfNotFound: true);
+        m_TileCreator_Replace = m_TileCreator.FindAction("Replace", throwIfNotFound: true);
+        m_TileCreator_Rotate = m_TileCreator.FindAction("Rotate", throwIfNotFound: true);
     }
 
     public void Dispose()
@@ -986,6 +1080,63 @@ public partial class @Controls : IInputActionCollection2, IDisposable
         }
     }
     public OtherActions @Other => new OtherActions(this);
+
+    // Tile Creator
+    private readonly InputActionMap m_TileCreator;
+    private ITileCreatorActions m_TileCreatorActionsCallbackInterface;
+    private readonly InputAction m_TileCreator_ToggleMenu;
+    private readonly InputAction m_TileCreator_Place;
+    private readonly InputAction m_TileCreator_Replace;
+    private readonly InputAction m_TileCreator_Rotate;
+    public struct TileCreatorActions
+    {
+        private @Controls m_Wrapper;
+        public TileCreatorActions(@Controls wrapper) { m_Wrapper = wrapper; }
+        public InputAction @ToggleMenu => m_Wrapper.m_TileCreator_ToggleMenu;
+        public InputAction @Place => m_Wrapper.m_TileCreator_Place;
+        public InputAction @Replace => m_Wrapper.m_TileCreator_Replace;
+        public InputAction @Rotate => m_Wrapper.m_TileCreator_Rotate;
+        public InputActionMap Get() { return m_Wrapper.m_TileCreator; }
+        public void Enable() { Get().Enable(); }
+        public void Disable() { Get().Disable(); }
+        public bool enabled => Get().enabled;
+        public static implicit operator InputActionMap(TileCreatorActions set) { return set.Get(); }
+        public void SetCallbacks(ITileCreatorActions instance)
+        {
+            if (m_Wrapper.m_TileCreatorActionsCallbackInterface != null)
+            {
+                @ToggleMenu.started -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnToggleMenu;
+                @ToggleMenu.performed -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnToggleMenu;
+                @ToggleMenu.canceled -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnToggleMenu;
+                @Place.started -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnPlace;
+                @Place.performed -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnPlace;
+                @Place.canceled -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnPlace;
+                @Replace.started -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnReplace;
+                @Replace.performed -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnReplace;
+                @Replace.canceled -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnReplace;
+                @Rotate.started -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnRotate;
+                @Rotate.performed -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnRotate;
+                @Rotate.canceled -= m_Wrapper.m_TileCreatorActionsCallbackInterface.OnRotate;
+            }
+            m_Wrapper.m_TileCreatorActionsCallbackInterface = instance;
+            if (instance != null)
+            {
+                @ToggleMenu.started += instance.OnToggleMenu;
+                @ToggleMenu.performed += instance.OnToggleMenu;
+                @ToggleMenu.canceled += instance.OnToggleMenu;
+                @Place.started += instance.OnPlace;
+                @Place.performed += instance.OnPlace;
+                @Place.canceled += instance.OnPlace;
+                @Replace.started += instance.OnReplace;
+                @Replace.performed += instance.OnReplace;
+                @Replace.canceled += instance.OnReplace;
+                @Rotate.started += instance.OnRotate;
+                @Rotate.performed += instance.OnRotate;
+                @Rotate.canceled += instance.OnRotate;
+            }
+        }
+    }
+    public TileCreatorActions @TileCreator => new TileCreatorActions(this);
     public interface ICameraActions
     {
         void OnZoom(InputAction.CallbackContext context);
@@ -1021,5 +1172,12 @@ public partial class @Controls : IInputActionCollection2, IDisposable
         void OnSecondaryClick(InputAction.CallbackContext context);
         void OnToggleMenu(InputAction.CallbackContext context);
         void OnSpawnCans(InputAction.CallbackContext context);
+    }
+    public interface ITileCreatorActions
+    {
+        void OnToggleMenu(InputAction.CallbackContext context);
+        void OnPlace(InputAction.CallbackContext context);
+        void OnReplace(InputAction.CallbackContext context);
+        void OnRotate(InputAction.CallbackContext context);
     }
 }

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapCreator.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapCreator.cs
@@ -1,10 +1,7 @@
 using Coimbra;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using SS3D.Systems.Tile;
 using SS3D.Core;
-using UnityEngine.UIElements;
 using UnityEngine.EventSystems;
 using System.Linq;
 using TMPro;
@@ -13,6 +10,7 @@ using FishNet.Connection;
 using SS3D.Logging;
 using SS3D.Core.Behaviours;
 using SS3D.Systems.Tile.TileMapCreator;
+using UnityEngine.InputSystem;
 
 namespace SS3D.Systems.Tile.UI
 {
@@ -40,6 +38,7 @@ namespace SS3D.Systems.Tile.UI
         private Plane _plane;
 
         private List<GenericObjectSo> _objectDatabase;
+        private Controls.TileCreatorActions _controls;
 
         public bool IsDeleting
         {
@@ -58,6 +57,51 @@ namespace SS3D.Systems.Tile.UI
         private void Start()
         {
             ShowUI(false);
+            _controls = SystemLocator.Get<InputSystem>().Inputs.TileCreator;
+            _controls.ToggleMenu.Enable();
+            _controls.ToggleMenu.performed += HandleToggleMenu;
+            _controls.Replace.performed += HandleReplace;
+            _controls.Replace.canceled += HandleReplace;
+            _controls.Place.performed += HandlePlace;
+            _controls.Rotate.performed += HandleRotate;
+        }
+        private void HandleToggleMenu(InputAction.CallbackContext context)
+        {
+            if (_enabled)
+            {
+                _controls.Disable();
+                _controls.ToggleMenu.Enable();
+            }
+            else
+            {
+                _controls.Enable();
+            }
+            _enabled = !_enabled;
+            ShowUI(_enabled);
+            Initialize();
+        }
+
+        private void HandleRotate(InputAction.CallbackContext context)
+        {
+            _ghostManager.SetNextRotation();
+            RefreshGhost();
+        }
+
+        private void HandleReplace(InputAction.CallbackContext context)
+        {
+            RefreshGhost();
+        }
+
+        private void HandlePlace(InputAction.CallbackContext context)
+        {
+            if (_mouseOverUI)
+            {
+                return;
+            }
+            if (_controls.Replace.IsPressed())
+                HandleMouseClick(_lastSnappedPosition, true);
+            else
+                HandleMouseClick(_lastSnappedPosition, false);
         }
 
         [ServerOrClient]
@@ -78,14 +122,6 @@ namespace SS3D.Systems.Tile.UI
         [ServerOrClient]
         private void Update()
         {
-            // Check for enabling the construction menu
-            if (Input.GetKeyDown(KeyCode.B))
-            {
-                _enabled = !_enabled;
-                ShowUI(_enabled);
-                Initialize();
-            }
-
             if (!_initalized)
                 return;
 
@@ -99,13 +135,6 @@ namespace SS3D.Systems.Tile.UI
             {
                 _ghostManager.CreateGhost(_selectedObject.prefab);
             }
-
-            if (Input.GetKeyDown(KeyCode.R))
-            {
-                _ghostManager.SetNextRotation();
-                RefreshGhost();
-            }
-
 
             // Check if mouse moved
             Vector3 snappedPosition = TileHelper.GetClosestPosition(GetMousePosition());
@@ -123,26 +152,16 @@ namespace SS3D.Systems.Tile.UI
                 _lastSnappedPosition = newPosition;
             }
 
-            // Move ghost
             _ghostManager.MoveGhost();
-
-            // Check if Left Shift was pressed to replace an existing tile
-            if (Input.GetKeyDown(KeyCode.LeftShift) || Input.GetKeyUp(KeyCode.LeftShift))
-                RefreshGhost();
-
-            // Check if we can want to place or delete an object
-            if (Input.GetKeyDown(KeyCode.Mouse0) && !_mouseOverUI)
-            {
-                if (Input.GetKey(KeyCode.LeftShift))
-                    HandleMouseClick(_lastSnappedPosition, true);
-                else
-                    HandleMouseClick(_lastSnappedPosition, false);
-            }
         }
 
         [ServerOrClient]
         private void HandleMouseClick(Vector3 snappedPosition, bool replaceExisting)
         {
+            if (_selectedObject == null)
+            {
+                return;
+            }
             if (_isDeleting)
             {
                 if (_itemPlacement)
@@ -283,7 +302,7 @@ namespace SS3D.Systems.Tile.UI
             }
             else if (!_itemPlacement)
             {
-                if (Input.GetKey(KeyCode.LeftShift))
+                if (_controls.Replace.phase == InputActionPhase.Performed)
                     CheckBuildValidity(_lastSnappedPosition, true);
                 else
                     CheckBuildValidity(_lastSnappedPosition, false);
@@ -364,12 +383,14 @@ namespace SS3D.Systems.Tile.UI
         public void OnPointerEnter(PointerEventData eventData)
         {
             _mouseOverUI = true;
+            SystemLocator.Get<InputSystem>().Inputs.Camera.Zoom.Disable();
         }
 
         [ServerOrClient]
         public void OnPointerExit(PointerEventData eventData)
         {
             _mouseOverUI = false;
+            SystemLocator.Get<InputSystem>().Inputs.Camera.Zoom.Enable();
         }
     }
 }


### PR DESCRIPTION
Closes #1086 

## Known issues

When you open the console, hover cursor over the building panel and move cursor away, you will be able to zoom when the console is opened. This is because OnPointerExit in TileMapCreater enables Zoom action.

