### PR TITLE
remove audio from lobby

### DIFF
--- a/Assets/Content/Scenes/Game.unity
+++ b/Assets/Content/Scenes/Game.unity
@@ -1439,7 +1439,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4468402021075485018, guid: cc5383d385556f443b2a7d3202f2b2c1, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -230.00015
+      value: -229.99997
       objectReference: {fileID: 0}
     - target: {fileID: 4468402021449001342, guid: cc5383d385556f443b2a7d3202f2b2c1, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -4363,6 +4363,10 @@ PrefabInstance:
     - target: {fileID: 7939122254879796211, guid: 2dff3e99d61d74c4282d2983e482289c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7939122254879796212, guid: 2dff3e99d61d74c4282d2983e482289c, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2dff3e99d61d74c4282d2983e482289c, type: 3}

--- a/Assets/Scripts/SS3D/Systems/Audio/AmbienceHandler.cs
+++ b/Assets/Scripts/SS3D/Systems/Audio/AmbienceHandler.cs
@@ -1,4 +1,6 @@
-﻿using SS3D.Core.Behaviours;
+﻿using SS3D.Core;
+using SS3D.Core.Behaviours;
+using SS3D.Systems.Entities;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.Audio;
@@ -86,19 +88,29 @@ namespace SS3D.Systems.Audio
         [SerializeField]
         private AudioMixer _masterMixer;
 
-        private void Start()
+        private bool _clientHasSpawned;
+
+        protected override void OnStart()
         {
-            if (_ambientNoiseFrequency != 0)
-            {
-                PlayAmbience();
-            }
+            Subsystems.Get<EntitySystem>().OnClientSpawn += HandleClientSpawn;
+            SetVolumeOfAll(0f);
         }
 
         private void Update()
         {
+            if (!_clientHasSpawned) return;
             AttenuateWindSounds();
             AttenuatePowerSounds();
             MuffleSFX();
+        }
+
+        private void HandleClientSpawn()
+        {
+            _clientHasSpawned = true;
+            if (_ambientNoiseFrequency != 0)
+            {
+                PlayAmbience();
+            }   
         }
 
         /// <summary>
@@ -191,6 +203,14 @@ namespace SS3D.Systems.Audio
                 StartCoroutine(AmbientNoiseTimer());
             }
 
+        }
+
+        private void SetVolumeOfAll(float volume)
+        {
+            _airPlayer.volume = volume;
+            _electricalPlayer.volume = volume;
+            _lightWindPlayer.volume = volume;
+            _heavyWindPlayer.volume = volume;
         }
     }
 }

--- a/Assets/Scripts/SS3D/Systems/Entities/EntitySystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/EntitySystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Coimbra;
 using Coimbra.Services.Events;
@@ -15,6 +16,7 @@ using SS3D.Systems.Rounds;
 using SS3D.Systems.Rounds.Events;
 using SS3D.Utils;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace SS3D.Systems.Entities
 {
@@ -23,6 +25,11 @@ namespace SS3D.Systems.Entities
     /// </summary>
     public class EntitySystem : NetworkSystem
     {
+        /// <summary>
+        /// Event that should be evoked only on client, when the client spawns in the station.
+        /// </summary>
+        public Action OnClientSpawn;
+
         /// <summary>
         /// The prefab used for the player object.
         /// </summary>
@@ -195,6 +202,8 @@ namespace SS3D.Systems.Entities
 
             _spawnedPlayers.Add(entity);
 
+            RpcInvokeClientSpawned(entity.Owner);
+
             Log.Information(this, "Spawning mind {createdMind} on {entity}", Logs.ServerOnly, createdMind.name, entity.name);
         }
 
@@ -309,5 +318,13 @@ namespace SS3D.Systems.Entities
 			_spawnedPlayers[index] = newEntity;
             return true;
 		}
+
+        [TargetRpc]
+        private void RpcInvokeClientSpawned(NetworkConnection target)
+        {
+            OnClientSpawn?.Invoke();
+        }
+
+
 	}
 }


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary

Make ambient sounds only play when onboarding.

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [x] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

<!-- optional. -->
# Pictures/Videos)

<!-- Include photos or videos if possible to help reviewers. -->
<!-- It may also be used in our monthly devblog. -->

# Testing

<!-- Explain how can a reviewer test this PR. -->

<!-- The networking checklist is optional if your feature doesn't require that. You can remove this list if unused. -->
#### Networking checklist
<!-- (ex. The host can open a door.) -->
- [x] Works from host in host mode.
<!-- (ex. The server can open a door, even if not interacting directly.) -->
- [x] Works from server in server mode.
<!-- (ex. The client tries to open a door, and the server opens it. The client and the server have to see the same thing. This would fail if only the client sees this interaction.). -->
- [x] Works on server in client mode.
<!-- (ex. The client tries to open a door, the server opens it, and another client sees that interaction.). -->
- [x] Works and is syncronized across different clients.
<!-- (ex. The client opens a door, the server opens it. The client closes the game, reopens it, and rejoins the server. The client sees the door open.). -->
- [x] Is persistent.

<!-- optional, but encouraged to give technical context. -->
<!-- changes to files, technical notes and known issues. -->
# Changes

Just added an event in the entity system. When a player spawn, a target rpc is sent to the client spawning, and the onSpawned event is called. The ambiant system suscribes to that.

# Related issues/PRs 

closes #1352 
