### PR TITLE
Don't allow walls to be placed over wall mounts

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Tile/BuildChecker.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/BuildChecker.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections;
+﻿using SS3D.Core;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace SS3D.Systems.Tile
@@ -16,7 +18,8 @@ namespace SS3D.Systems.Tile
         /// <param name="tileObjectSo"></param>
         /// <param name="replaceExisting"></param>
         /// <returns></returns>
-        public static bool CanBuild(ITileLocation[] tileLocations, TileObjectSo tileObjectSo, Direction dir, PlacedTileObject[] adjacentObjects, bool replaceExisting)
+        public static bool CanBuild(ITileLocation[] tileLocations, TileObjectSo tileObjectSo, Direction dir, Vector3 gridPosition,
+            PlacedTileObject[] adjacentObjects, bool replaceExisting)
         {
             bool canBuild = true;
 
@@ -60,6 +63,7 @@ namespace SS3D.Systems.Tile
                 {
                     canBuild &= tileLocations[(int)TileLayer.FurnitureBase].IsFullyEmpty() &&
                     tileLocations[(int)TileLayer.FurnitureTop].IsFullyEmpty();
+                    canBuild &= NoNeighbouringWallMount(gridPosition);
                     break;
                 }
             }
@@ -109,6 +113,21 @@ namespace SS3D.Systems.Tile
 
 
             return canBuild;
+        }
+
+
+        /// <summary>
+        /// Check if any wall mount is present as a neighbour of the tile found at the grid position.
+        /// </summary>
+        /// <param name="GridPosition">The position of the tile we want to check.</param>
+        private static bool NoNeighbouringWallMount(Vector3 GridPosition)
+        {
+            TileSystem tileSystem = Subsystems.Get<TileSystem>();
+            var map = tileSystem.CurrentMap;
+            var neighboursHigh = map.GetNeighbourPlacedObjects(TileLayer.WallMountHigh, GridPosition);
+            var neighboursLow= map.GetNeighbourPlacedObjects(TileLayer.WallMountLow, GridPosition);
+            if (neighboursHigh.Any(x => x != null) || neighboursLow.Any(x => x != null)) return false;
+            else return true;
         }
 
         private static bool CanBuildOnPlenum(SingleTileLocation plenumLocation)

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
@@ -173,7 +173,7 @@ namespace SS3D.Systems.Tile
                 // Verify if we are allowed to build for this grid position
                 Vector3 gridPosition = new(placePosition.x + gridOffset.x, 0, placePosition.z + gridOffset.y);
 
-                canBuild &= BuildChecker.CanBuild(GetTileLocations(gridPosition), tileObjectSo, dir, 
+                canBuild &= BuildChecker.CanBuild(GetTileLocations(gridPosition), tileObjectSo, dir, gridPosition,
                     GetNeighbourPlacedObjects(TileLayer.Turf, gridPosition), replaceExisting);
             }
             

--- a/Assets/Scripts/Tests/Edit Mode/TileMapTests.cs
+++ b/Assets/Scripts/Tests/Edit Mode/TileMapTests.cs
@@ -3,6 +3,7 @@ using SS3D.Systems.Tile;
 using System.Text;
 using UnityEditor;
 using UnityEngine;
+using static UnityEditor.Experimental.GraphView.GraphView;
 
 namespace EditorTests
 {
@@ -10,7 +11,7 @@ namespace EditorTests
     {
         #region Tests
         /// <summary>
-        /// Tests if an object can be built without a plenum by trying to build a wall on an empty tile;
+        /// Tests if an object can be built without a plenum by trying to build a disposal pipe on an empty tile;
         /// </summary>
         [Test]
         public void CannotBuildOnNonPlenum()
@@ -18,9 +19,10 @@ namespace EditorTests
             // SetUp
             ITileLocation[] tileLocations = CreateEmptyTileObjectArray();
             PlacedTileObject[] adjacentObjects = new PlacedTileObject[8];
-            TileObjectSo testSo = CreateTestWallSo();
+            TileObjectSo disposalPipeSo = CreateTestSo("disposal_pipe_test", 1, 1,
+                TileLayer.Disposal, TileObjectGenericType.Pipe);
 
-            bool canBuild = BuildChecker.CanBuild(tileLocations, testSo, Direction.North,
+            bool canBuild = BuildChecker.CanBuild(tileLocations, disposalPipeSo, Direction.North,
                 new Vector3(0,0,0), adjacentObjects, false);
 
             Assert.IsFalse(canBuild);
@@ -42,14 +44,15 @@ namespace EditorTests
             return tileLocations;
         }
 
-        private TileObjectSo CreateTestWallSo()
+        private TileObjectSo CreateTestSo(string name, int width, int height,
+            TileLayer layer, TileObjectGenericType genericType)
         {
             TileObjectSo testSo = (TileObjectSo)ScriptableObject.CreateInstance(typeof(TileObjectSo));
             testSo.nameString = "wall_test";
             testSo.width = 1;
             testSo.height = 1;
             testSo.layer = TileLayer.Turf;
-            testSo.genericType = TileObjectGenericType.Wall;
+            testSo.genericType = TileObjectGenericType.Pipe;
 
             return testSo;
         }

--- a/Assets/Scripts/Tests/Edit Mode/TileMapTests.cs
+++ b/Assets/Scripts/Tests/Edit Mode/TileMapTests.cs
@@ -20,7 +20,8 @@ namespace EditorTests
             PlacedTileObject[] adjacentObjects = new PlacedTileObject[8];
             TileObjectSo testSo = CreateTestWallSo();
 
-            bool canBuild = BuildChecker.CanBuild(tileLocations, testSo, Direction.North, adjacentObjects, false);
+            bool canBuild = BuildChecker.CanBuild(tileLocations, testSo, Direction.North,
+                new Vector3(0,0,0), adjacentObjects, false);
 
             Assert.IsFalse(canBuild);
         }


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary
All in the title

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [x] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

<!-- optional. -->
# Pictures/Videos)

<!-- Include photos or videos if possible to help reviewers. -->
<!-- It may also be used in our monthly devblog. -->

# Testing

Place a wall mount on a wall and try to build a wall on it.

<!-- The networking checklist is optional if your feature doesn't require that. You can remove this list if unused. -->
#### Networking checklist
<!-- (ex. The host can open a door.) -->
- [x] Works from host in host mode.
<!-- (ex. The server can open a door, even if not interacting directly.) -->
- [x] Works from server in server mode.
<!-- (ex. The client tries to open a door, and the server opens it. The client and the server have to see the same thing. This would fail if only the client sees this interaction.). -->
- [x] Works on server in client mode.
<!-- (ex. The client tries to open a door, the server opens it, and another client sees that interaction.). -->
- [x] Works and is syncronized across different clients.
<!-- (ex. The client opens a door, the server opens it. The client closes the game, reopens it, and rejoins the server. The client sees the door open.). -->
- [x] Is persistent.

<!-- optional, but encouraged to give technical context. -->
<!-- changes to files, technical notes and known issues. -->

# Related issues/PRs 

closes #1044 
