### PR TITLE
Fix UI disappearing on host death

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/HumanInventory.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/HumanInventory.cs
@@ -160,13 +160,13 @@ namespace SS3D.Systems.Inventory.Containers
             inventoryView.Setup(this);
         }
 
-		protected override void OnDisabled()
-		{
-			base.OnDisabled();
-			var inventoryView = ViewLocator.Get<InventoryView>().First();
-			inventoryView.DestroyAllSlots();
-
-		}
+        protected override void OnDisabled()
+        {
+            base.OnDisabled();
+            if (!IsOwner) return;
+            var inventoryView = ViewLocator.Get<InventoryView>().First();
+            inventoryView.DestroyAllSlots();
+        }
 
 		/// <summary>
 		/// Add a given container to this inventory, and register to a few events related to the container.


### PR DESCRIPTION
# Summary

Upon death of host, inventory UI should disappear on host but remain on client. This fixes it.
Very small change, just one added check for isOwner
