### PR TITLE
Install fast script reload

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.coimbrastudios.core": "11.0.5",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
+    "com.handzlikchris.fastscriptreload": "https://github.com/handzlikchris/FastScriptReload.git?path=Assets",
     "com.johannesmp.unityscenereference": "1.1.1",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.collab-proxy": "1.17.7",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -27,6 +27,13 @@
       "dependencies": {},
       "hash": "9e2163616b9c527fa9461544e2bcc5f93fd12d83"
     },
+    "com.handzlikchris.fastscriptreload": {
+      "version": "https://github.com/handzlikchris/FastScriptReload.git?path=Assets",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "c33f8e2b466ce2eeb176e3fc5ca4f6c15bb9f379"
+    },
     "com.johannesmp.unityscenereference": {
       "version": "1.1.1",
       "depth": 0,
@@ -45,11 +52,11 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.scriptablebuildpipeline": "1.19.6",
         "com.unity.modules.assetbundle": "1.0.0",
-        "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.scriptablebuildpipeline": "1.19.6",
         "com.unity.modules.unitywebrequestassetbundle": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -173,9 +180,9 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.androidjni": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.0.2",
-        "com.unity.modules.androidjni": "1.0.0"
+        "com.unity.modules.unitywebrequest": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary

[Fast script Reload](https://github.com/handzlikchris/FastScriptReload) is a Unity Package allowing one to make code changes in play mode, without recompiling the whole domain. This allow effiencient play test. Even better, Parrelsync works with it, changes done in playmode are immediatly transferred to the other Unity editor instance.

I tried to push it further with an observerRpc but as expected it does not work with code involving networking. However, if code is purely client or server side (no rpcs or syncvars), then it should work well.

#### PR checklist


- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [x] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

<!-- optional. -->
# Pictures/Videos)

https://github.com/user-attachments/assets/12b9abc4-5d18-4df8-ad46-41e8eacfb308



# Changes

- added FSR package

