### PR TITLE
Add issue to milestone project

### DIFF
--- a/.github/actions/get-single-select-field-id/action.yml
+++ b/.github/actions/get-single-select-field-id/action.yml
@@ -1,0 +1,14 @@
+name: 'Get Single Select Field Id'
+inputs:
+  JSON_FIELD_OPTIONS:
+    description: 'Results of a GraphQL query returning all options in a single select field.'
+    required: true
+  TARGET_OPTION:
+    description: 'The name of the option to search for.'
+    required: true
+outputs:
+  OPTION_ID:
+    description: 'ID for the specific single select field option.'
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/.github/actions/get-single-select-field-id/index.js
+++ b/.github/actions/get-single-select-field-id/index.js
@@ -1,0 +1,14 @@
+const core = require('@actions/core');
+const results = JSON.parse(core.getInput('JSON_FIELD_OPTIONS'))
+const target = core.getInput('TARGET_OPTION').toUpperCase()
+
+var fieldId = null
+var lengthOfTarget = target.length;
+console.log('Target = ' + target)
+for (let i = 0; i < results.node.options.length; i++) {
+    console.log(results.node.options[i].name.toUpperCase().slice(-lengthOfTarget))
+    if (target == results.node.options[i].name.toUpperCase().slice(-lengthOfTarget)) {
+        fieldId = results.node.options[i].id
+    }
+}
+core.setOutput('OPTION_ID', fieldId);

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -1,0 +1,125 @@
+name: Add Issue To Milestone Project
+on:
+  issues:
+    types: [milestoned]
+jobs:
+  AddIssueToProject:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm install @actions/core
+      - run: npm install @actions/github
+      - name: Get list of projects
+        uses: octokit/graphql-action@v2.2.24
+        id: get-project-title
+        with:
+          query: |
+            query getTitle( $org:String!) {
+              organization(login:$org) {
+                projectsV2(first:100) {
+                  nodes {
+                    id
+                    title
+                    number
+                    template
+                    closed
+                    owner {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+          org: RE-SS3D
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Check for existence of milestone project
+        uses: ./.github/actions/check-milestone-exists
+        id: check-milestone-exists
+        with:
+          JSON_LIST_OF_PROJECTS: ${{ steps.get-project-title.outputs.data }}
+          PROJECT_NAME: ${{ github.event.milestone.title }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - run: "echo 'Existing project ID: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID }}'"
+      - run: "echo 'Project information: ${{ steps.get-project-title.outputs.data }}'"
+      - name: Add Issue to Milestone Project
+        uses: octokit/graphql-action@v2.2.24
+        id: add-issue-to-milestone-project
+        if: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID != ''}}
+        with:
+          query: |
+            mutation AddToMilestone {
+              addProjectV2ItemById(input: {projectId:"${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID }}", contentId:"${{ github.event.issue.node_id }}" }) {
+                clientMutationId
+                item {
+                  id
+                }
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Locate Status Column
+        uses: octokit/graphql-action@v2.2.24
+        id: locate-status-column
+        if: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID != ''}}
+        with:
+          query: |
+            query getStatusColumn {
+              node(id:"${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID }}") {
+                ... on ProjectV2 {
+                  field(name: "Status") {
+                    ... on ProjectV2SingleSelectField {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Get Backlog Id
+        uses: octokit/graphql-action@v2.2.24
+        id: get-backlog-id
+        if: ${{ fromJSON(steps.locate-status-column.outputs.data).node.field.id != ''}}
+        with:
+          query: |
+            query getStatusColumn {
+              node(id:"${{ fromJSON(steps.locate-status-column.outputs.data).node.field.id }}") {
+                ... on ProjectV2SingleSelectField {
+                  options {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - run: "echo 'Field options: ${{ steps.get-backlog-id.outputs.data }}'"
+      - name: Get target field ID
+        uses: ./.github/actions/get-single-select-field-id
+        id: get-single-select-field-id
+        with:
+          JSON_FIELD_OPTIONS: ${{ steps.get-backlog-id.outputs.data }}
+          TARGET_OPTION: Backlog
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
+      - name: Add To Backlog
+        uses: octokit/graphql-action@v2.2.24
+        id: add-issue-to-backlog-column
+        if: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID != ''}}
+        with:
+          query: |
+            mutation AddToBacklog {
+              updateProjectV2ItemFieldValue(input: {projectId:"${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID }}", itemId:"${{ fromJSON(steps.add-issue-to-milestone-project.outputs.data).addProjectV2ItemById.item.id }}", fieldId: "${{ fromJSON(steps.locate-status-column.outputs.data).node.field.id }}", value: { singleSelectOptionId: "${{steps.get-single-select-field-id.outputs.OPTION_ID}}" }}) {
+                clientMutationId
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}


### PR DESCRIPTION
## Summary

Adds issue to the appropriate milestone project when milestone is set.

## Changes to Files

Nil changes, new code only.

## Limitations

- This workflow is unidirectional. Although adding an issue to a milestone will trigger its insertion to the project board, removing it from a milestone will not automatically trigger its removal from the board.

## Fixes

Contributes to #1112 by completing the following task:

- [x] When a GitHub Milestone is added to an open issue, add the issue to the GH Project of the same name as the Milestone, in the 'backlog' column.