### PR TITLE
Logging bug fixes and added a flag for non-json file sinks

### DIFF
--- a/Assets/Content/Addressables/AddressableAssetSettings.asset
+++ b/Assets/Content/Addressables/AddressableAssetSettings.asset
@@ -63,6 +63,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 46b9ed05a1b2cc7489177bea7080db40, type: 2}
   - {fileID: 11400000, guid: 1dd6dd18af88a7f48a541271e8169fbf, type: 2}
   - {fileID: 11400000, guid: 1af7b985abde02a47bd3e464bb8f8433, type: 2}
+  - {fileID: 11400000, guid: 2caa591261a883b4183d04829ce705fd, type: 2}
   m_BuildSettings:
     m_CompileScriptsInVirtualMode: 0
     m_CleanupStreamingAssetsAfterBuilds: 1

--- a/Assets/Scripts/SS3D/Logging/Log.cs
+++ b/Assets/Scripts/SS3D/Logging/Log.cs
@@ -1,198 +1,139 @@
 ﻿using System;
 using System.Linq;
-using Serilog;
 using Serilog.Core;
 using Serilog.Events;
 
 namespace SS3D.Logging
 {
     /// <summary>
-    /// Wrapper class for Serilog Logger. Makes mandatory adding a sender object.
-    /// Makes mandatory adding additionnal log context with the Logs enum.
+    /// Wrapper class for Serilog Logger.
+    /// Makes mandatory adding a sender object.
+    /// Makes mandatory adding additional log context with the Logs enum.
     /// Takes care of adding infoLog and sender properties to Serilog Logger.
     /// </summary>
     public static class Log
-    {
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
-        /// </summary>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Punpun.Verbose(this, "Starting up at {StartedAt} for client {ClientId}.", Logs.ServerOnly, DateTime.Now, connection.ClientId);
-        /// Punpun.Verbose(this, "Player set up.");
-        /// </example>
-        public static void Verbose(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[]{infoLog}.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Verbose("{InfoLog}" + messageTemplate, properties);
-        }
+	{
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Verbose(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, null, messageTemplate, LogEventLevel.Verbose, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
-        /// </summary>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Punpun.Verbose(this, "Starting up at {StartedAt} for client {ClientId}.", Logs.ServerOnly, DateTime.Now, connection.ClientId);
-        /// Punpun.Verbose(this, "Player set up.");
-        /// </example>
-        public static void Verbose(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Verbose(exception,"{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Verbose(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, exception, messageTemplate, LogEventLevel.Verbose, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
-        /// </summary>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Punpun.Debug(this, "Starting up at {StartedAt} for client {ClientId}.", Logs.ServerOnly, DateTime.Now, connection.ClientId);
-        /// Punpun.Debug(this, "Player set up.");
-        /// </example>
-        public static void Debug(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Debug("{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Debug(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, null, messageTemplate, LogEventLevel.Debug, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
-        /// </summary>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Log.Debug(ex, "Swallowing a mundane exception.");
-        /// </example>
-        public static void Debug(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Debug(exception, "{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Debug(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, exception, messageTemplate, LogEventLevel.Debug, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
-        /// </summary>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Punpun.Verbose(this, "Starting up at {StartedAt} for client {ClientId}.", Logs.ServerOnly, DateTime.Now, connection.ClientId);
-        /// Punpun.Verbose(this, "Player set up.");
-        /// </example>
-        public static void Information(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Information("{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Information(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, null, messageTemplate, LogEventLevel.Information, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
-        /// </summary>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Log.Information(this, new NullException(),  "Failed to load command line arguments in {TimeMs}.", Logs.Generic, sw.ElapsedMilliseconds);
-        /// </example>
-        public static void Information(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Debug(exception, "{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Information(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, exception, messageTemplate, LogEventLevel.Information, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
-        /// </summary>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Punpun.Verbose(this, "Starting up at {StartedAt} for client {ClientId}.", Logs.ServerOnly, DateTime.Now, connection.ClientId);
-        /// Punpun.Verbose(this, "Player set up.");
-        /// </example>
-        public static void Warning(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Warning("{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Warning(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, null, messageTemplate, LogEventLevel.Warning, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
-        /// </summary>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Log.Warning(this, new NullException(),  "Failed to load command line arguments in {TimeMs}.", Logs.Generic, sw.ElapsedMilliseconds);
-        /// </example>
-        public static void Warning(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Debug(exception, "{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Warning(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, exception, messageTemplate, LogEventLevel.Warning, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
-        /// </summary>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Punpun.Verbose(this, "Starting up failed at {StartedAt} for client {ClientId}.", Logs.ServerOnly, DateTime.Now, connection.ClientId);
-        /// Punpun.Verbose(this, "Player set up.");
-        /// </example>
-        public static void Error(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Error("{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Error(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, null, messageTemplate, LogEventLevel.Error, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
-        /// </summary>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Log.Error(this, new NullException(),  "Failed to load command line arguments in {TimeMs}.", Logs.Generic, sw.ElapsedMilliseconds);
-        /// </example>
-        public static void Error(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Error(exception, "{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Error(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, exception, messageTemplate, LogEventLevel.Error, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
-        /// </summary>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Punpun.Verbose(this, "Starting up failed at {StartedAt} for client {ClientId}.", Logs.ServerOnly, DateTime.Now, connection.ClientId);
-        /// Punpun.Verbose(this, "Player set up.");
-        /// </example>
-        public static void Fatal(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Fatal("{InfoLog}" + messageTemplate, properties);
-        }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Fatal(object sender, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, null, messageTemplate, LogEventLevel.Fatal, infoLog, propertyValues);
 
-        /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
-        /// </summary>
-        /// <param name="exception">Exception related to the event.</param>
-        /// <param name="messageTemplate">Message template describing the event.</param>
-        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
-        /// <example>
-        /// Log.Fatal(this, new NullException(),  "Failed to load command line arguments in {TimeMs}.", Logs.Generic, sw.ElapsedMilliseconds);
-        /// </example>
-        public static void Fatal(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues)
-        {
-            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
-            Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name).Fatal(exception, "{InfoLog}" + messageTemplate, properties);
-        }
-        
-    }
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public static void Fatal(object sender, Exception exception, string messageTemplate, Logs infoLog = Logs.Generic, params object[] propertyValues) => InnerLog(sender, exception, messageTemplate, LogEventLevel.Fatal, infoLog, propertyValues);
+
+		private static void InnerLog(object sender, Exception exception, string messageTemplate, LogEventLevel level, Logs infoLog = Logs.Generic, params object[] propertyValues)
+		{
+			var properties = new object[] { infoLog }.Concat(propertyValues);
+
+			var logger = Serilog.Log.Logger;
+			if (sender != null)
+			{
+				logger = Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name);
+            }
+
+			switch (level)
+			{
+				case LogEventLevel.Verbose:
+					logger.Verbose(exception, messageTemplate, properties);
+					break;
+				case LogEventLevel.Debug:
+					logger.Debug(exception, messageTemplate, properties);
+					break;
+				case LogEventLevel.Information:
+					logger.Information(exception, messageTemplate, properties);
+					break;
+				case LogEventLevel.Warning:
+					logger.Warning(exception, messageTemplate, properties);
+					break;
+				case LogEventLevel.Error:
+					logger.Error(exception, messageTemplate, properties);
+					break;
+				case LogEventLevel.Fatal:
+					logger.Fatal(exception, messageTemplate, properties);
+					break;
+			}
+		}
+	}
 }

--- a/Assets/Scripts/SS3D/Logging/Log.cs
+++ b/Assets/Scripts/SS3D/Logging/Log.cs
@@ -106,7 +106,7 @@ namespace SS3D.Logging
 
 		private static void InnerLog(object sender, Exception exception, string messageTemplate, LogEventLevel level, Logs infoLog = Logs.Generic, params object[] propertyValues)
 		{
-            IEnumerable<object> properties = new object[] { infoLog }.Concat(propertyValues);
+            object[] properties = new object[] { infoLog }.Concat(propertyValues).ToArray();
             Serilog.ILogger logger = Serilog.Log.Logger;
 
 			if (sender != null)
@@ -117,22 +117,22 @@ namespace SS3D.Logging
 			switch (level)
 			{
 				case LogEventLevel.Verbose:
-					logger.Verbose(exception, messageTemplate, properties);
+					logger.Verbose(exception, "{InfoLog}" + messageTemplate, properties);
 					break;
 				case LogEventLevel.Debug:
-					logger.Debug(exception, messageTemplate, properties);
+					logger.Debug(exception, "{InfoLog}" + messageTemplate, properties);
 					break;
 				case LogEventLevel.Information:
-					logger.Information(exception, messageTemplate, properties);
+					logger.Information(exception, "{InfoLog}" + messageTemplate, properties);
 					break;
 				case LogEventLevel.Warning:
-					logger.Warning(exception, messageTemplate, properties);
+					logger.Warning(exception, "{InfoLog}" + messageTemplate, properties);
 					break;
 				case LogEventLevel.Error:
-					logger.Error(exception, messageTemplate, properties);
+					logger.Error(exception, "{InfoLog}" + messageTemplate, properties);
 					break;
 				case LogEventLevel.Fatal:
-					logger.Fatal(exception, messageTemplate, properties);
+					logger.Fatal(exception, "{InfoLog}" + messageTemplate, properties);
 					break;
 			}
 		}

--- a/Assets/Scripts/SS3D/Logging/Log.cs
+++ b/Assets/Scripts/SS3D/Logging/Log.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Serilog.Core;
 using Serilog.Events;
@@ -105,9 +106,9 @@ namespace SS3D.Logging
 
 		private static void InnerLog(object sender, Exception exception, string messageTemplate, LogEventLevel level, Logs infoLog = Logs.Generic, params object[] propertyValues)
 		{
-			var properties = new object[] { infoLog }.Concat(propertyValues);
+            IEnumerable<object> properties = new object[] { infoLog }.Concat(propertyValues);
+            Serilog.ILogger logger = Serilog.Log.Logger;
 
-			var logger = Serilog.Log.Logger;
 			if (sender != null)
 			{
 				logger = Serilog.Log.ForContext(Constants.SourceContextPropertyName, sender.GetType().Name);

--- a/Assets/Scripts/SS3D/Logging/LogManager.cs
+++ b/Assets/Scripts/SS3D/Logging/LogManager.cs
@@ -78,7 +78,7 @@ namespace SS3D.Logging
 
             // The path of the log file depends if connection is host, server only, or client.
             // Write in a different file depending on client's connection id.
-            string path = "Log.log";
+            string path = "Log.json";
 
             if (!string.IsNullOrEmpty(overrideLogPath))
             {
@@ -86,26 +86,26 @@ namespace SS3D.Logging
             }
             else if (InstanceFinder.IsHost)
             {
-                path = "LogHost.log";
+                path = "LogHost.json";
             }
             else if (InstanceFinder.IsClientOnly)
             {
-                path = $"LogClient_{InstanceFinder.NetworkManager.ClientManager.Connection.ClientId}.log";
+                path = $"LogClient_{InstanceFinder.NetworkManager.ClientManager.Connection.ClientId}.json";
             }
             else if (InstanceFinder.IsServerOnly)
             {
-                path = "LogServer.log";
+                path = "LogServer.json";
             }
 
             path = Path.Combine(LogFolderPath, path);
 
             if (Settings.UseCompactJsonFormatter)
 			{
-                path = Path.ChangeExtension(path, "json");
 				configuration.WriteTo.File(new CompactJsonFormatter(), path);
 			}
             else
 			{
+				path = Path.ChangeExtension(path, "log");
 				configuration.WriteTo.File(path);
 			}
 

--- a/Assets/Scripts/SS3D/Logging/LogManager.cs
+++ b/Assets/Scripts/SS3D/Logging/LogManager.cs
@@ -5,9 +5,8 @@ using Serilog.Events;
 using Serilog.Formatting.Compact;
 using Serilog.Sinks.Unity3D;
 using SS3D.Logging.LogSettings;
-using System;
+using System.IO;
 using UnityEngine;
-
 
 namespace SS3D.Logging
 {
@@ -21,20 +20,18 @@ namespace SS3D.Logging
     {
         private static readonly string DefaultUnityLogTemplate;
         private static readonly string LogFolderPath;
-        private static bool IsInitialized;
-
         private static readonly LogSettings.LogSettings Settings;
+        private static bool IsInitialized;
 
         static LogManager()
         {
             DefaultUnityLogTemplate = "{SourceContext} {Message}{NewLine}{Exception}";
-            LogFolderPath = Application.dataPath + "/../Logs/";
+            LogFolderPath = Path.Combine(Application.dataPath, "../Logs");
 
             if (Application.isPlaying)
             {
                 Settings = ScriptableSettings.GetOrFind<LogSettings.LogSettings>();
             }
-            
         }
 
         public static void Initialize(string logPath = null)
@@ -43,8 +40,6 @@ namespace SS3D.Logging
             {
                 return;
             }
-
-            IsInitialized = true;
 
             LoggerConfiguration configuration = new LoggerConfiguration();
 
@@ -60,6 +55,8 @@ namespace SS3D.Logging
             Serilog.Log.Logger = configuration.CreateLogger();
 
             Log.Information(typeof(LogManager), "Logging settings loaded and initialized", Logs.Important);
+
+            IsInitialized = true;
         }
 
         private static LoggerConfiguration ConfigureForPlayMode(LoggerConfiguration configuration, string overrideLogPath = null)
@@ -71,15 +68,17 @@ namespace SS3D.Logging
             // Does not apply override if the logging level corresponds to the global minimum level.
             foreach (NamespaceLogLevel levelForNameSpace in Settings.SS3DNameSpaces)
             {
-                if (levelForNameSpace.Level == Settings.DefaultLogLevel) continue;
+                if (levelForNameSpace.Level == Settings.DefaultLogLevel)
+                {
+                    continue;
+                }
 
                 configuration = configuration.MinimumLevel.Override(levelForNameSpace.Name, levelForNameSpace.Level);
             }
 
-            // Configure writing to log files using a CompactJsonFormatter.
             // The path of the log file depends if connection is host, server only, or client.
             // Write in a different file depending on client's connection id.
-            string path = string.Empty;
+            string path = "Log.log";
 
             if (!string.IsNullOrEmpty(overrideLogPath))
             {
@@ -87,20 +86,28 @@ namespace SS3D.Logging
             }
             else if (InstanceFinder.IsHost)
             {
-                path = "LogHost.json";
+                path = "LogHost.log";
             }
             else if (InstanceFinder.IsClientOnly)
             {
-                path = "LogClient" + InstanceFinder.NetworkManager.ClientManager.Connection.ClientId + ".json";
+                path = $"LogClient_{InstanceFinder.NetworkManager.ClientManager.Connection.ClientId}.log";
             }
             else if (InstanceFinder.IsServerOnly)
             {
-                path = "LogServer.json";
+                path = "LogServer.log";
             }
 
-            path = LogFolderPath + path;
+            path = Path.Combine(LogFolderPath, path);
 
-            configuration.WriteTo.File(new CompactJsonFormatter(), LogFolderPath + path);
+            if (Settings.UseCompactJsonFormatter)
+			{
+                path = Path.ChangeExtension(path, "json");
+				configuration.WriteTo.File(new CompactJsonFormatter(), path);
+			}
+            else
+			{
+				configuration.WriteTo.File(path);
+			}
 
             return configuration;
         }
@@ -122,6 +129,4 @@ namespace SS3D.Logging
              }
         }
     }
-
 }
-

--- a/Assets/Scripts/SS3D/Logging/LogSettings/InspectorEditor/LogSettingsInspectorEditor.cs
+++ b/Assets/Scripts/SS3D/Logging/LogSettings/InspectorEditor/LogSettingsInspectorEditor.cs
@@ -17,7 +17,10 @@ namespace SS3D.Logging.LogSettings.InspectorEditor
         {
             serializedObject.Update();
 
-            SerializedProperty spDefaultLevel = serializedObject.FindProperty(nameof(LogSettings.DefaultLogLevel));
+			SerializedProperty useCompactJsonFormatter = serializedObject.FindProperty(nameof(LogSettings.UseCompactJsonFormatter));
+            EditorGUILayout.PropertyField(useCompactJsonFormatter);
+
+			SerializedProperty spDefaultLevel = serializedObject.FindProperty(nameof(LogSettings.DefaultLogLevel));
 
             // default log level, the log level at which all namespace will be by default.
             LogEventLevel defaultLevel = (LogEventLevel)EditorGUILayout.EnumPopup(new GUIContent("Default log level"), (LogEventLevel)spDefaultLevel.enumValueIndex);

--- a/Assets/Scripts/SS3D/Logging/LogSettings/InspectorEditor/LogSettingsInspectorEditor.cs
+++ b/Assets/Scripts/SS3D/Logging/LogSettings/InspectorEditor/LogSettingsInspectorEditor.cs
@@ -1,17 +1,14 @@
-#if UNITY_EDITOR
+﻿#if UNITY_EDITOR
 
 using Serilog.Events;
 using UnityEditor;
-using UnityEditor.UIElements;
 using UnityEngine;
-using UnityEngine.UIElements;
-using SS3D.Logging.LogSettings;
 
 namespace SS3D.Logging.LogSettings.InspectorEditor
 {
     /// <summary>
-    /// Custom inspector for the log settings, allow to show the list of namespaces in a convenient manner,
-    /// as well as resetting easily all namespaces logging level.
+    /// Custom inspector for the log settings
+    /// Shows the list of namespaces in a convenient manner, as well as easily resetting all namespaces logging level.
     /// </summary>
     [CustomEditor(typeof(LogSettings))]
     public class LogSettingsInspectorEditor : Editor
@@ -20,14 +17,14 @@ namespace SS3D.Logging.LogSettings.InspectorEditor
         {
             serializedObject.Update();
 
-            SerializedProperty spDefaultLevel = serializedObject.FindProperty("defaultLogLevel");
+            SerializedProperty spDefaultLevel = serializedObject.FindProperty(nameof(LogSettings.DefaultLogLevel));
 
             // default log level, the log level at which all namespace will be by default.
             LogEventLevel defaultLevel = (LogEventLevel)EditorGUILayout.EnumPopup(new GUIContent("Default log level"), (LogEventLevel)spDefaultLevel.enumValueIndex);
 
             spDefaultLevel.enumValueIndex = (int)defaultLevel;
 
-            SerializedProperty sp = serializedObject.FindProperty("SS3DNameSpaces");
+            SerializedProperty sp = serializedObject.FindProperty(nameof(LogSettings.SS3DNameSpaces));
 
             // Button to reset all namespaces to the default log level.
             if (GUILayout.Button("Reset to default log level"))
@@ -48,4 +45,5 @@ namespace SS3D.Logging.LogSettings.InspectorEditor
         }
     }
 }
+
 #endif

--- a/Assets/Scripts/SS3D/Logging/LogSettings/LogSettings.cs
+++ b/Assets/Scripts/SS3D/Logging/LogSettings/LogSettings.cs
@@ -23,6 +23,8 @@ namespace SS3D.Logging.LogSettings
 	    [FormerlySerializedAs("defaultLogLevel")]
 	    public LogEventLevel DefaultLogLevel = LogEventLevel.Verbose;
 
+        public bool UseCompactJsonFormatter = false;
+
         /// <summary>
         /// Get all the name of the SS3D namespaces in alphanumerical order.
         /// </summary>

--- a/Assets/Scripts/SS3D/Networking/NetworkSessionSystem.cs
+++ b/Assets/Scripts/SS3D/Networking/NetworkSessionSystem.cs
@@ -1,4 +1,4 @@
-using Coimbra;
+﻿using Coimbra;
 using Coimbra.Services.Events;
 using FishNet;
 using FishNet.Managing;
@@ -32,18 +32,17 @@ namespace SS3D.Networking
         {
             NetworkSettings networkSettings = ScriptableSettings.GetOrFind<NetworkSettings>();
 
-            string path = String.Empty;
-
+            string path;
             switch (networkSettings.NetworkType)
             {
                 case NetworkType.DedicatedServer:
-                    path = "LogServer.json"; 
+                    path = "LogServer.log"; 
                     break;
                 case NetworkType.Client:
-                    path = "LogClient" + networkSettings.Ckey + ".json";
+                    path = $"LogClient_{networkSettings.Ckey}.log";
                     break;
                 case NetworkType.Host:
-                    path = "LogHost.json";
+                    path = "LogHost.log";
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Assets/Scripts/SS3D/Networking/NetworkSessionSystem.cs
+++ b/Assets/Scripts/SS3D/Networking/NetworkSessionSystem.cs
@@ -32,17 +32,18 @@ namespace SS3D.Networking
         {
             NetworkSettings networkSettings = ScriptableSettings.GetOrFind<NetworkSettings>();
 
-            string path;
+            string path = String.Empty;
+
             switch (networkSettings.NetworkType)
             {
                 case NetworkType.DedicatedServer:
-                    path = "LogServer.log"; 
+                    path = "LogServer.json"; 
                     break;
                 case NetworkType.Client:
-                    path = $"LogClient_{networkSettings.Ckey}.log";
+                    path = "LogClient" + networkSettings.Ckey + ".json";
                     break;
                 case NetworkType.Host:
-                    path = "LogHost.log";
+                    path = "LogHost.json";
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Assets/Settings/LogSettings.asset
+++ b/Assets/Settings/LogSettings.asset
@@ -148,3 +148,4 @@ MonoBehaviour:
   - _name: SS3D.Utils.Editor
     _level: 0
   DefaultLogLevel: 0
+  UseCompactJsonFormatter: 0


### PR DESCRIPTION
# Summary
Updates to the logging system
- Notably to fix a bug in the serilog file sink path
- Add a flag in the settings to toggle logging to json
- Various formatting updates in respect to the editorconfig file.

#### PR checklist
- [x] The game builds properly without errors.
    - No new errors that I've introduced
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
    - AddressableAssetSettings.settings has a new line? I'm not familiar enough with Unity's addressable system to know if I caused that or not
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
- [x] Relevant code is documented.
- [ ] Update the related GitBook document, or create a new one if needed.

# Testing
Testing can be accomplished by running the game and viewing the log file generated under the Logs folder.

# Changes
- Fixed a path bug in LogManager that was attempting to combine two absolute paths when building the sink
- Fixed an bug in the inspector code that referenced a renamed settings variable, which was preventing the inspector from showing the log settings properly
- Modified the Log.cs file to call a single private function to do the actual logging
    - It cleaned up a lot of the duplicate code
    - It fixed several bugs where Information and Warning log calls were actually using submitting Debug logs
- Added a toggle to the logging settings to turn off the compact json formatter
    - I predominantly use vscode to view running log files, and using serilogs default format looks slick with it.
- Moved the IsInitialized set to be at the end of the LogManager initialization.
- Updated SS3DUnityTextFormatter to respect the editorconfig file

