### PR TITLE
Normalize movement speed

### DIFF
--- a/Assets/Content/Systems/Input/Controls.inputactions
+++ b/Assets/Content/Systems/Input/Controls.inputactions
@@ -180,7 +180,7 @@
                 {
                     "name": "2D Vector",
                     "id": "6bf42294-8111-4bb7-9d46-8600bba84e15",
-                    "path": "2DVector(mode=1)",
+                    "path": "2DVector",
                     "interactions": "",
                     "processors": "",
                     "groups": "",

--- a/Assets/Scripts/SS3D/Systems/Entities/Humanoid/HumanoidController.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/Humanoid/HumanoidController.cs
@@ -167,10 +167,7 @@ namespace SS3D.Systems.Entities.Humanoid
             float y = MovementControls.Movement.ReadValue<Vector2>().y;
             float inputFilteredSpeed = FilterSpeed();
 
-            x = Mathf.Clamp(x, -inputFilteredSpeed, inputFilteredSpeed);
-            y = Mathf.Clamp(y, -inputFilteredSpeed, inputFilteredSpeed);
-
-            Input = new Vector2(x, y);
+            Input = Vector2.ClampMagnitude(new Vector2(x, y), inputFilteredSpeed);
             SmoothedInput = Vector2.Lerp(SmoothedInput, Input, Time.deltaTime * (_lerpMultiplier / 10));
 
             OnSpeedChanged(Input.magnitude != 0 ? inputFilteredSpeed : 0);

--- a/Assets/Scripts/SS3D/Systems/Inputs/Controls.cs
+++ b/Assets/Scripts/SS3D/Systems/Inputs/Controls.cs
@@ -204,7 +204,7 @@ namespace SS3D.Systems.Inputs
                 {
                     ""name"": ""2D Vector"",
                     ""id"": ""6bf42294-8111-4bb7-9d46-8600bba84e15"",
-                    ""path"": ""2DVector(mode=1)"",
+                    ""path"": ""2DVector"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",


### PR DESCRIPTION
## Summary

Changed the method of clamping speed from inputFilteredSpeed to clamp the entire vector instead of each value individually. Additionally updates input actions to pass in normalized values (Digital Normalized as opposed to Digital) for movement.

Fixes #989 by normalizing movement speed and ensuring if movement is used elsewhere it will be passed in as normalized.

## Pictures/Videos
![InputNormalization](https://user-images.githubusercontent.com/130250291/231153063-a2f8b36a-b635-44ed-8789-cb2c9780a03a.gif)

## Changes to Files

- Modifies the 'Movement' action map in Controls.inputactions
- Modifies ProcessPlayerInput() in HumanoidController.cs
- Updates the auto-generated Controls.cs

## Fixes

Closes #989 
