### PR TITLE
fix port server still busy

### DIFF
--- a/Assets/Scripts/SS3D/Core/SessionNetworkSystem.cs
+++ b/Assets/Scripts/SS3D/Core/SessionNetworkSystem.cs
@@ -2,6 +2,7 @@ using System;
 using Coimbra;
 using FishNet;
 using FishNet.Managing;
+using FishNet.Managing.Server;
 using SS3D.Core.Events;
 using SS3D.Core.Settings;
 using SS3D.Logging;
@@ -56,6 +57,12 @@ namespace SS3D.Core
 
             ApplicationStartedEvent applicationStartedEvent = new(ckey, networkType);
             applicationStartedEvent.Invoke(this);
+        }
+
+        public void OnDestroy()
+        {
+            NetworkManager networkManager = InstanceFinder.NetworkManager;
+            networkManager.ServerManager.StopConnection(true);
         }
     }
 }


### PR DESCRIPTION


## Summary

very small PR to properly close the connection and free the port.
Seems to solve #1079 on my side, but please test it extensively on your side before merging it, this bug is unreliable, I launch the game 15 time just host and 10 time with client joining and did not see the bug occurring, but I'd like you to do something similar to be sure.

## Fixes (optional)

close #1079
