### PR TITLE
get colliders from children

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/GhostManager.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/GhostManager.cs
@@ -37,7 +37,7 @@ namespace SS3D.Systems.Tile.TileMapCreator
                     ghostRigidbody.useGravity = false;
                     ghostRigidbody.isKinematic = true;
                 }
-                var colliders = _ghostObject.GetComponents<Collider>();
+                var colliders = _ghostObject.GetComponentsInChildren<Collider>();
                 foreach (Collider col in colliders)
                 {
                     col.enabled = false;


### PR DESCRIPTION
## Summary
Checks for colliders in children, not just the gameObject

## Technical Notes (optional)
The better approach by performance would be to change the layer of a gameObject and its children. "Items" layer would be a great candidate for it, but I'm not sure if it's suitable. 
Creating a new layer specifically for ghost objects might over complicate the project.

## Fixes (optional)
Closes #1105
