### PR TITLE
Stable horizontal inventory slot alignment

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/InventoryView.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/InventoryView.cs
@@ -57,7 +57,7 @@ namespace SS3D.Systems.Inventory.UI
         [SerializeField] private GameObject EarRightPrefab;
         [SerializeField] private GameObject DummyPrefab;
 
-
+        private HorizontalLayoutGroup layoutGroup;
         private object lockObject = new object();
 
         /// <summary>
@@ -87,6 +87,7 @@ namespace SS3D.Systems.Inventory.UI
         {
             FillClothingLayoutWithDummySlots();
             Inventory = inventory;
+            layoutGroup = HorizontalLayout.GetComponent<HorizontalLayoutGroup>();
 
             foreach(var container in inventory.Containers)
             {
@@ -119,6 +120,11 @@ namespace SS3D.Systems.Inventory.UI
         {
             if (Slots.Exists(x => x.Container == container))
                 return;
+
+            if (HorizontalSlotOrder.Contains(container.Type) && layoutGroup.enabled == false)
+            {
+                layoutGroup.enabled = true;
+            }
 
             SingleItemContainerSlot slot;
             switch (container.Type)
@@ -375,6 +381,11 @@ namespace SS3D.Systems.Inventory.UI
 
             SingleItemContainerSlot slot = Slots[indexToRemove];
             if (slot == null) return;
+
+            if (HorizontalSlotOrder.Contains(container.Type) && layoutGroup.enabled)
+            {
+                layoutGroup.enabled = false;
+            }
 
             slot?.gameObject.Dispose(true);
             Slots.RemoveAt(indexToRemove);


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary

<!-- Provide a general summary of your change here. -->

Enable horizontal layout group in `HandleInventoryContainerAdded` and disable in `HandleInventoryContainerRemoved`.

<!-- Follow with a more concise explanation of your change here. -->

<!-- What features does this change include/not include? -->

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [ ] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

<!-- optional. -->
# Pictures/Videos

<!-- Include photos or videos if possible to help reviewers. -->
<!-- It may also be used in our monthly devblog. -->

https://github.com/RE-SS3D/SS3D/assets/25079277/c085cdfa-ec23-4e26-9b4e-57c1fe49cad4

# Tests

Are there any other items that would affect the horizontal layout slot?

<!-- optional -->
# Related issues/PRs 

<!-- List any issues or other PRs connected to this one. -->

<!-- If this PR CLOSES any issues/PRs, add "Closes" before the number (e.g. "Closes #123"). -->
Closes #1365Closes #1365Closes #1365