### PR TITLE
Fix the nuke

### DIFF
--- a/Assets/Content/WorldObjects/Furniture/Generic/NukeCart.prefab
+++ b/Assets/Content/WorldObjects/Furniture/Generic/NukeCart.prefab
@@ -113,9 +113,9 @@ MeshCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 4
-  m_Convex: 0
+  m_Convex: 1
   m_CookingOptions: 30
-  m_Mesh: {fileID: 4300000, guid: bad6ca84c39067346bef31493e4dd0ce, type: 2}
+  m_Mesh: {fileID: 756681063864955725, guid: 7fc5df50928c6254ab6a553fe9207656, type: 3}
 --- !u!1 &2658310835758749969
 GameObject:
   m_ObjectHideFlags: 0
@@ -215,7 +215,7 @@ MeshCollider:
   serializedVersion: 4
   m_Convex: 0
   m_CookingOptions: 30
-  m_Mesh: {fileID: 4300000, guid: 3c20103bab91e1641aadc6ae9baccbf9, type: 2}
+  m_Mesh: {fileID: 756681063864955725, guid: 7fc5df50928c6254ab6a553fe9207656, type: 3}
 --- !u!114 &1871071288925904272
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -230,32 +230,22 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <IsNested>k__BackingField: 0
   <ComponentIndex>k__BackingField: 0
+  <PredictedSpawn>k__BackingField: {fileID: 0}
   _networkBehaviours:
   - {fileID: 135671415768211417}
   <ParentNetworkObject>k__BackingField: {fileID: 0}
   <ChildNetworkObjects>k__BackingField: []
+  SerializedTransformProperties:
+    Position: {x: 0, y: 0, z: 0}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+    LocalScale: {x: 0, y: 0, z: 0}
   _isNetworked: 1
   _isGlobal: 0
+  _initializeOrder: 0
   _defaultDespawnType: 0
   NetworkObserver: {fileID: 0}
-  <PrefabId>k__BackingField: -1
+  <PrefabId>k__BackingField: 65535
+  <SpawnableCollectionId>k__BackingField: 0
   _scenePathHash: 0
   <SceneId>k__BackingField: 0
   <AssetPathHash>k__BackingField: 708179046754819001
-  _sceneNetworkObjects:
-  - {fileID: 1871071288925904272}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Generic/NukeDetonateInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Generic/NukeDetonateInteraction.cs
@@ -55,7 +55,7 @@ namespace SS3D.Systems.Inventory.Items.Generic
                 nuke.Detonate();
                 PlayerSystem playerSystem = Subsystems.Get<PlayerSystem>();
 
-                new NukeDetonateEvent(nuke, playerSystem.GetCkey(source.GetComponentInTree<Entity>().Owner)).Invoke(this);
+                new NukeDetonateEvent(nuke, playerSystem.GetCkey(source.GetComponentInParent<Entity>().Owner)).Invoke(this);
             }
             return false;
         }


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary
Nuke was broken because of two things : 
- missing mesh colliders on the nuke itself.
- Issue with getting the component entity using GetComponentInTree. Contrary to GetComponentInParent, getComponentInTree uses the interaction source tree. That was not working anymore because hand scripts are no longer on the same game object as entity script on human, to keep it simple.


# Related issues/PRs 

Closes #1294 
