### PR TITLE
hotfix #1030

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/Container.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/Container.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using FishNet.Object.Synchronizing;
 using SS3D.Core.Behaviours;
+using SS3D.Logging;
 using SS3D.Systems.Entities;
 using SS3D.Systems.Inventory.Items;
 using UnityEngine;
@@ -609,11 +610,6 @@ namespace SS3D.Systems.Inventory.Containers
 
         private void handleItemRemoved(Item item)
         {
-            // Only unfreeze the item if it was not just placed into another container
-            if (item.Container == null)
-            {
-                item.Unfreeze();
-            }
 
             // Restore visibility
             if (HideItems)
@@ -627,6 +623,8 @@ namespace SS3D.Systems.Inventory.Containers
                 item.transform.SetParent(null, true);
                 AttachedTo.ProcessItemDetached(item);
             }
+
+            item.Unfreeze();
         }
 
         private void handleItemAdded(Item item)

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/Inventory.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/Inventory.cs
@@ -226,6 +226,7 @@ namespace SS3D.Systems.Inventory.Containers
                 return;
             }
 
+            itemContainer.RemoveItem(item);
             container.Container.AddItemPosition(item, position);
         }
 

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
@@ -42,6 +42,8 @@ namespace SS3D.Systems.Inventory.Items
 
         [SerializeField] private Rigidbody _rigidbody;
 
+        public string Name => _name;
+
         /// <summary>
         /// The item's relative weight in kilograms.
         /// </summary>
@@ -158,6 +160,7 @@ namespace SS3D.Systems.Inventory.Items
             var itemCollider = GetComponent<Collider>();
             if (itemCollider != null)
             {
+                Punpun.Debug(this, "item {item} frozen", Logs.Generic, Name);
                 itemCollider.enabled = false;
             }
         }
@@ -264,8 +267,10 @@ namespace SS3D.Systems.Inventory.Items
 
             _container = newContainer;
             RpcSetContainer(newContainer);
+            
         }
 
+        // It could become an issue that only observers see the container updated...
         [ObserversRpc]
         private void RpcSetContainer(Container newContainer)
         {


### PR DESCRIPTION
## Summary

There was an issue with the container not being null when it should be.
```
            // Only unfreeze the item if it was not just placed into another container
            if (item.Container == null)
            {
                item.Unfreeze();
            }
```
This condition is removed, but doing just so, AddItem is called before RemoveItem when switching item between two containers. This result in item not being frozen properly. A simple line is added in Inventory to enforce item to be removed from it's previous container before being added to another.


## Fixes (optional)

Close #1030 
