### PR TITLE
Disable rigidbody physics for ghost items in construction mode

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/GhostManager.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/GhostManager.cs
@@ -32,6 +32,11 @@ namespace SS3D.Systems.Tile.TileMapCreator
             {
                 _ghostObject = Instantiate(prefab);
 
+                if (_ghostObject.TryGetComponent<Rigidbody>(out var ghostRigidbody))
+                {
+                    ghostRigidbody.useGravity = false;
+                    ghostRigidbody.isKinematic = true;
+                }
                 var colliders = _ghostObject.GetComponents<Collider>();
                 foreach (Collider col in colliders)
                 {


### PR DESCRIPTION
## Summary
Basically sets useGravity and isKinematic of a ghost object's rigidbody to a correct states

## Known issues
Now player can get stuck or stuck someone inside of the constructions

https://user-images.githubusercontent.com/13234587/229009336-cb755fba-625e-4793-924a-ce22980cd914.mp4


## Fixes (optional)
Closes #1076
Closes #1105

