### PR TITLE
Dispose components on death

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Health/HealthController.cs
+++ b/Assets/Scripts/SS3D/Systems/Health/HealthController.cs
@@ -29,6 +29,7 @@ public class HealthController : NetworkBehaviour
     private void RpcDestroyObjects(Entity originEntity)
     {
         GameObject originEntityGameObject = originEntity.gameObject;
+        // TODO: Optimize these GetComponents, this is a temporary solution.
         originEntityGameObject.GetComponent<Hands>().Dispose(true);
         originEntityGameObject.GetComponent<Inventory>().Dispose(true);
         originEntityGameObject.GetComponent<InteractionController>().Dispose(true);
@@ -40,9 +41,8 @@ public class HealthController : NetworkBehaviour
     [ObserversRpc]
     private void RpcUpdateGhostPosition(Entity originEntity, Entity ghostEntity)
     {
-        Transform originEntityTransform = originEntity.transform;
-        ghostEntity.transform.SetPositionAndRotation(originEntityTransform.position, originEntityTransform.rotation);
-        originEntityTransform.Rotate(new Vector3(90, 0, 0));
+        ghostEntity.Transform.SetPositionAndRotation(originEntity.Transform.position, originEntity.Transform.rotation);
+        originEntity.Transform.Rotate(new Vector3(90, 0, 0));
     }
 
     [Client]

--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -57,11 +57,22 @@ namespace SS3D.Systems.Interactions
         public override void OnStopClient()
         {
             base.OnStopClient();
-            
+            UnsubscribeFromEvents();
+        }
+
+        private void UnsubscribeFromEvents()
+        {
+            if (!Owner.IsLocalClient) return;
             _controls.RunPrimary.performed -= HandleRunPrimary;
             _controls.ViewInteractions.performed -= HandleView;
             _hotkeysControls.Use.performed -= HandleUse;
             _inputSystem.ToggleActionMap(_controls, false);
+        }
+        
+        protected override void OnDestroyed()
+        {
+            base.OnDestroyed();
+            UnsubscribeFromEvents();
         }
 
         /// <summary>

--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -62,7 +62,10 @@ namespace SS3D.Systems.Interactions
 
         private void UnsubscribeFromEvents()
         {
-            if (!Owner.IsLocalClient) return;
+            if (!Owner.IsLocalClient)
+            {
+                return;
+            }
             _controls.RunPrimary.performed -= HandleRunPrimary;
             _controls.ViewInteractions.performed -= HandleView;
             _hotkeysControls.Use.performed -= HandleUse;

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/Inventory.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/Inventory.cs
@@ -71,13 +71,17 @@ namespace SS3D.Systems.Inventory.Containers
                 return;
             }
 
+            SetupView();
+            Subsystems.Get<RoleSystem>().GiveRoleLoadoutToPlayer(Body);
+        }
+
+        private void SetupView()
+        {
             InventoryView = ViewLocator.Get<InventoryView>().First();
             InventoryView.Inventory = this;
 
             InventoryView.Setup();
             InventoryView.Enable(true);
-
-            Subsystems.Get<RoleSystem>().GiveRoleLoadoutToPlayer(Body);
         }
 
         protected override void OnAwake()
@@ -87,6 +91,12 @@ namespace SS3D.Systems.Inventory.Containers
             AddHandle(UpdateEvent.AddListener(HandleUpdate));
 
             Hands.Inventory = this;
+        }
+
+        protected override void OnDestroyed()
+        {
+            base.OnDestroyed();
+            InventoryView.Enable(false);
         }
 
         private void HandleUpdate(ref EventContext context, in UpdateEvent updateEvent)


### PR DESCRIPTION
## Summary
Dispose hands, inventory and interactions also hide inventory for ghost ([reference](https://www.youtube.com/watch?v=45ryS19cNy4))


## Technical Notes (optional)

<!-- Provide a more technical description of your changes to help save the reviewers some time. -->

## Known issues
Issues below were present before the PR
* Player's body is floating above the ground after the rotation is applied to it,
* If the match restarts player can't walk on spawn

## Fixes (optional)
Closes #991 

<!-- List any issues or other PRs connected to this one. -->

<!-- If this PR CLOSES any issues/PRs, add "Closes" before the number (e.g. "Closes #123"). -->
