### PR TITLE
Resolved warnings caused by hiding inherited members.

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Entities/Humanoid/HumanoidAnimatorController.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/Humanoid/HumanoidAnimatorController.cs
@@ -11,13 +11,15 @@ namespace SS3D.Systems.Entities.Humanoid
         [SerializeField] private Animator _animator;
         [SerializeField] private float _lerpMultiplier;
 
-        private void Start()
+        protected override void OnStart()
         {
+            base.OnStart();
             SubscribeToEvents();    
         }
 
-        private void OnDestroy()
+        protected override void OnDestroyed()
         {
+            base.OnDestroyed();
             UnsubscribeFromEvents();
         }
 

--- a/Assets/Scripts/SS3D/Systems/Entities/Silicon/EngineerBorgAnimatorController.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/Silicon/EngineerBorgAnimatorController.cs
@@ -11,13 +11,15 @@ namespace SS3D.Systems.Entities.Silicon
         [SerializeField] private Animator _animator;
         [SerializeField] private float _lerpMultiplier;
         
-        private void Start()
+        protected override void OnStart()
         {
+            base.OnStart();
             SubscribeToEvents();    
         }
 
-        private void OnDestroy()
+        protected override void OnDestroyed()
         {
+            base.OnDestroyed();
             UnsubscribeFromEvents();
         }
 

--- a/Assets/Scripts/SS3D/Systems/Furniture/Locker.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/Locker.cs
@@ -16,7 +16,7 @@ namespace SS3D.Systems.Furniture
         [SerializeField, SyncVar] private IDPermission permissionToUnlock;
         public GameObject LockLight;
         private MaterialPropertyBlock propertyBlock;
-        private Renderer renderer;
+        private new Renderer renderer;
 
         private void OnLocked(bool prev, bool next, bool asServer)
         {

--- a/Assets/Scripts/SS3D/Systems/Furniture/Locker.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/Locker.cs
@@ -16,19 +16,19 @@ namespace SS3D.Systems.Furniture
         [SerializeField, SyncVar] private IDPermission permissionToUnlock;
         public GameObject LockLight;
         private MaterialPropertyBlock propertyBlock;
-        private new Renderer renderer;
+        private Renderer _renderer;
 
         private void OnLocked(bool prev, bool next, bool asServer)
         {
             if(next)
             {
                 propertyBlock.SetColor("_Color", Color.red);
-                renderer.SetPropertyBlock(propertyBlock);
+                _renderer.SetPropertyBlock(propertyBlock);
             }
             else
             {
                 propertyBlock.SetColor("_Color", Color.green);
-                renderer.SetPropertyBlock(propertyBlock);
+                _renderer.SetPropertyBlock(propertyBlock);
             }
         }
 
@@ -36,7 +36,7 @@ namespace SS3D.Systems.Furniture
         {
             base.OnStart();
             propertyBlock = new MaterialPropertyBlock();
-            renderer = LockLight.GetComponent<Renderer>();
+            _renderer = LockLight.GetComponent<Renderer>();
         }
 
         public IInteraction[] CreateTargetInteractions(InteractionEvent interactionEvent)

--- a/Assets/Scripts/SS3D/Systems/Health/StaminaController.cs
+++ b/Assets/Scripts/SS3D/Systems/Health/StaminaController.cs
@@ -93,8 +93,9 @@ namespace SS3D.Systems.Health
             }
         }
 
-        private void OnDestroy()
+        protected override void OnDestroyed()
         {
+            base.OnDestroyed();
             UnsubscribeFromEvents();
         }
 

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/AttachedContainer.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/AttachedContainer.cs
@@ -172,8 +172,9 @@ namespace SS3D.Systems.Inventory.Containers
             _container.OnContentsChanged += HandleContainerContentsChanged;
         }
 
-        public void OnDestroy()
+        protected override void OnDestroyed()
         {
+            base.OnDestroyed();
             Container?.Purge();
         }
 

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/NetworkedOpenable.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/NetworkedOpenable.cs
@@ -37,8 +37,9 @@ namespace SS3D.Systems.Inventory.Containers
             return _openState;
         }
 
-        protected virtual void Start()
+        protected override void OnStart()
         {
+            base.OnStart();
             Animator = GetComponent<Animator>();
         }
 

--- a/Assets/Scripts/SS3D/Systems/Substances/SubstanceDispenser.cs
+++ b/Assets/Scripts/SS3D/Systems/Substances/SubstanceDispenser.cs
@@ -32,8 +32,9 @@ namespace SS3D.Content.Furniture.Generic
 
         private SubstancesSystem registry;
 
-        private void Start()
+        protected override void OnStart()
         {
+            base.OnStart();
             registry = Subsystems.Get<SubstancesSystem>();
             if (registry == null)
             {

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapCreator.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapCreator.cs
@@ -57,8 +57,9 @@ namespace SS3D.Systems.Tile.UI
         }
 
         [ServerOrClient]
-        private void Start()
+        protected override void OnStart()
         {
+            base.OnStart();
             ShowUI(false);
             _inputSystem = Subsystems.Get<InputSystem>();
             _controls = _inputSystem.Inputs.TileCreator;


### PR DESCRIPTION
## Summary

Fixes a number of  warnings caused by hiding inherited members.

<details>
  <summary><b>List of warnings resolved</b></summary>

Assets/Scripts/SS3D/Systems/Furniture/Locker.cs(19,26): warning CS0108: 'Locker.renderer' hides inherited member 'Component.renderer'. Use the new keyword if hiding was intended.

Assets/Scripts/SS3D/Systems/Entities/Humanoid/HumanoidAnimatorController.cs(14,22): warning CS0108: 'HumanoidAnimatorController.Start()' hides inherited member 'Actor.Start()'. Use the new keyword if hiding was intended.

Assets/Scripts/SS3D/Systems/Entities/Humanoid/HumanoidAnimatorController.cs(19,22): warning CS0108: 'HumanoidAnimatorController.OnDestroy()' hides inherited member 'Actor.OnDestroy()'. Use the new keyword if hiding was intended.

Assets/Scripts/SS3D/Systems/Substances/SubstanceDispenser.cs(35,22): warning CS0108: 'SubstanceDispenser.Start()' hides inherited member 'Actor.Start()'. Use the new keyword if hiding was intended.

Assets/Scripts/SS3D/Systems/Inventory/Containers/AttachedContainer.cs(175,21): warning CS0108: 'AttachedContainer.OnDestroy()' hides inherited member 'NetworkActor.OnDestroy()'. Use the new keyword if hiding was intended.

Assets/Scripts/SS3D/Systems/Entities/Silicon/EngineerBorgAnimatorController.cs(14,22): warning CS0108: 'EngineerBorgAnimatorController.Start()' hides inherited member 'Actor.Start()'. Use the new keyword if hiding was intended.

Assets/Scripts/SS3D/Systems/Entities/Silicon/EngineerBorgAnimatorController.cs(19,22): warning CS0108: 'EngineerBorgAnimatorController.OnDestroy()' hides inherited member 'Actor.OnDestroy()'. Use the new keyword if hiding was intended.

Assets/Scripts/SS3D/Systems/Health/StaminaController.cs(96,22): warning CS0108: 'StaminaController.OnDestroy()' hides inherited member 'NetworkActor.OnDestroy()'. Use the new keyword if hiding was intended.

Assets/Scripts/SS3D/Systems/Inventory/Containers/NetworkedOpenable.cs(40,32): warning CS0108: 'NetworkedOpenable.Start()' hides inherited member 'NetworkActor.Start()'. Use the new keyword if hiding was intended.

Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapCreator.cs(60,22): warning CS0108: 'TileMapCreator.Start()' hides inherited member 'NetworkActor.Start()'. Use the new keyword if hiding was intended.</details>

## Technical Notes

Component.renderer is obsolete according to the [documentation](https://docs.unity3d.com/ScriptReference/Component-renderer.html), so it was intentionally overridden to resolve the Locker.cs warning.

All other fixes relate to the intended means of inheriting from the Actor / NetworkActor base classes. I have made an assumption about how they should be used, but require @joaoburatto to confirm that this is correct.
