### PR TITLE
Input system events used in OnStart and OnDestroyed moved to OnEnabled and OnDisbaled #1221

### DIFF
--- a/Assets/Scripts/External/RuntimeInspector/RuntimeEditorView.cs
+++ b/Assets/Scripts/External/RuntimeInspector/RuntimeEditorView.cs
@@ -1,5 +1,6 @@
 ﻿using DG.Tweening;
 using SS3D.Core;
+using SS3D.Systems.Inputs;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -20,9 +21,28 @@ namespace External.RuntimeInspector
         // Start is called before the first frame update
         void Start()
         {
-            SubSystems.Get<SS3D.Systems.Inputs.InputSubSystem>().Inputs.Other.ToggleRuntimeEditor.performed += HandleToggle;
             _hierarchyWidth = _runtimeHierarchy.sizeDelta.x;
             _inspectorWidth = _runtimeInspector.sizeDelta.x;
+        }
+
+        private void OnEnable()
+        {
+            InputSubSystem inputSubSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSubSystem)
+            {
+                inputSubSystem.Inputs.Other.ToggleRuntimeEditor.performed += HandleToggle;
+            }
+        }
+        
+        private void OnDisable()
+        {
+            InputSubSystem inputSubSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSubSystem)
+            {
+                inputSubSystem.Inputs.Other.ToggleRuntimeEditor.performed -= HandleToggle;
+            }
         }
 
         private void HandleToggle(InputAction.CallbackContext context)

--- a/Assets/Scripts/SS3D/Hacks/AttackBodyPartByClickingIt.cs
+++ b/Assets/Scripts/SS3D/Hacks/AttackBodyPartByClickingIt.cs
@@ -3,7 +3,6 @@ using SS3D.Core;
 using System.Linq;
 using UnityEngine;
 using SS3D.Systems.Health;
-using System;
 using System.Collections;
 using UnityEngine.InputSystem;
 using InputSubSystem = SS3D.Systems.Inputs.InputSubSystem;
@@ -34,14 +33,24 @@ namespace SS3D.Hacks
 			if (!IsOwner) enabled = false;
 		}
 
-        private void Start()
+        private void OnEnable()
         {
-            SubSystems.Get<InputSubSystem>().Inputs.Other.Attack.performed += CheckForAttack;
+            InputSubSystem inputSubSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSubSystem)
+            {
+                inputSubSystem.Inputs.Other.Attack.performed += CheckForAttack;
+            }
         }
 
-        private void OnDestroy()
+        private void OnDisable()
         {
-            SubSystems.Get<InputSubSystem>().Inputs.Other.Attack.performed -= CheckForAttack;
+            InputSubSystem inputSubSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSubSystem)
+            {
+                inputSubSystem.Inputs.Other.Attack.performed -= CheckForAttack;
+            }
         }
 
         private void CheckForAttack(InputAction.CallbackContext callbackContext)

--- a/Assets/Scripts/SS3D/Hacks/RagdollWhenPressingButton.cs
+++ b/Assets/Scripts/SS3D/Hacks/RagdollWhenPressingButton.cs
@@ -2,6 +2,7 @@
 using SS3D.Core.Behaviours;
 using SS3D.Systems.Entities.Humanoid;
 using SS3D.Systems.Inputs;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using InputSubSystem = SS3D.Systems.Inputs.InputSubSystem;
@@ -21,15 +22,56 @@ namespace SS3D.Hacks
 
         private Controls.OtherActions _controls;
 
-        public override void OnStartClient()
+        protected override void OnAwake()
         {
-            base.OnStartClient();
-            if (!IsOwner) return;
+            base.OnAwake();
 
-            _controls = SubSystems.Get<InputSubSystem>().Inputs.Other;
-            _controls.Ragdoll.performed += HandleKnockdown;
+            InputSubSystem inputSubSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSubSystem)
+            {
+                _controls = inputSubSystem.Inputs.Other;
+            }
         }
 
+        protected override void OnEnabled()
+        {
+            base.OnEnabled();
+
+            StartCoroutine(SubscribeToInput());
+        }
+
+        protected override void OnDisabled()
+        {
+            base.OnDisabled();
+
+            UnsubscribeFromInput();
+        }
+
+        /// <summary>
+        /// Waits until the owner is valid before subscribing to input
+        /// </summary>
+        private IEnumerator SubscribeToInput()
+        {
+            // Wait until the owner is valid
+            yield return new WaitUntil(() => Owner.IsValid);
+
+            if (Owner.IsLocalClient)
+            {
+                _controls.Ragdoll.performed += HandleKnockdown;
+            }
+        }
+
+        /// <summary>
+        /// Unsubscribes from input events
+        /// </summary>
+        private void UnsubscribeFromInput()
+        {
+            if (Owner.IsLocalClient)
+            {
+                _controls.Ragdoll.performed -= HandleKnockdown;
+            }
+        }
 
         private void HandleKnockdown(InputAction.CallbackContext context)
         {
@@ -37,4 +79,3 @@ namespace SS3D.Hacks
         }
     }
 }
-

--- a/Assets/Scripts/SS3D/Systems/Gamemodes/UI/GamemodeObjectivePanelView.cs
+++ b/Assets/Scripts/SS3D/Systems/Gamemodes/UI/GamemodeObjectivePanelView.cs
@@ -26,6 +26,13 @@ namespace SS3D.Systems.Gamemodes.UI
         protected override void OnAwake()
         {
             base.OnAwake();
+            
+            InputSubSystem inputSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSystem)
+            {
+                _controls = inputSystem.Inputs.Other;
+            }
 
             _gamemodeObjectiveItems = new Dictionary<int, GamemodeObjectiveItemView>();
 
@@ -37,14 +44,19 @@ namespace SS3D.Systems.Gamemodes.UI
             base.OnStart();
 
             _fade.SetFade(false);
-            _controls = SubSystems.Get<InputSubSystem>().Inputs.Other;
+        }
+
+        protected override void OnEnabled()
+        {
+            base.OnEnabled();
+            
             _controls.Fade.performed += HandleFadePerformed;
             _controls.Fade.canceled += HandleFadeCanceled;
         }
-
-        protected override void OnDestroyed()
+        
+        protected override void OnDisabled()
         {
-            base.OnDestroyed();
+            base.OnDisabled();
             
             _controls.Fade.performed -= HandleFadePerformed;
             _controls.Fade.canceled -= HandleFadeCanceled;

--- a/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/ConsolePanelView.cs
+++ b/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/ConsolePanelView.cs
@@ -54,23 +54,43 @@ namespace SS3D.Systems.IngameConsoleSystem
             _inputSystem = SubSystems.Get<InputSubSystem>();
             _controls = _inputSystem.Inputs;
             _consoleControls = _controls.Console;
-            _consoleControls.Close.performed += HandleClose;
-            _consoleControls.Open.performed += HandleOpen;
-            _consoleControls.SwitchCommand.performed += HandleSwitchCommand;
-            _consoleControls.Submit.performed += HandleSubmit;
             _inputSystem.ToggleAction(_consoleControls.Open, true);
 
             AddHandle(UpdateEvent.AddListener(HandleUpdate));
         }
 
-        protected override void OnDestroyed()
+        protected override void OnEnabled()
         {
-            base.OnDestroyed();
-            
-            _consoleControls.Close.performed -= HandleClose;
-            _consoleControls.Open.performed -= HandleOpen;
-            _consoleControls.SwitchCommand.performed -= HandleSwitchCommand;
-            _consoleControls.Submit.performed -= HandleSubmit;
+            base.OnEnabled();
+
+            InputSubSystem inputSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSystem && inputSystem.Inputs != null)
+            {
+                Controls.ConsoleActions consoleInputs = inputSystem.Inputs.Console;
+
+                consoleInputs.Close.performed += HandleClose;
+                consoleInputs.Open.performed += HandleOpen;
+                consoleInputs.SwitchCommand.performed += HandleSwitchCommand;
+                consoleInputs.Submit.performed += HandleSubmit;
+            }
+        }
+
+        protected override void OnDisabled()
+        {
+            base.OnDisabled();
+
+            InputSubSystem inputSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSystem && inputSystem.Inputs != null)
+            {
+                Controls.ConsoleActions consoleInputs = inputSystem.Inputs.Console;
+
+                consoleInputs.Close.performed -= HandleClose;
+                consoleInputs.Open.performed -= HandleOpen;
+                consoleInputs.SwitchCommand.performed -= HandleSwitchCommand;
+                consoleInputs.Submit.performed -= HandleSubmit;
+            }
         }
 
         private void HandleUpdate(ref EventContext context, in UpdateEvent updateEvent)

--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -10,6 +10,7 @@ using SS3D.Systems.Inputs;
 using SS3D.Systems.Screens;
 using SS3D.Systems.Inventory.Containers;
 using SS3D.Systems.Inventory.Items;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
@@ -34,48 +35,57 @@ namespace SS3D.Systems.Interactions
         
         private Camera _camera;
         private RadialInteractionSubSystem _radialView;
-        
-        public override void OnStartClient()
-        {
-            base.OnStartClient();
-            if (!Owner.IsLocalClient) return;
 
+        protected override void OnAwake()
+        {
+            base.OnAwake();
+            
             _radialView = SubSystems.Get<RadialInteractionSubSystem>();
             _camera = SubSystems.Get<CameraSubSystem>().PlayerCamera.GetComponent<Camera>();
+            
             _inputSystem = SubSystems.Get<InputSubSystem>();
             Controls controls = _inputSystem.Inputs;
             _controls = controls.Interactions;
             _hotkeysControls = controls.Hotkeys;
-            _radialView = SubSystems.Get<RadialInteractionSubSystem>();
-            _camera = SubSystems.Get<CameraSubSystem>().PlayerCamera.GetComponent<Camera>();
-            _controls.RunPrimary.performed += HandleRunPrimary;
-            _controls.ViewInteractions.performed += HandleView;
-            _hotkeysControls.Use.performed += HandleUse;
-            _inputSystem.ToggleActionMap(_controls, true);
         }
 
-        public override void OnStopClient()
+        protected override void OnEnabled()
         {
-            base.OnStopClient();
-            UnsubscribeFromEvents();
+            base.OnEnabled();
+            
+            StartCoroutine(EnableInput());
         }
 
-        private void UnsubscribeFromEvents()
+        protected override void OnDisabled()
         {
-            if (!Owner.IsLocalClient)
+            base.OnDisabled();
+            
+            DisableInput();
+        }
+
+        private IEnumerator EnableInput()
+        {
+            // Wait until the owner is valid
+            yield return new WaitUntil(() => Owner.IsValid);
+
+            if (Owner.IsLocalClient)
             {
-                return;
+                _controls.RunPrimary.performed += HandleRunPrimary;
+                _controls.ViewInteractions.performed += HandleView;
+                _hotkeysControls.Use.performed += HandleUse;
+                _inputSystem.ToggleActionMap(_controls, true);
             }
-            _controls.RunPrimary.performed -= HandleRunPrimary;
-            _controls.ViewInteractions.performed -= HandleView;
-            _hotkeysControls.Use.performed -= HandleUse;
-            _inputSystem.ToggleActionMap(_controls, false);
         }
-        
-        protected override void OnDestroyed()
+
+        private void DisableInput()
         {
-            base.OnDestroyed();
-            UnsubscribeFromEvents();
+            if (Owner.IsLocalClient)
+            {
+                _controls.RunPrimary.performed -= HandleRunPrimary;
+                _controls.ViewInteractions.performed -= HandleView;
+                _hotkeysControls.Use.performed -= HandleUse;
+                _inputSystem.ToggleActionMap(_controls, false);
+            }
         }
 
         /// <summary>
@@ -84,7 +94,6 @@ namespace SS3D.Systems.Interactions
         [Client]
         public void HandleRunPrimary(InputAction.CallbackContext callbackContext)
         {
-            
             Debug.Log("run primary : " + Mouse.current.position.ReadValue());
             if (EventSystem.current.IsPointerOverGameObject())
             {

--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -63,6 +63,9 @@ namespace SS3D.Systems.Interactions
             DisableInput();
         }
 
+        /// <summary>
+        /// Function to subscribe to input events and toggle action maps when the owner is local client.
+        /// </summary>
         private IEnumerator EnableInput()
         {
             // Wait until the owner is valid
@@ -77,6 +80,9 @@ namespace SS3D.Systems.Interactions
             }
         }
 
+        /// <summary>
+        /// Function to unsubscribe from input events and toggle action maps when the owner is local client.
+        /// </summary>
         private void DisableInput()
         {
             if (Owner.IsLocalClient)

--- a/Assets/Scripts/SS3D/Systems/Interactions/RadialInteractionSubSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/RadialInteractionSubSystem.cs
@@ -47,12 +47,32 @@ namespace SS3D.Systems.Interactions
         private Controls.InteractionsActions _controls;
         private InputSubSystem _inputSystem;
 
+        protected override void OnAwake()
+        {
+            base.OnAwake();
+
+            Setup();
+        }
+
         protected override void OnStart()
         {
             base.OnStart();
 
-            Setup();
             Disappear();
+        }
+
+        protected override void OnEnabled()
+        {
+            base.OnEnabled();
+
+            _controls.ViewInteractions.canceled += HandleDisappear;
+        }
+
+        protected override void OnDisabled()
+        {
+            base.OnDisabled();
+
+            _controls.ViewInteractions.canceled -= HandleDisappear;
         }
 
         private void HandleUpdate(ref EventContext context, in UpdateEvent updateEvent)
@@ -65,6 +85,7 @@ namespace SS3D.Systems.Interactions
             AddHandle(UpdateEvent.AddListener(HandleUpdate));
 
             Interactions = new List<IInteraction>();
+
             foreach (RadialInteractionButton interactionButton in _interactionButtons)
             {
                 interactionButton.OnHovered += HandleInteractionButtonHovered;
@@ -72,14 +93,6 @@ namespace SS3D.Systems.Interactions
 
             _inputSystem = SubSystems.Get<InputSubSystem>();
             _controls = _inputSystem.Inputs.Interactions;
-            _controls.ViewInteractions.canceled += HandleDisappear;
-        }
-
-        protected override void OnDestroyed()
-        {
-            base.OnDestroyed();
-            
-            _controls.ViewInteractions.canceled -= HandleDisappear;
         }
 
         private void HandleInteractionButtonHovered(GameObject button, IInteraction interaction)

--- a/Assets/Scripts/SS3D/Systems/Screens/CameraFollow.cs
+++ b/Assets/Scripts/SS3D/Systems/Screens/CameraFollow.cs
@@ -91,31 +91,40 @@ namespace SS3D.Systems.Screens
 
         #endregion
 
-        protected override void OnStart()
+        protected override void OnAwake()
         {
-            base.OnStart();
+            base.OnAwake();
+            
             _inputSystem = SubSystems.Get<InputSubSystem>();
             _controls = _inputSystem.Inputs.Camera;
-            _controls.Zoom.performed += HandleZoom;
-            _controls.SnapRight.performed += HandleSnapRight;
-            _controls.SnapLeft.performed += HandleSnapLeft;
-            _controls.MouseRotation.performed += HandleMouseRotation;
-            _inputSystem.ToggleActionMap(_controls, true);
 
             AddHandle(UpdateEvent.AddListener(HandleUpdate));
         }
 
-        protected override void OnDestroyed()
+        protected override void OnEnabled()
         {
-            base.OnDestroyed();
+            base.OnEnabled();
+            
+            _controls.Zoom.performed += HandleZoom;
+            _controls.SnapRight.performed += HandleSnapRight;
+            _controls.SnapLeft.performed += HandleSnapLeft;
+            _controls.MouseRotation.performed += HandleMouseRotation;
+            
+            _inputSystem.ToggleActionMap(_controls, true);
+        }
+
+        protected override void OnDisabled()
+        {
+            base.OnDisabled();
             
             _controls.Zoom.performed -= HandleZoom;
             _controls.SnapRight.performed -= HandleSnapRight;
             _controls.SnapLeft.performed -= HandleSnapLeft;
             _controls.MouseRotation.performed -= HandleMouseRotation;
+            
             _inputSystem.ToggleActionMap(_controls, false);
         }
-        
+
         private void HandleUpdate(ref EventContext context, in UpdateEvent updateEvent)
         {
             ProcessCameraPosition();

--- a/Assets/Scripts/SS3D/Systems/Screens/GameScreensController.cs
+++ b/Assets/Scripts/SS3D/Systems/Screens/GameScreensController.cs
@@ -32,13 +32,19 @@ namespace SS3D.Systems.Screens
             AddHandle(RoundStateUpdated.AddListener(HandleRoundStateUpdated));
 
             _controls = SubSystems.Get<InputSubSystem>().Inputs.Other;
-            _controls.ToggleMenu.performed += HandleToggleMenu;
         }
 
-        protected override void OnDestroyed()
+        protected override void OnEnabled()
         {
-            base.OnDestroyed();
-
+            base.OnEnabled();
+            
+            _controls.ToggleMenu.performed += HandleToggleMenu;
+        }
+        
+        protected override void OnDisabled()
+        {
+            base.OnDisabled();
+            
             _controls.ToggleMenu.performed -= HandleToggleMenu;
         }
 

--- a/Assets/Scripts/SS3D/Systems/Selection/SelectionCamera.cs
+++ b/Assets/Scripts/SS3D/Systems/Selection/SelectionCamera.cs
@@ -61,7 +61,35 @@ namespace SS3D.Systems.Selection
 
             GenerateRenderTexture();
             GenerateReadbackTexture();
-            SubSystems.Get<InputSubSystem>().Inputs.Other.ToggleSelectionDebug.performed += ToggleDebugMode;
+        }
+
+        protected override void OnEnabled()
+        {
+            base.OnEnabled();
+            
+            InputSubSystem inputSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSystem)
+            {
+                inputSystem.Inputs.Other.ToggleSelectionDebug.performed += ToggleDebugMode;
+            }
+        }
+
+        protected override void OnDisabled()
+        {
+            base.OnDisabled();
+            
+            InputSubSystem inputSystem = SubSystems.Get<InputSubSystem>();
+
+            if (inputSystem)
+            {
+                inputSystem.Inputs.Other.ToggleSelectionDebug.performed -= ToggleDebugMode;
+            }
+        }
+
+        protected override void OnDestroyed()
+        {
+            _renderTexture.Release();
         }
 
         private void GenerateReadbackTexture()
@@ -107,12 +135,6 @@ namespace SS3D.Systems.Selection
             }
 
             _system.UpdateColourFromCamera(col);
-        }
-
-        protected override void OnDestroyed()
-        {
-            _renderTexture.Release();
-            SubSystems.Get<InputSubSystem>().Inputs.Other.ToggleSelectionDebug.performed -= ToggleDebugMode;
         }
 
         /// <summary>

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/ConstructionHologramManager.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/ConstructionHologramManager.cs
@@ -65,17 +65,36 @@ namespace SS3D.Systems.Tile.TileMapCreator
             CreateHologram(genericObjectSo.prefab, TileHelper.GetPointedPosition(!_isPlacingItem));
         }
 
-        protected override void OnStart()
+        protected override void OnAwake()
         {
-            base.OnStart();
-            AddHandle(UpdateEvent.AddListener(HandleUpdate));
+            base.OnAwake();
+            
             _inputSystem = SubSystems.Get<InputSubSystem>();
             _controls = _inputSystem.Inputs.TileCreator;
+            
+            AddHandle(UpdateEvent.AddListener(HandleUpdate));
+        }
+
+        protected override void OnEnabled()
+        {
+            base.OnEnabled();
+            
             _controls.Place.started += HandlePlaceStarted;
             _controls.Place.performed += HandlePlacePerformed;
             _controls.Replace.performed += HandleReplace;
             _controls.Replace.canceled += HandleReplace;
             _controls.Rotate.performed += HandleRotate;
+        }
+
+        protected override void OnDisabled()
+        {
+            base.OnDisabled();
+            
+            _controls.Place.started -= HandlePlaceStarted;
+            _controls.Place.performed -= HandlePlacePerformed;
+            _controls.Replace.performed -= HandleReplace;
+            _controls.Replace.canceled -= HandleReplace;
+            _controls.Rotate.performed -= HandleRotate;
         }
 
         private void HandleUpdate(ref EventContext context, in UpdateEvent updateEvent)


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary

<!-- Provide a general summary of your change here. -->
Moved Input System event subscriptions and unsubscriptions from OnStart and OnDestroyed to OnEnabled and OnDisabled. These scripts were changed:
<!-- Follow with a more concise explanation of your change here. -->
- RuntimeEditorView.cs
- AttackBodyPartByClickingIt.cs
- GamemodeObjectivePanelView.cs
- ConsolePanelView.cs
- RagdollWhenPressingButton.cs
- InteractionController

<!-- What features does this change include/not include? -->
There are a few scripts where this has not been done. These are the scripts:
- HumanoidController.cs: I'm trying to move the initialization function Setup() to OnAwake(), but for some reason, OnAwake isn't being called. Neither Awake nor OnAwake is overridden in any of the derived classes. I used breakpoint debugging in the Awake function of NetworkActor, and surprisingly, the breakpoint doesn't hit at all. If I use Awake directly in HumanoidController.cs, then it does work.
- TileMapMenuSubSystem.cs: It subscribes to the event to open and close the menu (basically turning the game object on and off), so if I subscribe and unsubscribe input events in OnEnabled and OnDisabled the menu won't open at all.
- Hands.cs: The input events are not subscribed to in OnStart and OnDestroy.
- ClientCanSeeContentOfAllContainers.cs: the script is out of use.
- WhoIsTheOwner.cs: the script is out of use.
- ToggleInternalClothingUI.cs: the script is out of use.

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [x] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

<!-- optional. -->
# Pictures/Videos)

<!-- Include photos or videos if possible to help reviewers. -->
<!-- It may also be used in our monthly devblog. -->

# Testing

<!-- Explain how can a reviewer test this PR. -->

<!-- The networking checklist is optional if your feature doesn't require that. You can remove this list if unused. -->
#### Networking checklist
<!-- (ex. The host can open a door.) -->
- [x] Works from host in host mode.
<!-- (ex. The server can open a door, even if not interacting directly.) -->
- [x] Works from server in server mode.
<!-- (ex. The client tries to open a door, and the server opens it. The client and the server have to see the same thing. This would fail if only the client sees this interaction.). -->
- [x] Works on server in client mode.
<!-- (ex. The client tries to open a door, the server opens it, and another client sees that interaction.). -->
- [x] Works and is syncronized across different clients.
<!-- (ex. The client opens a door, the server opens it. The client closes the game, reopens it, and rejoins the server. The client sees the door open.). -->
- [x] Is persistent.

<!-- optional, but encouraged to give technical context. -->
<!-- changes to files, technical notes and known issues. -->
# Changes

<!-- List any major asset/script/scene changes and why/how they were changed. -->

<!-- Provide a more technical description of your changes to help save the reviewers some time. -->

<!-- List ANYTHING not working correctly, either part of your new change, or another part of the game. -->

<!-- Any known bugs will likely require sorting out before the PR is merged. -->

<!-- optional -->
# Related issues/PRs 

<!-- List any issues or other PRs connected to this one. -->

<!-- If this PR CLOSES any issues/PRs, add "Closes" before the number (e.g. "Closes #123"). -->
InputSystem in OnStart and OnDestroyed #1221 (Partially, check the summary for details)