### PR TITLE
Fix container issue with potential stack overflow

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
@@ -129,7 +129,7 @@ namespace SS3D.Systems.Inventory.Containers
             }
             ItemInHand.GiveOwnership(null);
             Item item = ItemInHand;
-            item.SetContainer(null);
+            item.Container.RemoveItem(item);
             ItemUtility.Place(item, position, rotation, transform);
         }
 

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/HumanInventory.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/HumanInventory.cs
@@ -275,7 +275,7 @@ namespace SS3D.Systems.Inventory.Containers
                 return;
             }
 
-            item.SetContainer(null);
+            attachedTo.RemoveItem(item);
         }
 
 

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
@@ -136,7 +136,7 @@ namespace SS3D.Systems.Inventory.Items
         [Server]
         public void Delete()
         {
-            SetContainer(null);
+            Container.RemoveItem(this);
 
             if (GameObject != null)
             {
@@ -256,17 +256,6 @@ namespace SS3D.Systems.Inventory.Items
             {
                 return;
             }
-
-            if (_container != null && _container.ContainsItem(this))
-            {
-                Container.RemoveItem(this);
-            }
-
-            if (newContainer != null && !newContainer.ContainsItem(this))
-            {
-                newContainer.AddItem(this);
-            }
-
             _container = newContainer;
         }
 


### PR DESCRIPTION
## Summary

SetContainer in Item.cs can call RemoveItem in AttachedContainer which can call SetContainer which can call RemoveItem... you get the idea. Most of the time this works because Setcontainer checks if item was removed, so SetContainer should not be called more than twice, but I encountered a case where it wasn't removed properly and it resulted in stack overflow.

This fixes it.
Tested on client and host.

Bugs occurs on Playtest PR, try running the test HostGameActions PlayerCanMoveInEachDirectionCorrectly. Upon exiting the test, the stack overflow occurs due to a loop between methods.


