### PR TITLE
Allow disabling Destroy logic on Actors

### DIFF
--- a/Assets/Scripts/SS3D/Core/Behaviours/Actor.cs
+++ b/Assets/Scripts/SS3D/Core/Behaviours/Actor.cs
@@ -36,6 +36,11 @@ namespace SS3D.Core.Behaviours
         private bool _initialized;
 
         /// <summary>
+        /// If this actor should call the destroy callback when done.
+        /// </summary>
+        private bool _shouldCallDestroy = true;
+
+        /// <summary>
         /// The event bus listeners added to this object, cleared on OnDestroy
         /// </summary>
         private readonly List<EventHandle> _eventHandles = new();
@@ -167,6 +172,12 @@ namespace SS3D.Core.Behaviours
             _eventHandles.Add(handle);
         }
 
+        
+        public void SetCallDestroy(bool callDestroy)
+        {
+            _shouldCallDestroy= callDestroy;
+        }
+
         protected void OnEnable()
         {
             OnEnabled();
@@ -192,6 +203,8 @@ namespace SS3D.Core.Behaviours
         protected void OnDestroy()
         {
             RemoveEventListeners();
+
+            if (!_shouldCallDestroy) return;
 
             OnDestroyed();
         }

--- a/Assets/Scripts/SS3D/Core/Behaviours/NetworkActor.cs
+++ b/Assets/Scripts/SS3D/Core/Behaviours/NetworkActor.cs
@@ -37,6 +37,11 @@ namespace SS3D.Core.Behaviours
         private bool _initialized;
 
         /// <summary>
+        /// If this actor should call the destroy callback when done.
+        /// </summary>
+        private bool _shouldCallDestroy = true;
+
+        /// <summary>
         /// The event bus listeners added to this object, cleared on OnDestroy
         /// </summary>
         private readonly List<EventHandle> _eventHandles = new();
@@ -168,6 +173,11 @@ namespace SS3D.Core.Behaviours
             _eventHandles.Add(handle);
         }
 
+        public void SetCallDestroy(bool callDestroy)
+        {
+            _shouldCallDestroy = callDestroy;
+        }
+
         protected void OnEnable()
         {
             OnEnabled();
@@ -193,6 +203,8 @@ namespace SS3D.Core.Behaviours
         protected void OnDestroy()
         {
             RemoveEventListeners();
+
+            if (!_shouldCallDestroy) return;
 
             OnDestroyed();
         }

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
@@ -123,12 +123,6 @@ namespace SS3D.Systems.Inventory.Items
             ItemId = id;
         }
 
-        protected override void OnDestroyed()
-        {
-            base.OnDestroyed();
-            Debug.Log("destroy item logic");
-        }
-
         public override void OnStartServer()
         {
             base.OnStartServer();

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
@@ -123,6 +123,12 @@ namespace SS3D.Systems.Inventory.Items
             ItemId = id;
         }
 
+        protected override void OnDestroyed()
+        {
+            base.OnDestroyed();
+            Debug.Log("destroy item logic");
+        }
+
         public override void OnStartServer()
         {
             base.OnStartServer();

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/ConstructionHologram.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/ConstructionHologram.cs
@@ -1,9 +1,11 @@
-﻿using Coimbra;
-using SS3D.Data;
+﻿using SS3D.Data;
 using SS3D.Data.Enums;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using SS3D.Core.Behaviours;
+using Coimbra;
+using Actor = SS3D.Core.Behaviours.Actor;
 
 namespace SS3D.Systems.Tile.TileMapCreator
 {
@@ -30,10 +32,7 @@ namespace SS3D.Systems.Tile.TileMapCreator
         public ConstructionHologram(GameObject ghostObject, Vector3 targetPosition, Direction dir)
         {
 
-            List<MonoBehaviour> components = ghostObject.GetComponentsInChildren<MonoBehaviour>()
-                .Where(x => x is not ICustomGhostRotation).ToList();
-
-            components.ForEach(x => x.enabled = false);
+            DisableBehaviours(ghostObject);
 
             _hologram = ghostObject;
             _position = targetPosition;
@@ -121,6 +120,19 @@ namespace SS3D.Systems.Tile.TileMapCreator
         public void Destroy()
         {
             _hologram.Dispose(true);
+        }
+
+        private void DisableBehaviours(GameObject ghostObject)
+        {
+            List<MonoBehaviour> components = ghostObject.GetComponentsInChildren<MonoBehaviour>()
+                .Where(x => x is not ICustomGhostRotation).ToList();
+
+            foreach (var component in components)
+            {
+                component.enabled = false;
+                if (component is Actor) ((Actor)component).SetCallDestroy(false);
+                if (component is NetworkActor) ((NetworkActor)component).SetCallDestroy(false);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary

This PR add a flag to allow Actors to not call the logic in OnDestroy if wanted. This is necessary for holograms. Holograms are destroyed when placing them, and the OnDestroy callback of unity executes. Issue is, sometimes the logic in OnDestroy 
should not be called as the components are inactive and some references might be not set up properly. 

you can test it by adding this in the item script, and see that no log appears in console when destroying holograms

`
        protected override void OnDestroyed()
        {
            base.OnDestroyed();
            Debug.Log("destroy item logic");
        }
`

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [x] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

<!-- optional. -->
# Pictures/Videos)

<!-- Include photos or videos if possible to help reviewers. -->
<!-- It may also be used in our monthly devblog. -->

# Testing

<!-- Explain how can a reviewer test this PR. -->

<!-- The networking checklist is optional if your feature doesn't require that. You can remove this list if unused. -->
#### Networking checklist
<!-- (ex. The host can open a door.) -->
- [x] Works from host in host mode.
<!-- (ex. The server can open a door, even if not interacting directly.) -->
- [x] Works from server in server mode.
<!-- (ex. The client tries to open a door, and the server opens it. The client and the server have to see the same thing. This would fail if only the client sees this interaction.). -->
- [x] Works on server in client mode.
<!-- (ex. The client tries to open a door, the server opens it, and another client sees that interaction.). -->
- [x] Works and is syncronized across different clients.
<!-- (ex. The client opens a door, the server opens it. The client closes the game, reopens it, and rejoins the server. The client sees the door open.). -->
- [x] Is persistent.

<!-- optional, but encouraged to give technical context. -->
<!-- changes to files, technical notes and known issues. -->
# Changes

<!-- List any major asset/script/scene changes and why/how they were changed. -->

<!-- Provide a more technical description of your changes to help save the reviewers some time. -->

<!-- List ANYTHING not working correctly, either part of your new change, or another part of the game. -->

<!-- Any known bugs will likely require sorting out before the PR is merged. -->

<!-- optional -->
# Related issues/PRs 

<!-- List any issues or other PRs connected to this one. -->

<!-- If this PR CLOSES any issues/PRs, add "Closes" before the number (e.g. "Closes #123"). -->
