### PR TITLE
Creates summarized test results in CI.

### DIFF
--- a/.github/actions/interpret-test-results/action.yml
+++ b/.github/actions/interpret-test-results/action.yml
@@ -1,0 +1,13 @@
+name: 'Interpret Test Results'
+inputs:
+  XML_PATH:
+    description: 'String containing the path of the test results (i.e. editmode-results.xml).'
+    required: true
+outputs:
+  DISPLAY_STRING:
+    description: 'String containing truncated output suitable for display.'
+  ALL_TESTS_PASSED:
+    description: 'Boolean indicating whether all test cases had passed.'  
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/.github/actions/interpret-test-results/index.js
+++ b/.github/actions/interpret-test-results/index.js
@@ -1,0 +1,59 @@
+function recursivelyOutputFailedTestCases(element) {
+    // If this element is a test case, we check it directly, and output if it has failed.
+    if (element.tagName == ("TEST-CASE")) {
+        if (element.getAttribute("result") == "Failed") {
+            output += "....Failed test case: " + element.getAttribute("name") + " (" + element.getAttribute("classname") + ")\n"
+            testsFailed = true;
+        }
+    }
+    // If not a test case, it may have subordinate test cases. Check them recursively.
+    else
+    {
+        for (const child of element.children) {
+            recursivelyOutputFailedTestCases(child);
+        }
+    }
+}
+
+// Remember: you will probably need to npm install jsdom in the workflow!
+const core = require('@actions/core');
+const jsdom = require("jsdom");
+const fs = require('fs');
+
+// Declare & Initialize variables as required.
+var testsFailed = false;         // Needs to be global.
+var output = "Test Results:\n";  // Needs to be global.
+var passed;
+var total;
+var name;
+
+// Read the results text, and turn it into Document Object Model (DOM) format
+const path = core.getInput('XML_PATH');
+const data = fs.readFileSync(path);
+const dom = new jsdom.JSDOM(data).window.document;
+var testSuites = dom.getElementsByTagName("test-suite")
+
+for (let i = 0; i < testSuites.length; i++) {
+
+    // Cycle through all of the test suites, and filter out the assemblies. Provide summary representative info.
+    if (testSuites[i].getAttribute("type") == "Assembly") {
+        name = testSuites[i].getAttribute("name");
+        passed = testSuites[i].getAttribute("passed");
+        total = testSuites[i].getAttribute("total");
+        output += "..Assembly: " + name + " (" + passed + "/" + total + ")\n"
+        recursivelyOutputFailedTestCases(testSuites[i]);
+    }
+}
+
+// Summarize and display the output
+output += "\nOverall result: ";
+if (testsFailed) {
+    output += "FAIL!";
+    core.setOutput('ALL_TESTS_PASSED', false);
+}
+else {
+    output += "PASS!";
+    core.setOutput('ALL_TESTS_PASSED', true);
+}
+console.log(output);
+core.setOutput('DISPLAY_STRING', output);

--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -7,26 +7,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           lfs: true
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm install @actions/core
+      - run: npm install @actions/github
+      - run: npm install jsdom
+      - run: npm install fs
       - name: Run tests
         uses: game-ci/unity-test-runner@v2
         env:
           UNITY_LICENSE_FILE: ../Documents/UnityLicense.ulf
+      - name: Produce summary output
+        uses: ./.github/actions/interpret-test-results
+        if: always()
+        id: interpret-test-results
+        with:
+          XML_PATH: artifacts/editmode-results.xml
       - name: Notify discord if tests fail
         uses: rjstone/discord-webhook-notify@v1
         if: failure() && github.event_name != 'pull_request'
         with:
           severity: error
-          details: Test runner failed!
+          details: ${{ steps.interpret-test-results.outputs.DISPLAY_STRING }}
           webhookUrl: ${{ secrets.DISCORD_WEBHOOK_TEST_RESULTS }}
       - name: Notify discord if tests succeed
         uses: rjstone/discord-webhook-notify@v1
         if: success() && github.event_name != 'pull_request'
         with:
           severity: info
-          details: Test runner passed!
+          details: ${{ steps.interpret-test-results.outputs.DISPLAY_STRING }}
           webhookUrl: ${{ secrets.DISCORD_WEBHOOK_TEST_RESULTS }}
       - name: Upload test results
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Summary

Creates a summary of the test log which is output in human readable form to both the Actions tab (see "Produce Summary Output" step) and to the #git-tests channel on Discord. The output lists each test assembly and the number of tests passed for that assembly. If failed tests exist, it then lists those specific tests individually, including the file where the test is found.

## Pictures

Discord output on pass:

![image](https://user-images.githubusercontent.com/64360820/236627486-d8f8e252-ffcd-4565-a737-779289728500.png)

Discord output on fail:

![image](https://user-images.githubusercontent.com/64360820/236627517-fdadea3c-1674-4e40-92f0-935b0e60f094.png)

Actions output on pass:

![image](https://user-images.githubusercontent.com/64360820/236627582-1d1d2a5c-044e-40a6-bac7-ab309508e267.png)

Actions output on fail:

![image](https://user-images.githubusercontent.com/64360820/236627639-54cd5526-45f6-4e60-9d0f-95e3143037c4.png)

## Fixes

Closes #1179
