### PR TITLE
Fix Tilemap move item save

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/AttachedContainer.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/AttachedContainer.cs
@@ -1,5 +1,6 @@
 ﻿using FishNet.Component.Transforming;
 using SS3D.Core.Behaviours;
+using SS3D.Core;
 using SS3D.Systems.Inventory.UI;
 using System.Collections.Generic;
 using System;
@@ -9,6 +10,7 @@ using FishNet.Object.Synchronizing;
 using System.Linq;
 using FishNet.Object;
 using SS3D.Logging;
+using SS3D.Systems.Tile;
 using UnityEditor;
 
 namespace SS3D.Systems.Inventory.Containers
@@ -318,6 +320,21 @@ namespace SS3D.Systems.Inventory.Containers
 			if (item == null) return;
 
 			item.Freeze();
+
+            // Remove PlacedItemObject component if it exists to prevent saving items in containers
+            PlacedItemObject placedItemObject = item.GetComponent<PlacedItemObject>();
+            if (placedItemObject != null)
+            {
+                // Remove from TileMap tracking
+                TileMap tileMap = SubSystems.Get<TileSubSystem>()?.CurrentMap;
+                if (tileMap != null)
+                {
+                    tileMap.RemovePlacedItemFromTracking(placedItemObject);
+                }
+                
+                // Destroy the PlacedItemObject component
+                DestroyImmediate(placedItemObject);
+            }
 
             // Make invisible
             if (HideItems)

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using SS3D.Interactions.Interfaces;
 using SS3D.Interactions;
 using FishNet.Object;
+using SS3D.Systems.Tile;
+using SS3D.Core;
 
 namespace SS3D.Systems.Inventory.Containers
 {
@@ -124,13 +126,23 @@ namespace SS3D.Systems.Inventory.Containers
         public void PlaceHeldItemOutOfHand(Vector3 position, Quaternion rotation)
         {
             if (IsEmpty())
-            {
                 return;
-            }
+            
             ItemInHand.GiveOwnership(null);
             Item item = ItemInHand;
             item.Container.RemoveItem(item);
             ItemUtility.Place(item, position, rotation);
+
+            // Register with TileMap for saving
+            var tileMap = SubSystems.Get<TileSubSystem>().CurrentMap;
+            if (tileMap != null)
+            {
+                var itemObjectSo = SubSystems.Get<TileSubSystem>().GetAsset(item.Asset.Id) as ItemObjectSo;
+                if (itemObjectSo != null)
+                {
+                    tileMap.PlaceItemObject(position, rotation, itemObjectSo, item.gameObject);
+                }
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
@@ -134,7 +134,7 @@ namespace SS3D.Systems.Inventory.Containers
             ItemUtility.Place(item, position, rotation);
 
             // Register with TileMap for saving
-            var tileMap = SubSystems.Get<TileSubSystem>().CurrentMap;
+            TileMap tileMap = SubSystems.Get<TileSubSystem>().CurrentMap;
             if (tileMap != null)
             {
                 var itemObjectSo = SubSystems.Get<TileSubSystem>().GetAsset(item.Asset.Id) as ItemObjectSo;

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs
@@ -137,7 +137,7 @@ namespace SS3D.Systems.Inventory.Containers
             TileMap tileMap = SubSystems.Get<TileSubSystem>().CurrentMap;
             if (tileMap != null)
             {
-                var itemObjectSo = SubSystems.Get<TileSubSystem>().GetAsset(item.Asset.Id) as ItemObjectSo;
+                ItemObjectSo itemObjectSo = SubSystems.Get<TileSubSystem>().GetAsset(item.Asset.Id) as ItemObjectSo;
                 if (itemObjectSo != null)
                 {
                     tileMap.PlaceItemObject(position, rotation, itemObjectSo, item.gameObject);

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
@@ -20,6 +20,7 @@ using UnityEngine.Serialization;
 using AssetDatabase = UnityEditor.AssetDatabase;
 using UnityEditor;
 #endif
+using SS3D.Systems.Tile;
 
 namespace SS3D.Systems.Inventory.Items
 {
@@ -54,6 +55,10 @@ namespace SS3D.Systems.Inventory.Items
         [SerializeField] private Rigidbody _rigidbody;
 
         private Sprite _sprite;
+
+        [SerializeField]
+        private ItemObjectSo _itemObjectSo;
+        public ItemObjectSo ItemObjectSo => _itemObjectSo;
 
         [Header("Attachment settings")]
 

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
@@ -7,6 +7,7 @@ using FishNet.Object;
 using FishNet.Object.Synchronizing;
 using SS3D.Attributes;
 using SS3D.Data.AssetDatabases;
+using SS3D.Data.Generated;
 using SS3D.Interactions;
 using SS3D.Interactions.Interfaces;
 using SS3D.Logging;
@@ -20,7 +21,6 @@ using UnityEngine.Serialization;
 using AssetDatabase = UnityEditor.AssetDatabase;
 using UnityEditor;
 #endif
-using SS3D.Systems.Tile;
 
 namespace SS3D.Systems.Inventory.Items
 {
@@ -55,10 +55,6 @@ namespace SS3D.Systems.Inventory.Items
         [SerializeField] private Rigidbody _rigidbody;
 
         private Sprite _sprite;
-
-        [SerializeField]
-        private ItemObjectSo _itemObjectSo;
-        public ItemObjectSo ItemObjectSo => _itemObjectSo;
 
         [Header("Attachment settings")]
 

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
@@ -7,7 +7,6 @@ using FishNet.Object;
 using FishNet.Object.Synchronizing;
 using SS3D.Attributes;
 using SS3D.Data.AssetDatabases;
-using SS3D.Data.Generated;
 using SS3D.Interactions;
 using SS3D.Interactions.Interfaces;
 using SS3D.Logging;

--- a/Assets/Scripts/SS3D/Systems/Tile/PlacedObjects/PlacedItemObject.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/PlacedObjects/PlacedItemObject.cs
@@ -15,7 +15,7 @@ namespace SS3D.Systems.Tile
     public class PlacedItemObject : NetworkBehaviour
     {
         /// <summary>
-        /// Creates a new PlacedItemObject from an existing item GameObject at a given position and rotation.
+        ///  Places an item on the tilemap at a given position and rotation
         /// </summary>
         /// <param name="worldPosition"></param>
         /// <param name="origin"></param>

--- a/Assets/Scripts/SS3D/Systems/Tile/PlacedObjects/PlacedItemObject.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/PlacedObjects/PlacedItemObject.cs
@@ -31,14 +31,12 @@ namespace SS3D.Systems.Tile
             {
                 // Use the existing item GameObject
                 placedGameObject = existingItem;
-                placedGameObject.transform.SetPositionAndRotation(worldPosition, rotation);
             }
             else
             {
-                // Create a new GameObject (for loading from save files)
                 placedGameObject = Instantiate(itemSo.prefab);
-                placedGameObject.transform.SetPositionAndRotation(worldPosition, rotation);
             }
+            placedGameObject.transform.SetPositionAndRotation(worldPosition, rotation);
 
             PlacedItemObject placedObject = placedGameObject.GetComponent<PlacedItemObject>();
             if (placedObject == null)

--- a/Assets/Scripts/SS3D/Systems/Tile/PlacedObjects/PlacedItemObject.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/PlacedObjects/PlacedItemObject.cs
@@ -15,17 +15,30 @@ namespace SS3D.Systems.Tile
     public class PlacedItemObject : NetworkBehaviour
     {
         /// <summary>
-        /// Creates a new PlacedItemObject from a prefab at a given position and rotation. Uses NetworkServer.Spawn() if a server is running.
+        /// Creates a new PlacedItemObject from an existing item GameObject at a given position and rotation.
         /// </summary>
         /// <param name="worldPosition"></param>
         /// <param name="origin"></param>
         /// <param name="rotation"></param>
         /// <param name="itemSo"></param>
+        /// <param name="existingItem">The existing Item GameObject to add the PlacedItemObject component to</param>
         /// <returns></returns>
-        public static PlacedItemObject Create(Vector3 worldPosition, Quaternion rotation, ItemObjectSo itemSo)
+        public static PlacedItemObject Create(Vector3 worldPosition, Quaternion rotation, ItemObjectSo itemSo, GameObject existingItem = null)
         {
-            GameObject placedGameObject = Instantiate(itemSo.prefab);
-            placedGameObject.transform.SetPositionAndRotation(worldPosition, rotation);
+            GameObject placedGameObject;
+            
+            if (existingItem != null)
+            {
+                // Use the existing item GameObject
+                placedGameObject = existingItem;
+                placedGameObject.transform.SetPositionAndRotation(worldPosition, rotation);
+            }
+            else
+            {
+                // Create a new GameObject (for loading from save files)
+                placedGameObject = Instantiate(itemSo.prefab);
+                placedGameObject.transform.SetPositionAndRotation(worldPosition, rotation);
+            }
 
             PlacedItemObject placedObject = placedGameObject.GetComponent<PlacedItemObject>();
             if (placedObject == null)
@@ -65,6 +78,18 @@ namespace SS3D.Systems.Tile
             _worldPosition = worldPosition;
             _rotation = rotation;
             _itemSo = itemSo;
+        }
+
+        /// <summary>
+        /// Updates the position and rotation of this placed item object.
+        /// </summary>
+        /// <param name="worldPosition"></param>
+        /// <param name="rotation"></param>
+        public void UpdatePosition(Vector3 worldPosition, Quaternion rotation)
+        {
+            _worldPosition = worldPosition;
+            _rotation = rotation;
+            transform.SetPositionAndRotation(worldPosition, rotation);
         }
 
         /// <summary>

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
@@ -296,9 +296,30 @@ namespace SS3D.Systems.Tile
             }
         }
 
-        public void PlaceItemObject(Vector3 worldPosition, Quaternion rotation, ItemObjectSo itemObjectSo)
+        public void PlaceItemObject(Vector3 worldPosition, Quaternion rotation, ItemObjectSo itemObjectSo, GameObject existingItem = null)
         {
-            PlacedItemObject placedItem = PlacedItemObject.Create(worldPosition, rotation, itemObjectSo);
+            // Handle existing items that already have a PlacedItemObject component
+            if (existingItem != null)
+            {
+                var existingPlacedItem = existingItem.GetComponent<PlacedItemObject>();
+                if (existingPlacedItem != null)
+                {
+                    if (_items.Contains(existingPlacedItem))
+                    {
+                        // Item is already tracked, just update its position
+                        existingPlacedItem.UpdatePosition(worldPosition, rotation);
+                        return;
+                    }
+                    else
+                    {
+                        // Item has PlacedItemObject but not tracked, remove the old component
+                        DestroyImmediate(existingPlacedItem);
+                    }
+                }
+            }
+            
+            // Create new PlacedItemObject and add to tracking
+            PlacedItemObject placedItem = PlacedItemObject.Create(worldPosition, rotation, itemObjectSo, existingItem);
             placedItem.transform.SetParent(transform);
             _items.Add(placedItem);
         }
@@ -329,12 +350,21 @@ namespace SS3D.Systems.Tile
 
             _chunks.Clear();
 
+            // Clear items list safely, checking for null references
+            var itemsToRemove = new List<PlacedItemObject>();
             foreach (PlacedItemObject item in _items)
             {
-                item.DestroySelf();
+                if (item != null && item.gameObject != null)
+                {
+                    item.DestroySelf();
+                }
+                itemsToRemove.Add(item);
             }
-
-            _items.Clear();
+            
+            foreach (var item in itemsToRemove)
+            {
+                _items.Remove(item);
+            }
         }
 
         /// <summary>
@@ -372,7 +402,11 @@ namespace SS3D.Systems.Tile
                 return;
             }
 
+            // Clear TileMap data first (this clears the _items list)
             Clear();
+            
+            // Then clear all items in the scene, not just those tracked by TileMap
+            ClearAllItemsInScene();
 
             TileSubSystem tileSystem = SubSystems.Get<TileSubSystem>();
 
@@ -418,6 +452,30 @@ namespace SS3D.Systems.Tile
                         var pos = chunk.GetWorldPosition(obj.Origin.x, obj.Origin.y);
                         obj.UpdateAdjacencies();
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clear all items in the scene, including those not tracked by TileMap
+        /// </summary>
+        private void ClearAllItemsInScene()
+        {
+            // Find all Item components in the scene
+            var allItems = GameObject.FindObjectsOfType<SS3D.Systems.Inventory.Items.Item>();
+            
+            foreach (var item in allItems)
+            {
+                // Skip items that are in containers (player inventory, etc.)
+                if (item.Container != null)
+                {
+                    continue;
+                }
+                
+                // Destroy items that are in the world (not in containers)
+                if (item.gameObject != null)
+                {
+                    DestroyImmediate(item.gameObject);
                 }
             }
         }

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
@@ -301,7 +301,7 @@ namespace SS3D.Systems.Tile
             // Handle existing items that already have a PlacedItemObject component
             if (existingItem != null)
             {
-                var existingPlacedItem = existingItem.GetComponent<PlacedItemObject>();
+                PlacedItemObject existingPlacedItem = existingItem.GetComponent<PlacedItemObject>();
                 if (existingPlacedItem != null)
                 {
                     if (_items.Contains(existingPlacedItem))

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
@@ -4,6 +4,7 @@ using JetBrains.Annotations;
 using SS3D.Core;
 using SS3D.Logging;
 using SS3D.Systems.Tile.Connections;
+using SS3D.Systems.Inventory.Items;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -341,6 +342,19 @@ namespace SS3D.Systems.Tile
             _items.Remove(toRemove);
         }
 
+        /// <summary>
+        /// Remove a specific PlacedItemObject from TileMap tracking without destroying the GameObject.
+        /// This is used when items are picked up and placed in containers.
+        /// </summary>
+        /// <param name="placedItemObject">The PlacedItemObject to remove from tracking</param>
+        public void RemovePlacedItemFromTracking(PlacedItemObject placedItemObject)
+        {
+            if (placedItemObject != null && _items.Contains(placedItemObject))
+            {
+                _items.Remove(placedItemObject);
+            }
+        }
+
         public void Clear()
         {
             foreach (TileChunk chunk in _chunks.Values)
@@ -351,10 +365,7 @@ namespace SS3D.Systems.Tile
             _chunks.Clear();
 
             // Clear items list safely, checking for null references
-            var itemsToRemove = new List<PlacedItemObject>();
-            foreach (PlacedItemObject item in _items)
-            {
-                while (_items.Count > 0)
+            while (_items.Count > 0)
             {
                 PlacedItemObject item = _items.First();
                 if (item != null && item.gameObject != null)
@@ -364,11 +375,12 @@ namespace SS3D.Systems.Tile
                 
                 _items.RemoveAt(0);
             }
-            }
         }
 
         /// <summary>
         /// Returns a new SaveObject for storing the entire map.
+        /// Note: Items in player inventory (containers) are not saved as they have their PlacedItemObject
+        /// component removed when picked up. Only items placed in the world are saved.
         /// </summary>
         /// <returns></returns>
         public SavedTileMap Save()
@@ -406,7 +418,7 @@ namespace SS3D.Systems.Tile
             Clear();
             
             // Then clear all items in the scene, not just those tracked by TileMap
-            ClearAllItemsInScene();
+            ClearUntrackedItems();
 
             TileSubSystem tileSystem = SubSystems.Get<TileSubSystem>();
 
@@ -457,9 +469,9 @@ namespace SS3D.Systems.Tile
         }
 
         /// <summary>
-        /// Clear items in the scene that could conflict with loaded items
+        /// Clear untracked items in the scene that are not in containers and don't have a PlacedItemObject component
         /// </summary>
-        private void ClearAllItemsInScene()
+        private void ClearUntrackedItems()
         {
             // Find all Item components in the scene
             Item[] allItems = FindObjectsOfType<Item>();
@@ -476,6 +488,7 @@ namespace SS3D.Systems.Tile
                 // Destroy items that are in the world but not tracked by TileMap
                 if (item.gameObject != null)
                 {
+                    Debug.LogWarning($"Destroying untracked item: {item.gameObject.name} at position {item.gameObject.transform.position}");
                     DestroyImmediate(item.gameObject);
                 }
             }

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
@@ -457,7 +457,7 @@ namespace SS3D.Systems.Tile
         }
 
         /// <summary>
-        /// Clear all items in the scene, including those not tracked by TileMap
+        /// Clear items in the scene that could conflict with loaded items
         /// </summary>
         private void ClearAllItemsInScene()
         {
@@ -472,7 +472,13 @@ namespace SS3D.Systems.Tile
                     continue;
                 }
                 
-                // Destroy items that are in the world (not in containers)
+                // Skip items that already have PlacedItemObject (they're already tracked)
+                if (item.GetComponent<PlacedItemObject>() != null)
+                {
+                    continue;
+                }
+                
+                // Destroy items that are in the world but not tracked by TileMap
                 if (item.gameObject != null)
                 {
                     DestroyImmediate(item.gameObject);

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
@@ -354,16 +354,16 @@ namespace SS3D.Systems.Tile
             var itemsToRemove = new List<PlacedItemObject>();
             foreach (PlacedItemObject item in _items)
             {
+                while (_items.Count > 0)
+            {
+                PlacedItemObject item = _items.First();
                 if (item != null && item.gameObject != null)
                 {
                     item.DestroySelf();
                 }
-                itemsToRemove.Add(item);
+                
+                _items.RemoveAt(0);
             }
-            
-            foreach (var item in itemsToRemove)
-            {
-                _items.Remove(item);
             }
         }
 

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
@@ -462,18 +462,13 @@ namespace SS3D.Systems.Tile
         private void ClearAllItemsInScene()
         {
             // Find all Item components in the scene
-            var allItems = GameObject.FindObjectsOfType<SS3D.Systems.Inventory.Items.Item>();
+            Item[] allItems = FindObjectsOfType<Item>();
             
-            foreach (var item in allItems)
+            foreach (Item item in allItems)
             {
                 // Skip items that are in containers (player inventory, etc.)
-                if (item.Container != null)
-                {
-                    continue;
-                }
-                
-                // Skip items that already have PlacedItemObject (they're already tracked)
-                if (item.GetComponent<PlacedItemObject>() != null)
+                // and items that already have PlacedItemObject (they're already tracked)
+                if (item.Container != null || item.GetComponent<PlacedItemObject>() != null)
                 {
                     continue;
                 }


### PR DESCRIPTION
(AI generated PR description, but is accurate. Let me know if the code needs work.)

# Summary

This PR implements persistent saving for items moved by players during gameplay. Previously, only items placed or deleted through the Unity Tilemap editor were being saved to the map file. Items dropped or moved by players at runtime were not being tracked by the TileMap system, causing them to revert to their original positions after saving and loading the map.

The solution involves registering player-dropped items with the TileMap system so they are included in the save/load cycle, while preventing duplication issues that could occur when items are moved multiple times or when loading maps with existing scene items.

#### PR checklist
- [x] The game builds properly without errors.
- [x] No unrelated changes are present.
- [x] No "trash" files are committed.
- [x] Relevant code is documented.
- [ ] Update the related GitBook document, or create a new one if needed.

# Pictures/Videos
https://drive.google.com/file/d/1AyIAofUcfhQju4kCo0Xn__71JnGez9v_/view
<!-- Include photos or videos if possible to help reviewers. -->
<!-- It may also be used in our monthly devblog. -->

# Testing

To test this PR:

1. **Basic Functionality**: Start a game, pick up an item from the world, drop it in a new location, save the map, then reload the map. The item should appear in the dropped location, not the original spawn location.

2. **Multiple Moves**: Pick up an item, drop it, pick it up again, drop it in another location, save and reload. The item should appear in the final dropped location.

3. **Editor vs Runtime**: Place items using the Tilemap editor and save - these should still work as before. Drop items as a player and save - these should now persist correctly.

4. **No Duplication**: Items should not duplicate when moved or when loading maps. Each item should appear only once in its correct location.

5. **Container Items**: Items in player inventories or containers should not be affected by the TileMap saving system.

#### Networking checklist
- [x] Works from host in host mode.
- [x] Works from server in server mode.
- [x] Works on server in client mode.
- [x] Works and is synchronized across different clients.
- [x] Is persistent.

# Changes

## Core Implementation

**`Assets/Scripts/SS3D/Systems/Inventory/Containers/Hand.cs`**
- Modified `PlaceHeldItemOutOfHand()` to register dropped items with the TileMap system
- Added dynamic `ItemObjectSo` lookup using `item.Asset.Id` instead of requiring manual assignment
- Added necessary using statements for `SS3D.Core` and `SS3D.Systems.Tile`

**`Assets/Scripts/SS3D/Systems/Tile/TileMap.cs`**
- Enhanced `PlaceItemObject()` to handle existing items and prevent duplication
- Added `UpdatePosition()` calls for already-tracked items to ensure position persistence
- Optimized `ClearAllItemsInScene()` to only clear untracked items, preventing unnecessary destruction
- Improved save/load logic to handle both editor-placed and player-dropped items

**`Assets/Scripts/SS3D/Systems/Tile/PlacedObjects/PlacedItemObject.cs`**
- Modified `Create()` method to accept existing GameObjects, preventing runtime duplication
- Added `UpdatePosition()` method to synchronize transform and internal save data
- Enhanced networking spawn logic to work with both new and existing items

## Code Cleanup

**`Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs`**
- Removed redundant `ItemObjectSo` field since `Asset` property provides the same information
- Removed unnecessary using statement for `SS3D.Systems.Tile`

**`Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapSaveTab.cs`**
- Removed `AssignItemObjectSoFields()` method and its automatic assignment logic
- Simplified save process since `ItemObjectSo` lookup is now handled dynamically

**`Assets/Scripts/SS3D/Systems/Inventory/Items/ItemUtility.cs`**
- Removed debug logs from `Place()` method for cleaner code

## Technical Notes

The implementation uses the existing `Asset` system to dynamically retrieve `ItemObjectSo` references at runtime, eliminating the need for manual prefab assignment. The `PlacedItemObject` component is used to track items in the world, with careful handling to prevent duplication when items are moved multiple times or when loading maps with existing scene items.

The solution maintains backward compatibility with editor-placed items while extending the save/load functionality to player interactions.

## Known Issues

- Items that spawn in the player's hand by default (loadout items) will still spawn in the player's hand on map reload, even if they were dropped. This is intentional behavior as the loadout system is separate from the TileMap system.

# Related issues/PRs

<!-- List any issues or other PRs connected to this one. -->

<!-- If this PR CLOSES any issues/PRs, add "Closes" before the number (e.g. "Closes #123"). -->
Closes #1325 