### PR TITLE
Fix vendor machines and add multiple options and stock

### DIFF
--- a/Assets/Content/WorldObjects/Furniture/Machines/Vendors/VendorHotDrinks.prefab
+++ b/Assets/Content/WorldObjects/Furniture/Machines/Vendors/VendorHotDrinks.prefab
@@ -154,7 +154,9 @@ MonoBehaviour:
   _componentIndexCache: 0
   _addedNetworkObject: {fileID: 1871071288925904272}
   _networkObjectCache: {fileID: 1871071288925904272}
-  _productToDispense: 5
+  _productsToDispense:
+  - Product: {fileID: 11400000, guid: edcff839a189118479387da05ec07d49, type: 2}
+    Stock: 5
   _dispensingTransform: {fileID: 5160227759105755511}
 --- !u!114 &-8220440043154804263
 MonoBehaviour:

--- a/Assets/Content/WorldObjects/Furniture/Machines/Vendors/VendorRobustSoftdrinks.prefab
+++ b/Assets/Content/WorldObjects/Furniture/Machines/Vendors/VendorRobustSoftdrinks.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 3665146264900623842}
   - component: {fileID: 8086907785789700544}
   m_Layer: 0
-  m_Name: VendorRobustSoftDrinks
+  m_Name: VendorRobustSoftdrinks
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -153,7 +153,21 @@ MonoBehaviour:
   _componentIndexCache: 0
   _addedNetworkObject: {fileID: 1871071288925904272}
   _networkObjectCache: {fileID: 1871071288925904272}
-  _productToDispense: 3
+  _productsToDispense:
+  - Product: {fileID: 11400000, guid: dd302b5636b41bb48ba3a2cdc72cc64c, type: 2}
+    Stock: 10
+  - Product: {fileID: 11400000, guid: a49cca9d10e0a3146aae1906542ea50a, type: 2}
+    Stock: 10
+  - Product: {fileID: 11400000, guid: e450161ce63de9045b97061a364533b1, type: 2}
+    Stock: 10
+  - Product: {fileID: 11400000, guid: 5c76cb2799458404db16e87cc1606975, type: 2}
+    Stock: 10
+  - Product: {fileID: 11400000, guid: 6ccd0b8aea90f5a489d73c02ccab3a98, type: 2}
+    Stock: 10
+  - Product: {fileID: 11400000, guid: be837baab1848a14d944ab050bfebc15, type: 2}
+    Stock: 10
+  - Product: {fileID: 11400000, guid: f5c190c5bf049bc429ca90309c334105, type: 2}
+    Stock: 10
   _dispensingTransform: {fileID: 5160227759105755511}
 --- !u!114 &3665146264900623842
 MonoBehaviour:

--- a/Assets/Content/WorldObjects/Furniture/Machines/Vendors/VendorSecTech.prefab
+++ b/Assets/Content/WorldObjects/Furniture/Machines/Vendors/VendorSecTech.prefab
@@ -238,7 +238,15 @@ MonoBehaviour:
   _componentIndexCache: 0
   _addedNetworkObject: {fileID: 1871071288925904272}
   _networkObjectCache: {fileID: 1871071288925904272}
-  _productToDispense: 11
+  _productsToDispense:
+  - Product: {fileID: 11400000, guid: ecb1cb0479842954a925e9013baf95f6, type: 2}
+    Stock: 5
+  - Product: {fileID: 11400000, guid: 3e3beac0c217b7c4492869d62e50a5b8, type: 2}
+    Stock: 5
+  - Product: {fileID: 11400000, guid: 2d3da1772e540e644a1b7cb548477c0c, type: 2}
+    Stock: 5
+  - Product: {fileID: 11400000, guid: 0628fd4af4e63fe4c884827fcb3ced1a, type: 2}
+    Stock: 5
   _dispensingTransform: {fileID: 5160227759105755511}
 --- !u!114 &-8922800647233213677
 MonoBehaviour:

--- a/Assets/Content/WorldObjects/Furniture/Machines/Vendors/VendorYouTool.prefab
+++ b/Assets/Content/WorldObjects/Furniture/Machines/Vendors/VendorYouTool.prefab
@@ -153,7 +153,15 @@ MonoBehaviour:
   _componentIndexCache: 0
   _addedNetworkObject: {fileID: 1871071288925904272}
   _networkObjectCache: {fileID: 1871071288925904272}
-  _productToDispense: 2
+  _productsToDispense:
+  - Product: {fileID: 11400000, guid: 4d5800940a547b2419e83ec0ccd555d4, type: 2}
+    Stock: 5
+  - Product: {fileID: 11400000, guid: 4b6f5ee7c28256e4783f03f8d96872b7, type: 2}
+    Stock: 5
+  - Product: {fileID: 11400000, guid: 4c4f968211b927b4aa55e22fc7adcb2b, type: 2}
+    Stock: 5
+  - Product: {fileID: 11400000, guid: 58b1ed19ea55c074cb719ae4c4791cf1, type: 2}
+    Stock: 5
   _dispensingTransform: {fileID: 5160227759105755511}
 --- !u!114 &6841733904447030618
 MonoBehaviour:

--- a/Assets/Scripts/SS3D/Systems/Furniture/DispenseProductInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/DispenseProductInteraction.cs
@@ -2,6 +2,7 @@
 using SS3D.Interactions;
 using SS3D.Interactions.Extensions;
 using SS3D.Interactions.Interfaces;
+using SS3D.Systems.Tile;
 using UnityEngine;
 
 namespace SS3D.Systems.Furniture
@@ -11,10 +12,14 @@ namespace SS3D.Systems.Furniture
     /// </summary>
     public class DispenseProductInteraction : Interaction
     {
+        public string ProductName;
+        public int ProductStock;
+        public int ProductIndex;
+        
         /// <inheritdoc />
         public override string GetName(InteractionEvent interactionEvent)
         {
-            return "Dispense";
+            return $"Dispense {ProductName} (x{ProductStock})";
         }
 
         /// <inheritdoc />
@@ -44,7 +49,7 @@ namespace SS3D.Systems.Furniture
 
             if (target is VendingMachine vendingMachine)
             {
-                vendingMachine.DispenseProduct();
+                vendingMachine.DispenseProduct(ProductIndex);
             }
             return false;
         }

--- a/Assets/Scripts/SS3D/Systems/Furniture/VendingMachine.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/VendingMachine.cs
@@ -3,6 +3,7 @@ using SS3D.Core;
 using SS3D.Data.Generated;
 using SS3D.Interactions;
 using SS3D.Interactions.Interfaces;
+using SS3D.Systems.Audio;
 using SS3D.Systems.Inventory.Items;
 using UnityEngine;
 
@@ -12,16 +13,14 @@ namespace SS3D.Systems.Furniture
     /// Simple implementation of a vending machine. This has many todos.
     ///
     /// TODO: Make proper UI for this.
-    /// TODO: Dispensing products should reduce their stock.
     /// </summary>
     public class VendingMachine : InteractionSource, IInteractionTarget
     {
         /// <summary>
-        /// The product to dispense.
-        /// TODO: Make a new struct for different products, and to support multiple products.
+        /// The products available to dispense and their stock.
         /// </summary>
         [SerializeField]
-        private GameObject _productToDispense;
+        private VendingMachineProductStock[] _productsToDispense;
 
         /// <summary>
         /// The transform representation of where the dispensed products should spawn at.
@@ -30,36 +29,61 @@ namespace SS3D.Systems.Furniture
         private Transform _dispensingTransform;
 
         /// <summary>
-        /// Requests the server to dispense a product.
+        /// Requests the server to dispense a specific product.
         /// </summary>
         [ServerRpc(RequireOwnership = false)]
-        public void CmdDispenseProduct()
+        public void CmdDispenseProduct(int productIndex)
         {
-            DispenseProduct();
+            DispenseProduct(productIndex);
         }
 
         /// <summary>
-        /// Dispenses the vending machine product at the dispensing transform position with a random rotation.
+        /// Dispenses a specific vending machine product at the dispensing transform position with a random rotation.
+        /// If there's not enough stock, a sound is played and the product isn't dispensed.
         /// </summary>
         [Server]
-        public void DispenseProduct()
+        public void DispenseProduct(int productIndex)
         {
+            if (productIndex >= _productsToDispense.Length)
+            {
+                Debug.LogError($"Product with index {productIndex} not found in products to dispense in {gameObject.name}. Max possible index is {_productsToDispense.Length - 1}");
+                return;
+            }
+
+            VendingMachineProductStock productToDispenseStock = _productsToDispense[productIndex];
+            if (productToDispenseStock.Stock <= 0)
+            {
+                Subsystems.Get<AudioSystem>().PlayAudioSource(Audio.AudioType.Sfx, Sounds.BikeHorn, Position, NetworkObject,
+                    false, 0.7f, 1, 1, 3);
+                return;
+            }
+
+            productToDispenseStock.Stock--;
+            Subsystems.Get<AudioSystem>().PlayAudioSource(Audio.AudioType.Sfx, Sounds.Can1, Position, NetworkObject,
+                false, 0.7f, 1, 1, 3);
+            
             ItemSystem itemSystem = Subsystems.Get<ItemSystem>();
             Quaternion quaternion = Quaternion.Euler(new Vector3(Random.Range(0, 360), Random.Range(0, 360), Random.Range(0, 360)));
 
-            itemSystem.SpawnItem(_productToDispense.name, _dispensingTransform.position, quaternion);
+            itemSystem.SpawnItem(productToDispenseStock.Product.name, _dispensingTransform.position, quaternion);
         }
 
         /// <inheritdoc />
         public IInteraction[] CreateTargetInteractions(InteractionEvent interactionEvent)
         {
-            return new IInteraction[]
+            IInteraction[] interactions = new IInteraction[_productsToDispense.Length];
+            for (int i = 0; i < _productsToDispense.Length; i++)
             {
-                new DispenseProductInteraction
+                interactions[i] = new DispenseProductInteraction
                 {
+                    ProductName = _productsToDispense[i].Product.NameString,
+                    ProductIndex = i,
+                    ProductStock = _productsToDispense[i].Stock,
                     Icon = InteractionIcons.Take
-                }
-            };
+                };
+            }
+
+            return interactions;
         }
     }
 }

--- a/Assets/Scripts/SS3D/Systems/Furniture/VendingMachine.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/VendingMachine.cs
@@ -3,6 +3,7 @@ using SS3D.Core;
 using SS3D.Data.Generated;
 using SS3D.Interactions;
 using SS3D.Interactions.Interfaces;
+using SS3D.Logging;
 using SS3D.Systems.Audio;
 using SS3D.Systems.Inventory.Items;
 using UnityEngine;
@@ -46,7 +47,14 @@ namespace SS3D.Systems.Furniture
         {
             if (productIndex >= _productsToDispense.Length)
             {
-                Debug.LogError($"Product with index {productIndex} not found in products to dispense in {gameObject.name}. Max possible index is {_productsToDispense.Length - 1}");
+                Log.Error(this, $"Product with index {productIndex} not found in products to dispense in {gameObject.name}. "
+                    + $"Max possible index is {_productsToDispense.Length - 1}");
+                return;
+            }
+            
+            if (productIndex < 0)
+            {
+                Log.Error(this, $"Invalid product index, value must be between 0 and {_productsToDispense.Length - 1}");
                 return;
             }
 

--- a/Assets/Scripts/SS3D/Systems/Furniture/VendingMachineProductStock.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/VendingMachineProductStock.cs
@@ -1,0 +1,11 @@
+﻿using SS3D.Systems.Tile;
+
+namespace SS3D.Systems.Furniture
+{
+    [System.Serializable]
+    public class VendingMachineProductStock
+    {
+        public ItemObjectSo Product;
+        public int Stock;
+    }
+}

--- a/Assets/Scripts/SS3D/Systems/Furniture/VendingMachineProductStock.cs.meta
+++ b/Assets/Scripts/SS3D/Systems/Furniture/VendingMachineProductStock.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fb98c04faa7e49548f43a8e55260b09f
+timeCreated: 1711279742


### PR DESCRIPTION
# Summary

Vendor machine code has been updated to work with more than one product and to have stock. The current four vendor machines (VendorHotDrinks, VendorYouTool, VendorSecTech, VendorRobustDrinks) have at least one product to be dispensed with an initial stock. Both products and stocks are placeholders, so they have functionality for now and can be tested.

They also now run a sound when dispensing, and an error sound when there are is no stock of the product selected. Both sound effects are placeholders.

#### PR checklist
- [ ] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [ ] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [ ] No "trash" files are committed.
<!-- optional, if no code -->
- [ ] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

# Pictures/Videos

https://github.com/RE-SS3D/SS3D/assets/50799541/b7034196-06e0-4088-9ad1-209c68002326

![imagen](https://github.com/RE-SS3D/SS3D/assets/50799541/bf918d3b-c6f5-4dc5-941d-6ebc74d123d8)

# Testing

Place a vendor and right-click on it to show the interaction menu, left click different items to dispense. All four vendors should have something to dispense and work correctly. When the stock of one product reaches 0 it should no longer dispense anything.

<!-- The networking checklist is optional if your feature doesn't require that. You can remove this list if unused. -->
#### Networking checklist
<!-- (ex. The host can open a door.) -->
- [ ] Works from host in host mode.
<!-- (ex. The server can open a door, even if not interacting directly.) -->
- [ ] Works from server in server mode.
<!-- (ex. The client tries to open a door, and the server opens it. The client and the server have to see the same thing. This would fail if only the client sees this interaction.). -->
- [ ] Works on server in client mode.
<!-- (ex. The client tries to open a door, the server opens it, and another client sees that interaction.). -->
- [ ] Works and is syncronized across different clients.
<!-- (ex. The client opens a door, the server opens it. The client closes the game, reopens it, and rejoins the server. The client sees the door open.). -->
- [ ] Is persistent.

# Changes

VendingMachine.cs has been updated to accept several products.
DispenseProductInteraction.cs has been updated so it works for a specific product, including the index of the product in the VendingMachine and the name/stock of the product to display in the interaction.
VendingMachineProductStock.cs has been created to deal with different products and their stock. Is not an struct, so we can update it easily.
Products are now referenced using the ItemObjectSo instead of the GameObject prefab directly. I'm not 100% sure if that's the correct approach, let me know if we should use something different.

# Related issues/PRs 

Closes #1437 
