### PR TITLE
log class name

### DIFF
--- a/Assets/Scripts/SS3D/Logging/Punpun.cs
+++ b/Assets/Scripts/SS3D/Logging/Punpun.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Serilog;
+using Serilog.Core;
 using Serilog.Events;
 
 namespace SS3D.Logging
@@ -24,7 +25,7 @@ namespace SS3D.Logging
         public static void Verbose(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[]{infoLog}.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Verbose("{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Verbose("{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace SS3D.Logging
         public static void Verbose(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Verbose(exception,"{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Verbose(exception,"{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace SS3D.Logging
         public static void Debug(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Debug("{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Debug("{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace SS3D.Logging
         public static void Debug(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Debug(exception, "{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Debug(exception, "{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace SS3D.Logging
         public static void Information(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Information("{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Information("{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -100,7 +101,7 @@ namespace SS3D.Logging
         public static void Information(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Debug(exception, "{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Debug(exception, "{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -115,7 +116,7 @@ namespace SS3D.Logging
         public static void Warning(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Warning("{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Warning("{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -130,7 +131,7 @@ namespace SS3D.Logging
         public static void Warning(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Debug(exception, "{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Debug(exception, "{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -145,7 +146,7 @@ namespace SS3D.Logging
         public static void Error(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Error("{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Error("{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -160,7 +161,7 @@ namespace SS3D.Logging
         public static void Error(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Error(exception, "{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Error(exception, "{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -175,7 +176,7 @@ namespace SS3D.Logging
         public static void Fatal(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Fatal("{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Fatal("{InfoLog}" + messageTemplate, properties);
         }
 
         /// <summary>
@@ -190,7 +191,7 @@ namespace SS3D.Logging
         public static void Fatal(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
         {
             var properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Log.ForContext(sender.GetType()).Fatal(exception, "{InfoLog}" + messageTemplate, properties);
+            Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Fatal(exception, "{InfoLog}" + messageTemplate, properties);
         }
         
     }

--- a/Assets/Scripts/Tests/Edit Mode/LogTests.cs
+++ b/Assets/Scripts/Tests/Edit Mode/LogTests.cs
@@ -67,7 +67,7 @@ namespace EditorTests.Log
             string color = LogColors.GetLogColor(Logs.Generic);
             Punpun.Information(this, "{simpleDictionary}", Logs.Generic, _simpleDictionaryToDisplay);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] {{\"one\":1,\"two\":2,\"three\":3}}");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] {{\"one\":1,\"two\":2,\"three\":3}}");
             _lastUnityConsoleMessage = "";
         }
 
@@ -85,7 +85,7 @@ namespace EditorTests.Log
             string color = LogColors.GetLogColor(Logs.Generic);
             Punpun.Information(this, "{@simpleStructure}", Logs.Generic, _simpleStructureToDisplay);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] {{\"Name\":\"simple\",\"Count\":3,\"IsCool\":true,\"$type\":\"SimpleStructure\"}}");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] {{\"Name\":\"simple\",\"Count\":3,\"IsCool\":true,\"$type\":\"SimpleStructure\"}}");
             _lastUnityConsoleMessage = "";
         }
 
@@ -100,7 +100,7 @@ namespace EditorTests.Log
             string color = LogColors.GetLogColor(Logs.Generic);
             Punpun.Information(this, "{list}", Logs.Generic, _floatListToDisplay);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] [0.4,0.222,4.7E-05,78789]");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] [0.4,0.222,4.7E-05,78789]");
             _lastUnityConsoleMessage = "";
         }
 
@@ -115,43 +115,43 @@ namespace EditorTests.Log
             string color = LogColors.GetLogColor(Logs.Generic);
             Punpun.Information(this, "hello there !", Logs.Generic);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] hello there !");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] hello there !");
             _lastUnityConsoleMessage = "";
 
             color = LogColors.GetLogColor(Logs.External);
             Punpun.Information(this, "hello there !", Logs.External);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] hello there !");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] hello there !");
             _lastUnityConsoleMessage = "";
 
             color = LogColors.GetLogColor(Logs.ServerOnly);
             Punpun.Information(this, "hello there !", Logs.ServerOnly);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] hello there !");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] hello there !");
             _lastUnityConsoleMessage = "";
 
             color = LogColors.GetLogColor(Logs.ClientOnly);
             Punpun.Information(this, "hello there !", Logs.ClientOnly);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] hello there !");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] hello there !");
             _lastUnityConsoleMessage = "";
 
             color = LogColors.GetLogColor(Logs.None);
             Punpun.Information(this, "hello there !", Logs.None);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] hello there !");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] hello there !");
             _lastUnityConsoleMessage = "";
 
             color = LogColors.GetLogColor(Logs.Important);
             Punpun.Information(this, "hello there !", Logs.Important);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] hello there !");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] hello there !");
             _lastUnityConsoleMessage = "";
 
             color = LogColors.GetLogColor(Logs.Physics);
             Punpun.Information(this, "hello there !", Logs.Physics);
             while (_lastUnityConsoleMessage == "") continue;
-            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>EditorTests.Log.LogTests</color>] hello there !");
+            Assert.IsTrue(_lastUnityConsoleMessage == $"[<color={color}>LogTests</color>] hello there !");
             _lastUnityConsoleMessage = "";
         }
 


### PR DESCRIPTION
## Summary
Displays only the class name of the `source` object

## Pictures/Videos (optional)
![image](https://user-images.githubusercontent.com/13234587/235166829-8b2ad4a4-6e9f-4d89-afcc-eb438ae5f3eb.png)
![image](https://user-images.githubusercontent.com/13234587/235166899-0539e486-7863-4496-8cb0-ccf725dfc911.png)

## Technical Notes (optional)
I think `Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name)` can be moved into a separate method to avoid code duplication

## Known issues
`Item.cs` sends data about frozen items with no name resulting in logs like `[IDCard] item "" frozen` (can be seen on a second screenshot)
The issue was present before the changes on my branch.

## Fixes (optional)
Closes #1180
