### PR TITLE
fix player key already added bug

### DIFF
--- a/Assets/Scripts/SS3D/Systems/PlayerControl/PlayerSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/PlayerControl/PlayerSystem.cs
@@ -179,7 +179,13 @@ namespace SS3D.Systems.PlayerControl
             }
 
             player.GiveOwnership(conn);
-            _onlinePlayers.Add(ckey, player);
+
+            bool hasOnlinePlayer = _onlinePlayers.TryGetValue(ckey, out Player onlinePlayer);
+            if (!hasOnlinePlayer)
+            {
+                _onlinePlayers.Add(ckey, player);
+            }
+                
         }
 
         [Server]


### PR DESCRIPTION
## Summary

When client joins a new host, it tries to add the host and every other client back to the online player dictionnary.
This is a quick fix to simply ignore adding players already added to the Sync dictionnary.
Important one because the exception can lead to client getting kicked.

Seems like it closes #1193 


