### PR TITLE
Add a hack to see all containers of the scene and their content.

### DIFF
--- a/Assets/Scripts/SS3D/Hacks.meta
+++ b/Assets/Scripts/SS3D/Hacks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 221d7648a4bc43343842b1275a944b30
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SS3D/Hacks/ClientSeeAllContainerHack.cs
+++ b/Assets/Scripts/SS3D/Hacks/ClientSeeAllContainerHack.cs
@@ -1,0 +1,29 @@
+using SS3D.Systems.Inventory.Containers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+/// <summary>
+/// Put that on the Human prefab, while roaming in the station, press L to see the content of all containers on the station.
+/// </summary>
+public class ClientSeeAllContainerHack : MonoBehaviour
+{
+
+    public void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.L))
+        {
+            Debug.Log("See all containers");
+            var containers = FindObjectsOfType<AttachedContainer>();
+            foreach(var container in containers)
+            {
+                var items = container.Container.StoredItems;
+                foreach(var item in items)
+                {
+                    Debug.Log(item.Item + " in container " + container.name + " at position " + container.gameObject.transform.position);
+                }
+            }  
+        }
+    }
+}

--- a/Assets/Scripts/SS3D/Hacks/ClientSeeAllContainerHack.cs.meta
+++ b/Assets/Scripts/SS3D/Hacks/ClientSeeAllContainerHack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65feb131469ee7843adfa56b985a886e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION


## Summary

This PR adds an hack folder. This will contain little scripts that can be attached to game objects at run time to give an unfair advantage to a client over others. These could be later on used in play mode tests to check if the hacks are effective or not.

Adds an hack to check the content of all containers on the scene.

Closes #971






