### PR TITLE
Drop Interactions and Item placement

### DIFF
--- a/Assets/Content/WorldObjects/Entities/Humanoids/Ghost.prefab
+++ b/Assets/Content/WorldObjects/Entities/Humanoids/Ghost.prefab
@@ -159,6 +159,37 @@ Transform:
   m_Father: {fileID: 8948279595827497419}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2286802132471542845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7266407612763213600}
+  m_Layer: 11
+  m_Name: ViewPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7266407612763213600
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2286802132471542845}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3286557327597274053}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2744201510418370859
 GameObject:
   m_ObjectHideFlags: 0
@@ -262,6 +293,7 @@ Transform:
   - {fileID: 22761190788478486}
   - {fileID: 2594776435570904838}
   - {fileID: 4985541985952727430}
+  - {fileID: 7266407612763213600}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -381,6 +413,7 @@ MonoBehaviour:
   _componentIndexCache: 1
   _addedNetworkObject: {fileID: 3227132888119106738}
   _networkObjectCache: {fileID: 3227132888119106738}
+  ViewPoint: {fileID: 2286802132471542845}
   _mind: {fileID: 0}
 --- !u!114 &-824690604824484445
 MonoBehaviour:
@@ -438,6 +471,7 @@ MonoBehaviour:
   _lerpMultiplier: 2
   _rotationLerpMultiplier: 5
   _movementTarget: {fileID: 4985541985952727430}
+  TargetMovement: {x: 0, y: 0, z: 0}
 --- !u!1 &2858841725742773226
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
+++ b/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
@@ -5195,6 +5195,37 @@ SkinnedMeshRenderer:
     m_Center: {x: 0.039833866, y: 0.58982587, z: 0.08249249}
     m_Extent: {x: 0.021712415, y: 0.031627595, z: 0.014719635}
   m_DirtyAABB: 0
+--- !u!1 &5083048957016572449
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8293670469922695905}
+  m_Layer: 11
+  m_Name: ViewPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8293670469922695905
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5083048957016572449}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5927494552340417975}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5123606445737711681
 GameObject:
   m_ObjectHideFlags: 0
@@ -6633,6 +6664,7 @@ Transform:
   - {fileID: 3760363089904687261}
   - {fileID: 1870850359086752095}
   - {fileID: 282733360052666326}
+  - {fileID: 8293670469922695905}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -7069,6 +7101,7 @@ MonoBehaviour:
   _componentIndexCache: 11
   _addedNetworkObject: {fileID: 2930813178971533500}
   _networkObjectCache: {fileID: 2930813178971533500}
+  ViewPoint: {fileID: 5083048957016572449}
   _mind: {fileID: 0}
   Ghost: {fileID: 2798955099631966591, guid: 7bbb74a7ffc8cae44baa886de43c586b, type: 3}
 --- !u!114 &5164211669966765644

--- a/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
+++ b/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 5633133699961766715}
   - component: {fileID: 8626656600768578774}
   - component: {fileID: 1524200455027456264}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: ShoeRight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -190,7 +190,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 632582029456137362}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: 02 Organs
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -232,7 +232,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1726071883580151758}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_thumb2_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -264,7 +264,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1870850359086752095}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: 04 Clothing
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -305,7 +305,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4290133361346042276}
   - component: {fileID: 1462192947679949082}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanIntestineSmall
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -438,7 +438,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6924190181149792844}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_index3_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -469,7 +469,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 438709074631424037}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: toes_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -500,7 +500,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2403132919681660608}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_index1_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -533,7 +533,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8516086115442059685}
   - component: {fileID: 2501210953772138950}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanLungRight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -669,7 +669,7 @@ GameObject:
   - component: {fileID: 1326662398481621788}
   - component: {fileID: 6233962219268866637}
   - component: {fileID: 8149984355783769363}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: GloveLeft
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -848,7 +848,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7674647883911498251}
   - component: {fileID: 8737830854039402060}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanIntestineLarge
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -982,7 +982,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6760954323899670605}
   - component: {fileID: 8008076984776314350}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanLungLeft
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1116,7 +1116,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5019498308210494149}
   - component: {fileID: 8201768223750088614}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanAppendix
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1250,7 +1250,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5662633098722087954}
   - component: {fileID: 1471950008773350561}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: BodyColliderArm_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1295,7 +1295,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6307282637357716550}
   - component: {fileID: 2619973390650449415}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: chest
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1342,7 +1342,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8122397135647964431}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_ring2_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1374,7 +1374,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5194134162726775776}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_thumb1_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1406,7 +1406,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4856542740340688858}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Gloves
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1442,7 +1442,7 @@ GameObject:
   - component: {fileID: 8109082287784449202}
   - component: {fileID: 6911900315559804093}
   - component: {fileID: 706420925057494135}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: ShoeLeft
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1621,7 +1621,7 @@ GameObject:
   m_Component:
   - component: {fileID: 867479788888244943}
   - component: {fileID: 9161248745305005310}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Eyebrows
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1755,7 +1755,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6579065618054923413}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_index3_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1786,7 +1786,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1163351478397259458}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: toes_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1822,7 +1822,7 @@ GameObject:
   - component: {fileID: 941489488890892815}
   - component: {fileID: 150013760654436893}
   - component: {fileID: 1277523114241716566}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: spine
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1987,7 +1987,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3917704808688368387}
   - component: {fileID: 8434385556144608016}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Hair
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2122,7 +2122,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2935458371136628918}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_index2_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2159,7 +2159,7 @@ GameObject:
   - component: {fileID: 8993925622019568346}
   - component: {fileID: 1528961629195760479}
   - component: {fileID: 7517347392597976445}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: upper_arm_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2324,7 +2324,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 754194221811462458}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Shoes
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2360,7 +2360,7 @@ GameObject:
   - component: {fileID: 8339820939275692846}
   - component: {fileID: 7590913349156985469}
   - component: {fileID: 6053071042394239261}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Hat
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2540,7 +2540,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5988198273601441672}
   - component: {fileID: 5280620945916026454}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanBrain
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2675,7 +2675,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9136871507229749843}
   - component: {fileID: 5095774171039425627}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: UnderwearBottom
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2813,7 +2813,7 @@ GameObject:
   - component: {fileID: 3652358518435570056}
   - component: {fileID: 8785464256511967738}
   - component: {fileID: 1417451370988324021}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: lower_leg_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2978,7 +2978,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3622774868122681214}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: forearm_twist_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3010,7 +3010,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2561159763559213326}
   - component: {fileID: 6678433723894724694}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: hand_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3064,7 +3064,7 @@ GameObject:
   - component: {fileID: 9092931419345746643}
   - component: {fileID: 6974150074040530771}
   - component: {fileID: 8780544557873616261}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: forearm_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3231,7 +3231,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2166236694298732271}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_ring1_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3263,7 +3263,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1587600703330358405}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_thumb3_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3380,7 +3380,7 @@ GameObject:
   - component: {fileID: 1589596904512980411}
   - component: {fileID: 1527032890679831709}
   - component: {fileID: 5708275212759495835}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: EarWearRight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3561,7 +3561,7 @@ GameObject:
   - component: {fileID: 6858204281858372590}
   - component: {fileID: 8067289659534850981}
   - component: {fileID: 1421316668394371100}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: GloveRight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3740,7 +3740,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3978730619448687650}
   - component: {fileID: 57293475965881311}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Overwear
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3874,7 +3874,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8466479794276144567}
   - component: {fileID: 3661962909180790994}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Facial Hair
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4013,7 +4013,7 @@ GameObject:
   - component: {fileID: 705039401336309144}
   - component: {fileID: 6254882417085489341}
   - component: {fileID: 7944220910828946103}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: thigh_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4179,7 +4179,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3172643569644450408}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_middle2_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4211,7 +4211,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8637305464530177015}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Underwear
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4248,7 +4248,7 @@ GameObject:
   - component: {fileID: 5695998073342401492}
   - component: {fileID: 7534105608452820685}
   - component: {fileID: 4251283191739647136}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: EarWearLeft
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4427,7 +4427,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6994247970310072217}
   - component: {fileID: 5957969264668744151}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: BodyColliderArm_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4472,7 +4472,7 @@ GameObject:
   m_Component:
   - component: {fileID: 851636886438930025}
   - component: {fileID: 1490189817795883494}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: foot_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4517,7 +4517,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7984160872506313774}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_thumb3_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4549,7 +4549,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1208824478222506581}
   - component: {fileID: 7775550213077128715}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanEyeLeft
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4684,7 +4684,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4983652985280326632}
   - component: {fileID: 5694751844136662217}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: hand_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4867,7 +4867,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6831649574724549004}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_thumb1_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4904,7 +4904,7 @@ GameObject:
   - component: {fileID: 3565971262460538726}
   - component: {fileID: 4230347653723566291}
   - component: {fileID: 406215485719401368}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: thigh_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5238,7 +5238,7 @@ GameObject:
   - component: {fileID: 3775646212739373028}
   - component: {fileID: 8410791339138828931}
   - component: {fileID: 6299264923820670093}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Glasses
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5417,7 +5417,7 @@ GameObject:
   m_Component:
   - component: {fileID: 754592265810907282}
   - component: {fileID: 5524920077191417987}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanStomach
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5550,7 +5550,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 658316473173035848}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: IDHold
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5582,7 +5582,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3824984762086596364}
   - component: {fileID: 1503068000312408174}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: foot_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5627,7 +5627,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1156745993025133393}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_ring3_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5691,7 +5691,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6525079246486181739}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HeadWear
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5728,7 +5728,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6486374076238238496}
   - component: {fileID: 4166356956706542912}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanLiver
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5861,7 +5861,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3657004668181364307}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_thumb2_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5893,7 +5893,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2223645953135068443}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_index2_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5928,7 +5928,7 @@ GameObject:
   - component: {fileID: 8050946424626858951}
   - component: {fileID: 4138789318277530234}
   - component: {fileID: 5174669343730670165}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Jumpsuit
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6111,7 +6111,7 @@ GameObject:
   - component: {fileID: 637651137529271570}
   - component: {fileID: 4958391835158779518}
   - component: {fileID: 7141798988881879058}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: forearm_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6412,7 +6412,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6355804955344212816}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: forearm_twist_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6448,7 +6448,7 @@ GameObject:
   - component: {fileID: 5452039571083585463}
   - component: {fileID: 2208495717390157512}
   - component: {fileID: 8371257896879233468}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: upper_arm_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7257,7 +7257,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3619422700326762265}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_middle3_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7288,7 +7288,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7804972431541233091}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_middle2_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7354,7 +7354,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7567842513458124526}
   - component: {fileID: 3958753870908479741}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanHeart
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7487,7 +7487,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5115173101446557820}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_middle1_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7520,7 +7520,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8597866665138281237}
   - component: {fileID: 2901963028592262164}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: UnderwearTop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7658,7 +7658,7 @@ GameObject:
   - component: {fileID: 2871099191270620610}
   - component: {fileID: 30942941506442024}
   - component: {fileID: 4568435749376703628}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: head
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7823,7 +7823,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2071817197721020090}
   - component: {fileID: 7004274367669955809}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: BodyColliderLeg_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7867,7 +7867,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5336292931747755294}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_middle1_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7902,7 +7902,7 @@ GameObject:
   - component: {fileID: 8057421560981843689}
   - component: {fileID: 2091115627957921416}
   - component: {fileID: 113844057537055301}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Mask
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8123,7 +8123,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1577642226099443706}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_ring1_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8155,7 +8155,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6189060155573503914}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_ring2_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8192,7 +8192,7 @@ GameObject:
   - component: {fileID: 6724913370264790015}
   - component: {fileID: 6373547393611225806}
   - component: {fileID: 7723213180831109276}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: shoulder_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8357,7 +8357,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8625957104459741184}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_middle3_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8389,7 +8389,7 @@ GameObject:
   m_Component:
   - component: {fileID: 231479877643016212}
   - component: {fileID: 6474779925468168836}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Neck
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8525,7 +8525,7 @@ GameObject:
   - component: {fileID: 4089904536153596817}
   - component: {fileID: 3532639061135859339}
   - component: {fileID: 646566339906030138}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Waist
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8708,7 +8708,7 @@ GameObject:
   - component: {fileID: 767656094765434278}
   - component: {fileID: 8579559020481729139}
   - component: {fileID: 8620817205179831689}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: lower_leg_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8873,7 +8873,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5539079144479387355}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: neck
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8909,7 +8909,7 @@ GameObject:
   - component: {fileID: 2503432167856152966}
   - component: {fileID: 1792255455613643041}
   - component: {fileID: 283003928918962364}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: hips
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9031,7 +9031,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4478298089421918591}
   - component: {fileID: 2380861371685847287}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Socks
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9164,7 +9164,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8356004225170572391}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Armature
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9196,7 +9196,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3918743488675097537}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_ring3_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9362,7 +9362,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8718513553022905464}
   - component: {fileID: 1551437058160495390}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: HumanEyeRight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9496,7 +9496,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1342008326084027676}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: hold.l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9530,7 +9530,7 @@ GameObject:
   - component: {fileID: 9015990342576147118}
   - component: {fileID: 4684017524585288931}
   - component: {fileID: 1621818506458342007}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Back
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9709,7 +9709,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3760363089904687261}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: 03 Hair
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9743,7 +9743,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6653541696833174003}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: hold.r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9775,7 +9775,7 @@ GameObject:
   m_Component:
   - component: {fileID: 82091401320169561}
   - component: {fileID: 3233858438047360200}
-  m_Layer: 12
+  m_Layer: 11
   m_Name: BodyColliderLeg_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9819,7 +9819,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5332390800146613625}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: c_index1_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9856,7 +9856,7 @@ GameObject:
   - component: {fileID: 667784239286808157}
   - component: {fileID: 8936448688867116204}
   - component: {fileID: 7216301373266220740}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: shoulder_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Content/WorldObjects/Entities/Silicon/EngineeringBorg/EngineeringBorg.prefab
+++ b/Assets/Content/WorldObjects/Entities/Silicon/EngineeringBorg/EngineeringBorg.prefab
@@ -1325,6 +1325,7 @@ Transform:
   m_Children:
   - {fileID: 4301167961274605312}
   - {fileID: 6852574109517490658}
+  - {fileID: 1018753449391517355}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1359,7 +1360,7 @@ MonoBehaviour:
   _initializeOrder: 0
   _defaultDespawnType: 0
   NetworkObserver: {fileID: 0}
-  <PrefabId>k__BackingField: 85
+  <PrefabId>k__BackingField: 91
   <SpawnableCollectionId>k__BackingField: 0
   _scenePathHash: 0
   <SceneId>k__BackingField: 0
@@ -1519,6 +1520,7 @@ MonoBehaviour:
   _componentIndexCache: 3
   _addedNetworkObject: {fileID: 1019513474262773944}
   _networkObjectCache: {fileID: 1019513474262773944}
+  ViewPoint: {fileID: 8997088538082488408}
   _mind: {fileID: 0}
 --- !u!114 &6718533481539137195
 MonoBehaviour:
@@ -2418,6 +2420,37 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8997088538082488408
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1018753449391517355}
+  m_Layer: 11
+  m_Name: ViewPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1018753449391517355
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8997088538082488408}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6719813189308296762}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9132705238130881436
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SS3D/Interactions/InteractionEvent.cs
+++ b/Assets/Scripts/SS3D/Interactions/InteractionEvent.cs
@@ -17,12 +17,17 @@ namespace SS3D.Interactions
         /// The point at which the interaction took place
         /// </summary>
         public Vector3 Point { get; }
+        /// <summary>
+        /// The normal angle at which the interacted surface is facing
+        /// </summary>
+        public Vector3 Normal { get; }
 
-        public InteractionEvent(IInteractionSource source, IInteractionTarget target, Vector3 point = new())
+        public InteractionEvent(IInteractionSource source, IInteractionTarget target, Vector3 point = new(), Vector3 normal = new())
         {
             Source = source;
             Target = target;
             Point = point;
+            Normal = normal;
         }
     }
 }

--- a/Assets/Scripts/SS3D/Systems/Entities/Entity.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/Entity.cs
@@ -18,6 +18,9 @@ namespace SS3D.Systems.Entities
     [Serializable]
     public class Entity : NetworkActor
     {
+        /// <summary>
+        /// A reference point to use for this Entities perspective
+        /// </summary>
         public GameObject ViewPoint;
         public event Action<Mind> OnMindChanged;
 

--- a/Assets/Scripts/SS3D/Systems/Entities/Entity.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/Entity.cs
@@ -18,6 +18,7 @@ namespace SS3D.Systems.Entities
     [Serializable]
     public class Entity : NetworkActor
     {
+        public GameObject ViewPoint;
         public event Action<Mind> OnMindChanged;
 
         [SerializeField]

--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -277,15 +277,17 @@ namespace SS3D.Systems.Interactions
 
             // Raycast to find target game object
             Vector3 point = Vector3.zero;
+            Vector3 normal = Vector3.zero;
             bool raycast = Physics.Raycast(ray, out RaycastHit hit, float.PositiveInfinity, _selectionMask, QueryTriggerInteraction.Ignore);
             if (raycast)
             {
                 point = hit.point;
+                normal = hit.normal;
                 GameObject target = hit.transform.gameObject;
                 targets = GetTargetsFromGameObject(source, target);
             }
 
-            interactionEvent = new InteractionEvent(source, targets[0], point);
+            interactionEvent = new InteractionEvent(source, targets[0], point, normal);
 
             return GetInteractionsFromTargets(source, targets, interactionEvent);
         }

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
@@ -130,7 +130,7 @@ namespace SS3D.Systems.Inventory.Containers
             ItemInHand.GiveOwnership(null);
             Item item = ItemInHand;
             item.Container.RemoveItem(item);
-            ItemUtility.Place(item, position, rotation, transform);
+            ItemUtility.Place(item, position, rotation);
         }
 
         /// <summary>

--- a/Assets/Scripts/SS3D/Systems/Inventory/Interactions/DropInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Interactions/DropInteraction.cs
@@ -2,6 +2,7 @@
 using SS3D.Data.Generated;
 using SS3D.Interactions;
 using SS3D.Interactions.Extensions;
+using SS3D.Systems.Entities;
 using SS3D.Systems.Inventory.Containers;
 using UnityEngine;
 
@@ -30,6 +31,31 @@ namespace SS3D.Systems.Inventory.Interactions
         {
             // if the interaction source's parent is not a hand we return false
             if (interactionEvent.Source.GetRootSource() is not Hand)
+            {
+                return false;
+            }
+
+            // confirm that there is an entity doing this interaction
+            Entity entity = interactionEvent.Source.GetComponentInParent<Entity>();
+            if (!entity)
+            {
+                return false;
+            }
+
+            // confirm the entities ViewPoint can see the drop point
+            Vector3 direction = (interactionEvent.Point - entity.ViewPoint.transform.position).normalized;
+            bool raycast = Physics.Raycast(entity.ViewPoint.transform.position, direction, out RaycastHit hit);
+            if (!raycast)
+            {
+                return false;
+            }
+
+            //TODO: remove
+            Debug.DrawLine(entity.ViewPoint.transform.position, hit.point, Color.red, 10);
+
+            // check the angle of the surface hit
+            float angle = Vector3.Angle(hit.normal, Vector3.up);
+            if (angle > _maxSurfaceAngle)
             {
                 return false;
             }

--- a/Assets/Scripts/SS3D/Systems/Inventory/Interactions/DropInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Interactions/DropInteraction.cs
@@ -11,6 +11,11 @@ namespace SS3D.Systems.Inventory.Interactions
     [Serializable]
     public class DropInteraction : Interaction
     {
+        /// <summary>
+        /// The maximum angle of surface the item will allow being dropped on
+        /// </summary>
+        private float _maxSurfaceAngle = 10;
+
         public override string GetName(InteractionEvent interactionEvent)
         {
             return "Drop";
@@ -35,11 +40,21 @@ namespace SS3D.Systems.Inventory.Interactions
 
         public override bool Start(InteractionEvent interactionEvent, InteractionReference reference)
         {
+            // we consider if the surface we are placing the item on is flat
+            float angle = Vector3.Angle(interactionEvent.Normal, Vector3.up);  
+            if (angle > _maxSurfaceAngle)
+            {
+                return false;
+            }
+
             // we check if the source of the interaction is a hand
             if (interactionEvent.Source.GetRootSource() is Hand hand)
             {
+                // we rotate the item based on the facing direction of the hand
+                Quaternion rotation = Quaternion.Euler(0, hand.ItemInHand.transform.eulerAngles.y, 0);
+
                 // we place the item in the hand in the point we clicked
-                hand?.PlaceHeldItemOutOfHand(interactionEvent.Point, hand.ItemInHand.transform.rotation);
+                hand?.PlaceHeldItemOutOfHand(interactionEvent.Point, rotation);
             }
 
             return false;

--- a/Assets/Scripts/SS3D/Systems/Inventory/Interactions/DropInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Interactions/DropInteraction.cs
@@ -18,7 +18,7 @@ namespace SS3D.Systems.Inventory.Interactions
         private float _maxSurfaceAngle = 10;
 
         /// <summary>
-        /// Only raycast the default layer
+        /// Only raycast the default layer for seeing if we are vision blocked
         /// </summary>
         private LayerMask _defaultMask = LayerMask.GetMask("Default");
 
@@ -61,9 +61,6 @@ namespace SS3D.Systems.Inventory.Interactions
                 return false;
             }
 
-            //TODO: remove
-            Debug.DrawLine(entity.ViewPoint.transform.position, hit.point, Color.red, 10);
-
             // check the angle of the surface hit
             float angle = Vector3.Angle(hit.normal, Vector3.up);
             if (angle > _maxSurfaceAngle)
@@ -94,7 +91,7 @@ namespace SS3D.Systems.Inventory.Interactions
             // we check if the source of the interaction is a hand
             if (interactionEvent.Source.GetRootSource() is Hand hand)
             {
-                // we rotate the item based on the facing direction of the hand
+                // we rotate the item based on the facing direction of the entity
                 Quaternion rotation = Quaternion.Euler(0, entity.transform.eulerAngles.y, 0);
 
                 // we place the item in the hand in the point we clicked

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/ItemUtility.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/ItemUtility.cs
@@ -20,7 +20,7 @@ namespace SS3D.Systems.Inventory.Items
             float distance = Vector3.Distance(item.transform.position, position);
             position = distance > 0 ? position + new Vector3(0, itemSize * 0.5f, 0) : position;
 
-            if (distance > 0)
+            if (lookTarget && distance > 0)
             {
                 item.transform.LookAt(lookTarget);
             }


### PR DESCRIPTION
# Summary
- Added raycast checks to item drop interactions, so items cannot be placed;
1. Outside of the ViewPoint of an Entity.
2. On surfaces with a normal angle > 10.

The reason for the surface normal angle check is previously you could place any item against a wall or in any small place you could click, and the item would react with physics bouncing off the object it was spawned into.

- Set rotation of placed item to be facing direction of entity.
Items now seem to place neatly on the floor or on tables, previously items would LookAt the hand of player entity and also have the rotation of the hand when placed.

- Added ViewPoint to Entity, to use as position reference to check if an Entity has line of sight with a position.

#### PR checklist
- [x] The game builds properly without errors.
- [x] No unrelated changes are present.
- [x] No "trash" files are committed.
- [x] Relevant code is documented.

# Testing

Can be tested by attempting to place item 

#### Networking checklist

- [x] Works from host in host mode.

# Changes

- Modified existing Entity prefabs (Human, Ghost, EngineeringBorg) to have a child ViewPoint Gameobject.