### PR TITLE
change default port in editor

### DIFF
--- a/Assets/Settings/ApplicationSettings.asset
+++ b/Assets/Settings/ApplicationSettings.asset
@@ -17,6 +17,6 @@ MonoBehaviour:
   NetworkType: 2
   Ckey: editorUser
   ServerAddress: 127.0.0.1
-  ServerPort: 2222
+  ServerPort: 1974
   EnableDiscord: 0
   SkipIntro: 1


### PR DESCRIPTION
Simply change default port in editor to be the same (1974) as the one when launching executable via .bat files

