### PR TITLE
Initial manipulation of Projects using Milestones

### DIFF
--- a/.github/actions/check-milestone-exists/action.yml
+++ b/.github/actions/check-milestone-exists/action.yml
@@ -1,0 +1,14 @@
+name: 'Check milestone exists'
+inputs:
+  JSON_LIST_OF_PROJECTS:
+    description: 'Results of a GraphQL query returning all ProjectV2 owned by RE-SS3D.'
+    required: true
+  PROJECT_NAME:
+    description: 'The name of the project to search for.'
+    required: true
+outputs:
+  EXISTING_PROJECT_ID:
+    description: 'String containing the project ID that matches the provided project name. Blank string if not found.'
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/.github/actions/check-milestone-exists/index.js
+++ b/.github/actions/check-milestone-exists/index.js
@@ -1,0 +1,12 @@
+const core = require('@actions/core');
+const results = JSON.parse(core.getInput('JSON_LIST_OF_PROJECTS'))
+const target = core.getInput('PROJECT_NAME').toUpperCase()
+
+var existingProjectId = null
+for (let i = 0; i < results.organization.projectsV2.nodes.length; i++) {
+    console.log( results.organization.projectsV2.nodes[i].title.toUpperCase() )
+    if (target == results.organization.projectsV2.nodes[i].title.toUpperCase()) {
+        existingProjectId = results.organization.projectsV2.nodes[i].id
+    }
+}
+core.setOutput('EXISTING_PROJECT_ID', existingProjectId);

--- a/.github/workflows/CloseProjectWhenMilestoneClosed.yml
+++ b/.github/workflows/CloseProjectWhenMilestoneClosed.yml
@@ -1,0 +1,61 @@
+name: Close Project When Milestone Closed
+on:
+  milestone:
+    types: [closed]
+jobs:
+  CloseProjectWhenMilestoneClosed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm install @actions/core
+      - run: npm install @actions/github
+      - name: Get list of projects
+        uses: octokit/graphql-action@v2.2.24
+        id: get-project-title
+        with:
+          query: |
+            query getTitle( $org:String!) {
+              organization(login:$org) {
+                projectsV2(first:100) {
+                  nodes {
+                    id
+                    title
+                    number
+                    template
+                    closed
+                    owner {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+          org: RE-SS3D
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Check for existence of milestone project
+        uses: ./.github/actions/check-milestone-exists
+        id: check-milestone-exists
+        with:
+          JSON_LIST_OF_PROJECTS: ${{ steps.get-project-title.outputs.data }}
+          PROJECT_NAME: ${{ github.event.milestone.title }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Close Project
+        uses: octokit/graphql-action@v2.2.24
+        id: close-project
+        if: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID != ''}}
+        with:
+          query: |
+            mutation CloseTheProject {
+              updateProjectV2(input: {projectId:"${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID }}", closed:true }) {
+                clientMutationId
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}

--- a/.github/workflows/CreateProjectWhenMilestoneCreated.yml
+++ b/.github/workflows/CreateProjectWhenMilestoneCreated.yml
@@ -69,7 +69,33 @@ jobs:
         with:
           query: |
             mutation setupTheProject {
-              updateProjectV2(input: {projectId:"${{ fromJSON(steps.duplicate-template-project.outputs.data).copyProjectV2.projectV2.id }}", title:"${{ github.event.milestone.title }}" }) {
+              updateProjectV2(input: {projectId:"${{ fromJSON(steps.duplicate-template-project.outputs.data).copyProjectV2.projectV2.id }}", title:"${{ github.event.milestone.title }}", public:true}) {
+                clientMutationId
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Get repo ID
+        uses: octokit/graphql-action@v2.2.24
+        id: get-repo-id
+        with:
+          query: |
+            query getRepo( $org:String!) {
+              repository(name:"SS3D", owner:$org) {
+                id
+              }
+            }
+          org: RE-SS3D
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Link SS3D Repository to new Project
+        uses: octokit/graphql-action@v2.2.24
+        id: link-project
+        if: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID == ''}}
+        with:
+          query: |
+            mutation LinkTheProject {
+              linkProjectV2ToRepository(input: {projectId:"${{ fromJSON(steps.duplicate-template-project.outputs.data).copyProjectV2.projectV2.id }}", repositoryId:"${{ fromJSON(steps.get-repo-id.outputs.data).repository.id }}" }) {
                 clientMutationId
               }
             }

--- a/.github/workflows/CreateProjectWhenMilestoneCreated.yml
+++ b/.github/workflows/CreateProjectWhenMilestoneCreated.yml
@@ -1,0 +1,77 @@
+name: Create Project When Milestone Created
+on:
+  milestone:
+    types: [created]
+jobs:
+  CreateProjectFromMilestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm install @actions/core
+      - run: npm install @actions/github
+      - name: Get list of projects
+        uses: octokit/graphql-action@v2.2.24
+        id: get-project-title
+        with:
+          query: |
+            query getTitle( $org:String!) {
+              organization(login:$org) {
+                projectsV2(first:100) {
+                  nodes {
+                    id
+                    title
+                    number
+                    template
+                    closed
+                    owner {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+          org: RE-SS3D
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Check for existence of milestone project
+        uses: ./.github/actions/check-milestone-exists
+        id: check-milestone-exists
+        with:
+          JSON_LIST_OF_PROJECTS: ${{ steps.get-project-title.outputs.data }}
+          PROJECT_NAME: ${{ github.event.milestone.title }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Duplicate Template Project
+        uses: octokit/graphql-action@v2.2.24
+        id: duplicate-template-project
+        if: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID == '' }}
+        with:
+          query: |
+            mutation copyTheProject {
+              copyProjectV2(input: {ownerId:"MDEyOk9yZ2FuaXphdGlvbjQyNzc4NjQw", projectId:"PVT_kwDOAozAEM4AMVn2", title:"Example"}) {
+                clientMutationId  
+                projectV2 {
+                  id
+                }
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Setup Project
+        uses: octokit/graphql-action@v2.2.24
+        id: setup-project
+        if: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID == ''}}
+        with:
+          query: |
+            mutation setupTheProject {
+              updateProjectV2(input: {projectId:"${{ fromJSON(steps.duplicate-template-project.outputs.data).copyProjectV2.projectV2.id }}", title:"${{ github.event.milestone.title }}" }) {
+                clientMutationId
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}

--- a/.github/workflows/RenameProjectWhenMilestoneRenamed.yml
+++ b/.github/workflows/RenameProjectWhenMilestoneRenamed.yml
@@ -1,0 +1,61 @@
+name: Rename Project When Milestone Renamed
+on:
+  milestone:
+    types: [edited]
+jobs:
+  RenameProject:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm install @actions/core
+      - run: npm install @actions/github
+      - name: Get list of projects
+        uses: octokit/graphql-action@v2.2.24
+        id: get-project-title
+        with:
+          query: |
+            query getTitle( $org:String!) {
+              organization(login:$org) {
+                projectsV2(first:100) {
+                  nodes {
+                    id
+                    title
+                    number
+                    template
+                    closed
+                    owner {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+          org: RE-SS3D
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Check for existence of milestone project
+        uses: ./.github/actions/check-milestone-exists
+        id: check-milestone-exists
+        with:
+          JSON_LIST_OF_PROJECTS: ${{ steps.get-project-title.outputs.data }}
+          PROJECT_NAME: ${{ github.event.changes.title.from }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Rename Project
+        uses: octokit/graphql-action@v2.2.24
+        id: rename-project
+        if: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID != ''}}
+        with:
+          query: |
+            mutation RenameTheProject {
+              updateProjectV2(input: {projectId:"${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID }}", title:"${{ github.event.milestone.title }}" }) {
+                clientMutationId
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}


### PR DESCRIPTION
## Summary

Creating, renaming and closing Milestones will trigger corresponding changes to Projects.

## Changes to Files

Nil changes, new code only.

## Technical Notes

- This PR uses GraphQL queries and mutations: check out the [API docs](https://docs.github.com/en/graphql).

- Before use, someone with the appropriate access must create a **Personal Access Token (classic)** including the **repo** and **project** scopes using these [instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and add it to the secret PROJECT_MANAGEMENT_TOKEN.

- The template for projects has been hardcoded to "0.0.7 - Fixing, Cleaning, Testing" as no actual template was available.

## Limitations

- Avoid rapid changes to milestones. The relevant actions take ~15-30 seconds to run, so multiple changes in quick succession will outpace the actions.

- ~~Projects created in this manner are private, and will need to be manually changed to public. In theory, it is trivial to automate this; however, as I do not have the requisite permissions for this action I was not able to implement.~~ (*Edit: resolved. Projects will now be created as public, and linked to the SS3D repo. Whoevers account is used for the personal access token will need to have the appropriate access - i.e. be an owner of the RE-SS3D organization*)

## Fixes

Contributes to #1112 by completing the following tasks:
- [x] When a GItHub Milestone is created, create a new GitHub Project with the same name, using a project template copying our current format.
- [x] When a GitHub Milestone has its name changed, rename the GitHub Project with the same name as the Milestone to the Milestone's new name.
- [x] When a GitHub Milestone closes, close the GitHub Project of the same name.