### PR TITLE
Corrects columns of Pull Requests in milestone projects

### DIFF
--- a/.github/actions/determine-status-column/action.yml
+++ b/.github/actions/determine-status-column/action.yml
@@ -1,0 +1,14 @@
+name: 'Determine Status Column'
+inputs:
+  GITHUB_EVENT_NAME:
+    description: 'Name of the event triggering this (i.e. "Pull request" or "Issue").'
+    required: true
+  ISSUE_TITLE:
+    description: 'Title of the Issue or Pull Request'
+    required: true
+outputs:
+  COLUMN:
+    description: 'The appropriate column to place the issue in.'
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/.github/actions/determine-status-column/action.yml
+++ b/.github/actions/determine-status-column/action.yml
@@ -1,10 +1,10 @@
 name: 'Determine Status Column'
 inputs:
-  GITHUB_EVENT_NAME:
-    description: 'Name of the event triggering this (i.e. "Pull request" or "Issue").'
-    required: true
   ISSUE_TITLE:
     description: 'Title of the Issue or Pull Request'
+    required: true
+  PULL_REQUEST_URL:
+    description: 'Pull request URL (existence used to confirm whether pull request or issue)'
     required: true
 outputs:
   COLUMN:

--- a/.github/actions/determine-status-column/index.js
+++ b/.github/actions/determine-status-column/index.js
@@ -1,0 +1,25 @@
+const core = require('@actions/core');
+const event = core.getInput('GITHUB_EVENT_NAME')
+const title = core.getInput('ISSUE_TITLE')
+
+var column = null
+console.log(event);
+console.log(title);
+
+if (event == "issue") {
+    column = "Backlog";
+}
+else if (event == "pull_request")
+{
+    var potentialPrefix = title.toUpperCase().slice(0, 5);
+    console.log(potentialPrefix);
+    if (potentialPrefix == "[WIP]") {
+        column = "In Progress";
+    }
+    else
+    {
+        column = "In Review";
+    }
+}
+console.log(column);
+core.setOutput('COLUMN', column);

--- a/.github/actions/determine-status-column/index.js
+++ b/.github/actions/determine-status-column/index.js
@@ -6,7 +6,7 @@ var column = null
 console.log(url);
 console.log(title);
 
-if (url == null) {          // If Pull Request URL is null, the event must be an issue.
+if (url == "") {          // If Pull Request URL is empty, the event must be an issue.
     column = "Backlog";
 }
 else                        // Otherwise, it's a pull request.

--- a/.github/actions/determine-status-column/index.js
+++ b/.github/actions/determine-status-column/index.js
@@ -6,7 +6,7 @@ var column = null
 console.log(event);
 console.log(title);
 
-if (event == "issue") {
+if (event == "issues") {
     column = "Backlog";
 }
 else if (event == "pull_request")

--- a/.github/actions/determine-status-column/index.js
+++ b/.github/actions/determine-status-column/index.js
@@ -1,15 +1,15 @@
 const core = require('@actions/core');
-const event = core.getInput('GITHUB_EVENT_NAME')
+const url = core.getInput('PULL_REQUEST_URL')
 const title = core.getInput('ISSUE_TITLE')
 
 var column = null
-console.log(event);
+console.log(url);
 console.log(title);
 
-if (event == "issues") {
+if (url == null) {          // If Pull Request URL is null, the event must be an issue.
     column = "Backlog";
 }
-else if (event == "pull_request")
+else                        // Otherwise, it's a pull request.
 {
     var potentialPrefix = title.toUpperCase().slice(0, 5);
     console.log(potentialPrefix);

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -1,7 +1,5 @@
 name: Add Issues and Pull Requests To Milestone Project
 on:
-  pull_request:
-    types: [milestoned]
   issues:
     types: [milestoned]
 jobs:
@@ -108,7 +106,7 @@ jobs:
         uses: ./.github/actions/determine-status-column
         id: determine-status-column
         with:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
           ISSUE_TITLE: ${{ github.event.issue.title }}       
       - name: Get target field ID
         uses: ./.github/actions/get-single-select-field-id

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -1,5 +1,7 @@
 name: Add Issues and Pull Requests To Milestone Project
 on:
+  pull_request:
+    types: [milestoned]
   issues:
     types: [milestoned]
 jobs:

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -2,8 +2,6 @@ name: Add Issues and Pull Requests To Milestone Project
 on:
   issues:
     types: [milestoned]
-  pull_request:
-    types: [milestoned]
 jobs:
   AddIssueToProject:
     runs-on: ubuntu-latest

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -1,4 +1,4 @@
-name: Add Issue To Milestone Project
+name: Add Issues and Pull Requests To Milestone Project
 on:
   issues:
     types: [milestoned]

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -104,10 +104,10 @@ jobs:
       - run: "echo 'Field options: ${{ steps.get-backlog-id.outputs.data }}'"
       - name: Determine status column
         uses: ./.github/actions/determine-status-column
-        id: status
+        id: determine-status-column
         with:
-          GITHUB_EVENT_NAME: github.event_name
-          ISSUE_TITLE: github.event.issue.title        
+          GITHUB_EVENT_NAME: $github.event_name
+          ISSUE_TITLE: $github.event.issue.title        
       - name: Get target field ID
         uses: ./.github/actions/get-single-select-field-id
         id: get-single-select-field-id

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -2,6 +2,8 @@ name: Add Issue To Milestone Project
 on:
   issues:
     types: [milestoned]
+  pull_request:
+    types: [milestoned]
 jobs:
   AddIssueToProject:
     runs-on: ubuntu-latest
@@ -102,6 +104,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
       - run: "echo 'Field options: ${{ steps.get-backlog-id.outputs.data }}'"
+      - name: Determine status column
+        uses: ./.github/actions/determine-status-column
+        id: status
+        with:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}        
       - name: Get target field ID
         uses: ./.github/actions/get-single-select-field-id
         id: get-single-select-field-id

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -113,16 +113,16 @@ jobs:
         id: get-single-select-field-id
         with:
           JSON_FIELD_OPTIONS: ${{ steps.get-backlog-id.outputs.data }}
-          TARGET_OPTION: Backlog
+          TARGET_OPTION: ${{ steps.determine-status-column.outputs.COLUMN }}
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_TOKEN }}
-      - name: Add To Backlog
+      - name: Add To correct column
         uses: octokit/graphql-action@v2.2.24
-        id: add-issue-to-backlog-column
+        id: add-issue-to-correct-column
         if: ${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID != ''}}
         with:
           query: |
-            mutation AddToBacklog {
+            mutation AddToCorrectColumn {
               updateProjectV2ItemFieldValue(input: {projectId:"${{ steps.check-milestone-exists.outputs.EXISTING_PROJECT_ID }}", itemId:"${{ fromJSON(steps.add-issue-to-milestone-project.outputs.data).addProjectV2ItemById.item.id }}", fieldId: "${{ fromJSON(steps.locate-status-column.outputs.data).node.field.id }}", value: { singleSelectOptionId: "${{steps.get-single-select-field-id.outputs.OPTION_ID}}" }}) {
                 clientMutationId
               }

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -106,8 +106,8 @@ jobs:
         uses: ./.github/actions/determine-status-column
         id: determine-status-column
         with:
-          GITHUB_EVENT_NAME: $github.event_name
-          ISSUE_TITLE: $github.event.issue.title        
+          GITHUB_EVENT_NAME: github.event_name
+          ISSUE_TITLE: github.event.issue.title        
       - name: Get target field ID
         uses: ./.github/actions/get-single-select-field-id
         id: get-single-select-field-id

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -106,8 +106,8 @@ jobs:
         uses: ./.github/actions/determine-status-column
         id: status
         with:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}        
+          GITHUB_EVENT_NAME: github.event_name
+          ISSUE_TITLE: github.event.issue.title        
       - name: Get target field ID
         uses: ./.github/actions/get-single-select-field-id
         id: get-single-select-field-id

--- a/.github/workflows/AddIssueToMilestoneProject.yml
+++ b/.github/workflows/AddIssueToMilestoneProject.yml
@@ -106,8 +106,8 @@ jobs:
         uses: ./.github/actions/determine-status-column
         id: determine-status-column
         with:
-          GITHUB_EVENT_NAME: github.event_name
-          ISSUE_TITLE: github.event.issue.title        
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}       
       - name: Get target field ID
         uses: ./.github/actions/get-single-select-field-id
         id: get-single-select-field-id


### PR DESCRIPTION
## Summary

Edits previous workflow to place PR to the appropriate project column (In Progress / In Review) when it has been given a milestone. Previously PR's were placed in the Backlog column.

## Changes to Files

Created custom action: **determine-status-column**
Edited workflow **AddIssueToMilestoneProject**

## Limitations

I didn't go to the effort of checking whether the PR is open or not in this workflow. If essential functionality, I offer this as an exercise for an alternate contributor. My strong recommendation is just do not add milestones to PR's that are already closed (because: why would you need to do that??)

## Fixes

Contributes to #1112 by completing the following task:

- [x] When a GitHub Milestone is added to an ~~open~~ PR (develop repo):
  - if the PR has "WIP" in the title
    - add the PR to the GH Project of the same name as the Milestone, in the 'in progress' column
  - else
    - add the PR to the GH Project of the same name as the Milestone, in the 'in review' column