### PR TITLE
Reduce bandwidth usage

### DIFF
--- a/Assets/Content/Addressables/AssetGroups/Scenes.asset
+++ b/Assets/Content/Addressables/AssetGroups/Scenes.asset
@@ -17,18 +17,6 @@ MonoBehaviour:
     m_SerializedData: []
   m_GUID: e18ea8489b90bd7488de5c242bac11c6
   m_SerializeEntries:
-  - m_GUID: 61687ab4465bb6e4d8164057bedc63db
-    m_Address: Assets/Content/Scenes/Intro.unity
-    m_ReadOnly: 0
-    m_SerializedLabels: []
-  - m_GUID: c7d05c35cd4853643a09333ecceff608
-    m_Address: Assets/Content/Scenes/Game.unity
-    m_ReadOnly: 0
-    m_SerializedLabels: []
-  - m_GUID: 9fc0d4010bbf28b4594072e72b8655ab
-    m_Address: Assets/Content/Scenes/Boot.unity
-    m_ReadOnly: 0
-    m_SerializedLabels: []
   - m_GUID: a7a0fb29f301d364a822be64003a90cb
     m_Address: Assets/Content/Scenes/Empty.unity
     m_ReadOnly: 0

--- a/Assets/Content/Addressables/AssetGroups/Scenes.asset
+++ b/Assets/Content/Addressables/AssetGroups/Scenes.asset
@@ -17,6 +17,18 @@ MonoBehaviour:
     m_SerializedData: []
   m_GUID: e18ea8489b90bd7488de5c242bac11c6
   m_SerializeEntries:
+  - m_GUID: 61687ab4465bb6e4d8164057bedc63db
+    m_Address: Assets/Content/Scenes/Intro.unity
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+  - m_GUID: c7d05c35cd4853643a09333ecceff608
+    m_Address: Assets/Content/Scenes/Game.unity
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+  - m_GUID: 9fc0d4010bbf28b4594072e72b8655ab
+    m_Address: Assets/Content/Scenes/Boot.unity
+    m_ReadOnly: 0
+    m_SerializedLabels: []
   - m_GUID: a7a0fb29f301d364a822be64003a90cb
     m_Address: Assets/Content/Scenes/Empty.unity
     m_ReadOnly: 0

--- a/Assets/Content/Scenes/Boot.unity
+++ b/Assets/Content/Scenes/Boot.unity
@@ -349,7 +349,7 @@ MonoBehaviour:
   _timingType: 0
   _allowTickDropping: 0
   _maximumFrameTicks: 3
-  _tickRate: 120
+  _tickRate: 30
   _pingInterval: 1
   _physicsMode: 0
 --- !u!114 &340427418

--- a/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
+++ b/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
@@ -1953,14 +1953,14 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -1972,7 +1972,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -2291,8 +2291,8 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
@@ -2310,7 +2310,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -2945,14 +2945,14 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -2964,7 +2964,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -3198,14 +3198,14 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -3217,7 +3217,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -4146,14 +4146,14 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -4165,7 +4165,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -5037,14 +5037,14 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -5056,7 +5056,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -6245,8 +6245,8 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
@@ -6264,7 +6264,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -6580,14 +6580,14 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -6599,7 +6599,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -7790,8 +7790,8 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
@@ -7809,7 +7809,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -8325,8 +8325,8 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
@@ -8344,7 +8344,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -8841,14 +8841,14 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -8860,7 +8860,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -8998,14 +8998,14 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -9017,7 +9017,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0
@@ -9989,14 +9989,14 @@ MonoBehaviour:
     Position: 1
     Rotation: 1
     Scale: 0
-  _interpolation: 5
-  _extrapolation: 2
+  _interpolation: 1
+  _extrapolation: 0
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -10008,7 +10008,7 @@ MonoBehaviour:
     X: 0
     Y: 0
     Z: 0
-  _synchronizeScale: 1
+  _synchronizeScale: 0
   _scaleSnapping:
     X: 0
     Y: 0

--- a/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
+++ b/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
@@ -7172,6 +7172,7 @@ MonoBehaviour:
   _armatureRoot: {fileID: 8356004225170572391}
   _standUpFaceUpClip: {fileID: 7400000, guid: 819462e6a707a0147a647482f5d2a038, type: 2}
   _standUpFaceDownClip: {fileID: 7400000, guid: 3b44d4082074d7f4cb19f2036c9c9a01, type: 2}
+  _ragdollPartSyncInterval: 10
 --- !u!114 &7722998452492527915
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
+++ b/Assets/Content/WorldObjects/Entities/Humanoids/Human/Human.prefab
@@ -2298,7 +2298,7 @@ MonoBehaviour:
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -6252,7 +6252,7 @@ MonoBehaviour:
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -7796,7 +7796,7 @@ MonoBehaviour:
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -8331,7 +8331,7 @@ MonoBehaviour:
   _scaleThreshold: 1
   _clientAuthoritative: 1
   _sendToOwner: 1
-  _enableNetworkLod: 1
+  _enableNetworkLod: 0
   _interval: 1
   _synchronizePosition: 1
   _positionSnapping:
@@ -11357,6 +11357,7 @@ PrefabInstance:
     - {fileID: -5519180950159476568, guid: 7f5954f009d06b2439ca637b43920440, type: 3}
     - {fileID: 5300969123225040956, guid: 7f5954f009d06b2439ca637b43920440, type: 3}
     - {fileID: 6224308330480900340, guid: 7f5954f009d06b2439ca637b43920440, type: 3}
+    - {fileID: 427023688766138603, guid: 7f5954f009d06b2439ca637b43920440, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 7f5954f009d06b2439ca637b43920440, type: 3}
 --- !u!114 &2124807441123396136 stripped
 MonoBehaviour:
@@ -14416,6 +14417,7 @@ PrefabInstance:
     - {fileID: 3804509484627004799, guid: 35dfc7c3f708a5b48a206b4a44e7ab49, type: 3}
     - {fileID: 7380375041138074868, guid: 35dfc7c3f708a5b48a206b4a44e7ab49, type: 3}
     - {fileID: 6209280579436442931, guid: 35dfc7c3f708a5b48a206b4a44e7ab49, type: 3}
+    - {fileID: 3325623441715482320, guid: 35dfc7c3f708a5b48a206b4a44e7ab49, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 35dfc7c3f708a5b48a206b4a44e7ab49, type: 3}
 --- !u!114 &2032574427462071784 stripped
 MonoBehaviour:

--- a/Assets/Scripts/SS3D/Systems/Entities/Humanoid/Ragdoll.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/Humanoid/Ragdoll.cs
@@ -1,4 +1,6 @@
 ﻿using FishNet.Component.Animating;
+using FishNet.Component.Transforming;
+using FishNet.Connection;
 using FishNet.Object;
 using FishNet.Object.Synchronizing;
 using System;
@@ -67,6 +69,9 @@ namespace SS3D.Systems.Entities.Humanoid
         [SerializeField]
         private AnimationClip _standUpFaceDownClip;
 
+        [SerializeField]
+        private byte _ragdollPartSyncInterval;
+
         private void OnSyncKnockdown(bool prev, bool next, bool asServer)
 		{
 			if (prev == next) return;
@@ -102,7 +107,18 @@ namespace SS3D.Systems.Entities.Humanoid
             }
             // All rigid bodies are kinematic at start, only the owner should be able to change that afterwards.
 			ToggleKinematic(true);
-		}
+            ToggleSyncRagdoll(false);
+        }
+
+        public override void OnOwnershipClient(NetworkConnection prevOwner)
+        {
+            base.OnOwnershipClient(prevOwner);
+
+            foreach (Transform part in _ragdollParts)
+            {
+                part.GetComponent<NetworkTransform>().SetInterval(_ragdollPartSyncInterval);
+            }
+        }
 
         private void OnDisable()
         {
@@ -166,6 +182,7 @@ namespace SS3D.Systems.Entities.Humanoid
         {
             _currentState = RagdollState.Ragdoll;
             Vector3 movement = _humanoidLivingController.TargetMovement * 3;
+            ToggleSyncRagdoll(false);
             ToggleController(false);
             ToggleAnimator(false);
             if (!IsOwner && Owner.ClientId != -1)
@@ -357,6 +374,27 @@ namespace SS3D.Systems.Entities.Humanoid
             if (_networkAnimator != null)
             {
                 _networkAnimator.enabled = enable;
+            }
+        }
+
+        /// <summary>
+        /// Toggle the network transform syncing of the ragdoll parts, to save up on those sweet bytes.
+        /// </summary>
+        /// <param name="isActive"> true if the network transform of the ragdoll parts should sync</param>
+        /// <returns></returns>
+        private void ToggleSyncRagdoll(bool isActive)
+        {
+            // Only the owner should set the network transform, fishnet requirement,
+            // and then fishnet handles sending it to observers.
+            if (!IsOwner)
+            {
+                return;
+            }
+
+            foreach (Transform part in _ragdollParts)
+            {
+                part.GetComponent<NetworkTransform>().SetSynchronizePosition(isActive);
+                part.GetComponent<NetworkTransform>().SetSynchronizeRotation(isActive);
             }
         }
     }

--- a/Assets/Scripts/SS3D/Systems/Entities/Humanoid/Ragdoll.cs
+++ b/Assets/Scripts/SS3D/Systems/Entities/Humanoid/Ragdoll.cs
@@ -114,6 +114,7 @@ namespace SS3D.Systems.Entities.Humanoid
         {
             base.OnOwnershipClient(prevOwner);
 
+            // Set interval need to be called by owner. This allows fast setting
             foreach (Transform part in _ragdollParts)
             {
                 part.GetComponent<NetworkTransform>().SetInterval(_ragdollPartSyncInterval);
@@ -182,9 +183,10 @@ namespace SS3D.Systems.Entities.Humanoid
         {
             _currentState = RagdollState.Ragdoll;
             Vector3 movement = _humanoidLivingController.TargetMovement * 3;
-            ToggleSyncRagdoll(false);
+            ToggleSyncRagdoll(true);
             ToggleController(false);
             ToggleAnimator(false);
+
             if (!IsOwner && Owner.ClientId != -1)
                 return;
             
@@ -236,6 +238,8 @@ namespace SS3D.Systems.Entities.Humanoid
         {
             _currentState = RagdollState.BonesReset;
             _elapsedResetBonesTime = 0;
+
+            ToggleSyncRagdoll(false);
             
             // Only the owner handles ragdoll's physics
             if (!IsOwner) return;
@@ -382,15 +386,9 @@ namespace SS3D.Systems.Entities.Humanoid
         /// </summary>
         /// <param name="isActive"> true if the network transform of the ragdoll parts should sync</param>
         /// <returns></returns>
+        
         private void ToggleSyncRagdoll(bool isActive)
         {
-            // Only the owner should set the network transform, fishnet requirement,
-            // and then fishnet handles sending it to observers.
-            if (!IsOwner)
-            {
-                return;
-            }
-
             foreach (Transform part in _ragdollParts)
             {
                 part.GetComponent<NetworkTransform>().SetSynchronizePosition(isActive);

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/AttachedContainer.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/AttachedContainer.cs
@@ -1,4 +1,5 @@
-﻿using SS3D.Core.Behaviours;
+﻿using FishNet.Component.Transforming;
+using SS3D.Core.Behaviours;
 using SS3D.Systems.Inventory.UI;
 using System.Collections.Generic;
 using System;
@@ -269,8 +270,16 @@ namespace SS3D.Systems.Inventory.Containers
                     throw new ArgumentOutOfRangeException(nameof(op), op, null);
             }
 
-            if(changeType == ContainerChangeType.Remove)
+            if (changeType == ContainerChangeType.Add && newItem.Item.TryGetComponent(out NetworkTransform networkTransform))
             {
+                 networkTransform.SetSynchronizePosition(false);
+                 networkTransform.SetSynchronizeRotation(false);
+            }
+
+            if (changeType == ContainerChangeType.Remove && oldItem.Item.TryGetComponent(out NetworkTransform networkTransform2))
+            {
+                networkTransform2.SetSynchronizePosition(true);
+                networkTransform2.SetSynchronizeRotation(true);
                 //Punpun.Information(this, "from container " + this.gameObject + ", removing item" + oldItem.Item?.name);
             }
 


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary

Roughly reduce bandwidth consumption by a factor 6, from an average by client of 30 KB/s sent to server to 5 KB/s sent to server.

Current bandwidth usage is terrible for two reasons : 
- Server tick rate is way too high for this kind of game (120/s)
- We sync way too much transforms of stuff that do not need to be synced.

Solution : 
- cut tick rate to 30/s (imo enough for this kind of game, we're not a competitive fps).
- do not sync transforms that do not need syncing : that includes stuff in containers as they can rely solely on the networked container transform, and that include ragdolls not ragdolling.

This PR does not deal with reducing the impact of ragdolling, which is going to be an issue later. I got a few ideas but that require a PR on its own and I rather focus on other things for now.

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [x] Relevant code is documented.
<!-- optional, if doc is needed -->
- [x] Update the related GitBook document, or create a new one if needed.


# Testing

- Open one client, one host
- Move client around, taking stuff
- See the average bandwidth usage and compare to the actual one


