### PR TITLE
Add missing filters to slot inventories

### DIFF
--- a/Assets/Content/Data/Filters/Wearables/Belt.asset
+++ b/Assets/Content/Data/Filters/Wearables/Belt.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0adc192349dc57848b5394a2c6707c23, type: 3}
+  m_Name: Belt
+  m_EditorClassIdentifier: 
+  mustHaveAll: 0
+  acceptedTraits:
+  - {fileID: 11400000, guid: 5a7c5e53d45ef364ea78fcb8bb8e6b7f, type: 2}
+  deniedTraits: []

--- a/Assets/Content/Data/Filters/Wearables/Belt.asset.meta
+++ b/Assets/Content/Data/Filters/Wearables/Belt.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5012319ac2389e94e819989fd0a54f01
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/Data/Traits/Wearables/Belt.asset
+++ b/Assets/Content/Data/Traits/Wearables/Belt.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b120a07bf55051644adda51d564ace97, type: 3}
+  m_Name: Belt
+  m_EditorClassIdentifier: 

--- a/Assets/Content/Data/Traits/Wearables/Belt.asset.meta
+++ b/Assets/Content/Data/Traits/Wearables/Belt.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a7c5e53d45ef364ea78fcb8bb8e6b7f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Content/WorldObjects/Entities/Humanoids/Human/HumanBodyParts/HumanTorso.prefab
+++ b/Assets/Content/WorldObjects/Entities/Humanoids/Human/HumanBodyParts/HumanTorso.prefab
@@ -830,7 +830,7 @@ MonoBehaviour:
   _size: {x: 1, y: 1}
   _hideItems: 0
   _type: 8
-  _startFilter: {fileID: 0}
+  _startFilter: {fileID: 11400000, guid: 91b02707a12a4c546912f7432612d85f, type: 2}
 --- !u!114 &8136951514244066473
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/WorldObjects/Entities/Humanoids/Human/HumanBodyParts/HumanTorso.prefab
+++ b/Assets/Content/WorldObjects/Entities/Humanoids/Human/HumanBodyParts/HumanTorso.prefab
@@ -248,7 +248,7 @@ MonoBehaviour:
   _size: {x: 1, y: 1}
   _hideItems: 1
   _type: 32768
-  _startFilter: {fileID: 0}
+  _startFilter: {fileID: 11400000, guid: 5012319ac2389e94e819989fd0a54f01, type: 2}
 --- !u!114 &3856680766676271507
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/WorldObjects/Items/Clothing/Toolbelt.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/Toolbelt.prefab
@@ -205,7 +205,8 @@ MonoBehaviour:
   _asset: {fileID: 11400000, guid: 9cf2801a7b335074190840fc9112d582, type: 2}
   _name: Belt
   _weight: 1
-  _startingTraits: []
+  _startingTraits:
+  - {fileID: 11400000, guid: 5a7c5e53d45ef364ea78fcb8bb8e6b7f, type: 2}
   _rigidbody: {fileID: 8317416473142320945}
   AttachmentPoint: {fileID: 4492906417869608502}
   AttachmentPointAlt: {fileID: 4492906417869608502}


### PR DESCRIPTION
# Summary

This PR adds the "Belt" filter and trait and sets up the "Belt" and "IDSlot" filters

I'm not sure if it is expected to add any possible trait/filter that will be used (like for the HeadContainer, which is not in use as far as I can see, but may be in the future). If so, please let me know which containers we'll need to have the filters/traits and I'll gladly set them up!

#### PR checklist
- [ ] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [ ] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [ ] No "trash" files are committed.
<!-- optional, if no code -->
- [ ] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

# Pictures/Videos)

https://github.com/RE-SS3D/SS3D/assets/50799541/7248b705-faef-4b71-b139-881d76bf8ec0

# Testing

Try to drag any item to the BeltContainer - only the Toolbelt should work
Try to drag any item to the ID container - only PDAs/IDs should work

# Changes

"Belt" filter has been added to the "BeltContainer" inventory slot (in the Human prefab), and the "Belt" trait has been added to the "Toolbelt" as an starting trait

Also, "IDSlot" filter was already created and the "IDSlot" trait was already in the PDAs/IDs, but the "ID container" inventory slot didn't have the filter attached - so this PR fixes it

# Related issues/PRs 

Closes #1364 
