### PR TITLE
disable all  unnecessary components on construction hologram

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/ConstructionHologram.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/ConstructionHologram.cs
@@ -1,6 +1,7 @@
 ﻿using Coimbra;
 using SS3D.Data;
 using SS3D.Data.Enums;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -28,6 +29,12 @@ namespace SS3D.Systems.Tile.TileMapCreator
         /// all tile objects. If it's not, it will choose another available direction.</param>
         public ConstructionHologram(GameObject ghostObject, Vector3 targetPosition, Direction dir)
         {
+
+            List<MonoBehaviour> components = ghostObject.GetComponentsInChildren<MonoBehaviour>()
+                .Where(x => x is not ICustomGhostRotation).ToList();
+
+            components.ForEach(x => x.enabled = false);
+
             _hologram = ghostObject;
             _position = targetPosition;
             _direction = dir;


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary

Very small PR, to solve an issue that bugs me for my electricity PR. Construction hologram should not do anything beside displaying visually the item to pose. Currently, all the monobehaviours on the hologram will start and try to execute some logic. I ru into some trouble because of that. What this PR does is that it disable all monobehaviours upon instantiating an object to be an hologram. I've tried with around 30 holograms and didn't notice any issue.

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [x] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

<!-- optional. -->
# Pictures/Videos)

<!-- Include photos or videos if possible to help reviewers. -->
<!-- It may also be used in our monthly devblog. -->

# Testing

<!-- Explain how can a reviewer test this PR. -->

<!-- The networking checklist is optional if your feature doesn't require that. You can remove this list if unused. -->
#### Networking checklist
<!-- (ex. The host can open a door.) -->
- [x] Works from host in host mode.
<!-- (ex. The server can open a door, even if not interacting directly.) -->
- [x] Works from server in server mode.
<!-- (ex. The client tries to open a door, and the server opens it. The client and the server have to see the same thing. This would fail if only the client sees this interaction.). -->
- [x] Works on server in client mode.
<!-- (ex. The client tries to open a door, the server opens it, and another client sees that interaction.). -->
- [x] Works and is syncronized across different clients.
<!-- (ex. The client opens a door, the server opens it. The client closes the game, reopens it, and rejoins the server. The client sees the door open.). -->
- [x] Is persistent.

<!-- optional, but encouraged to give technical context. -->
<!-- changes to files, technical notes and known issues. -->
# Changes

<!-- List any major asset/script/scene changes and why/how they were changed. -->

<!-- Provide a more technical description of your changes to help save the reviewers some time. -->

<!-- List ANYTHING not working correctly, either part of your new change, or another part of the game. -->

<!-- Any known bugs will likely require sorting out before the PR is merged. -->

<!-- optional -->
# Related issues/PRs 

<!-- List any issues or other PRs connected to this one. -->

<!-- If this PR CLOSES any issues/PRs, add "Closes" before the number (e.g. "Closes #123"). -->
