### PR TITLE
fix exception attempting to readpixels outside of rendertexture bounds

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Selection/SelectionCamera.cs
+++ b/Assets/Scripts/SS3D/Systems/Selection/SelectionCamera.cs
@@ -1,9 +1,6 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using SS3D.Core.Behaviours;
 using SS3D.Core;
-using UnityEngine.UI;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.InputSystem;
 using InputSystem = SS3D.Systems.Inputs.InputSystem;
@@ -105,7 +102,7 @@ namespace SS3D.Systems.Selection
             }
             else
             {
-                _readbackTexture.ReadPixels(new Rect(pos.x, Screen.height - pos.y, 1, 1), 0, 0, false);
+                _readbackTexture.ReadPixels(new Rect(pos.x, Screen.height-pos.y-1, 1, 1), 0, 0, false);
                 col = _readbackTexture.GetPixel(0, 0);
             }
 


### PR DESCRIPTION

# Summary

Kill that annoying log filling bug when trying to read pixels at the bottom of the window in editor.


