### PR TITLE
Hotfix - Broken hand container when moving items

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hands.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hands.cs
@@ -150,6 +150,11 @@ namespace SS3D.Systems.Inventory.Containers
                 return;
             }
 
+            if (!HandContainers.Contains(selectedContainer))
+            {
+                return;
+            }
+
             SelectedHandIndex = HandContainers.ToList().IndexOf(selectedContainer);
             if (SelectedHandIndex != -1)
             {


### PR DESCRIPTION
## Summary

Simply fixes a problem where moving an item through clicking instead of drag 'n drop would break the hand containers and throw exceptions on interactions

## Changes to Files

Just adds a single check in the Hands.cs file