### PR TITLE
Item freeze in mid air for client owned object

### DIFF
--- a/Assets/Content/WorldObjects/Items/Clothing/Backpack.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/Backpack.prefab
@@ -134,7 +134,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1
@@ -237,7 +237,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac42f7f6bb00ec44dbe827d0faf7fd62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clothType: 11
   _clothMeshes:
     _list:
     - _key: 11

--- a/Assets/Content/WorldObjects/Items/Clothing/FacewearGasMask.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/FacewearGasMask.prefab
@@ -165,7 +165,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1
@@ -268,7 +268,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac42f7f6bb00ec44dbe827d0faf7fd62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clothType: 3
   _clothMeshes:
     _list:
     - _key: 3

--- a/Assets/Content/WorldObjects/Items/Clothing/GloveInsulated.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/GloveInsulated.prefab
@@ -165,7 +165,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Clothing/Headset.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/Headset.prefab
@@ -165,7 +165,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1
@@ -270,7 +270,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac42f7f6bb00ec44dbe827d0faf7fd62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clothType: 9
   _clothMeshes:
     _list:
     - _key: 9

--- a/Assets/Content/WorldObjects/Items/Clothing/JumpsuitGrey.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/JumpsuitGrey.prefab
@@ -166,7 +166,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1
@@ -255,7 +255,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac42f7f6bb00ec44dbe827d0faf7fd62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clothType: 5
   _clothMeshes:
     _list:
     - _key: 5

--- a/Assets/Content/WorldObjects/Items/Clothing/ShoeHiTops.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/ShoeHiTops.prefab
@@ -148,7 +148,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Clothing/ShoeJackboots.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/ShoeJackboots.prefab
@@ -134,7 +134,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Clothing/Sunglasses.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/Sunglasses.prefab
@@ -165,7 +165,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1
@@ -269,7 +269,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac42f7f6bb00ec44dbe827d0faf7fd62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clothType: 2
   _clothMeshes:
     _list:
     - _key: 2

--- a/Assets/Content/WorldObjects/Items/Clothing/Toolbelt.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/Toolbelt.prefab
@@ -134,7 +134,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1
@@ -237,7 +237,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac42f7f6bb00ec44dbe827d0faf7fd62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clothType: 12
   _clothMeshes:
     _list:
     - _key: 12

--- a/Assets/Content/WorldObjects/Items/Clothing/TruckerCap.prefab
+++ b/Assets/Content/WorldObjects/Items/Clothing/TruckerCap.prefab
@@ -166,7 +166,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1
@@ -270,7 +270,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac42f7f6bb00ec44dbe827d0faf7fd62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clothType: 4
   _clothMeshes:
     _list:
     - _key: 4

--- a/Assets/Content/WorldObjects/Items/Consumable/Chemical/Medications/BrutePatch.prefab
+++ b/Assets/Content/WorldObjects/Items/Consumable/Chemical/Medications/BrutePatch.prefab
@@ -211,7 +211,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Consumable/Chemical/Medications/BurnPatch.prefab
+++ b/Assets/Content/WorldObjects/Items/Consumable/Chemical/Medications/BurnPatch.prefab
@@ -177,7 +177,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Consumable/Chemical/Medications/MedicalPatch.prefab
+++ b/Assets/Content/WorldObjects/Items/Consumable/Chemical/Medications/MedicalPatch.prefab
@@ -200,7 +200,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Consumable/Food/Drinks/Soda/SodaCanGeneric.prefab
+++ b/Assets/Content/WorldObjects/Items/Consumable/Food/Drinks/Soda/SodaCanGeneric.prefab
@@ -181,7 +181,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Consumable/Food/General/Snacks/DonkPocket.prefab
+++ b/Assets/Content/WorldObjects/Items/Consumable/Food/General/Snacks/DonkPocket.prefab
@@ -211,7 +211,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Cosmetic/BikeHorn/BikeHorn.prefab
+++ b/Assets/Content/WorldObjects/Items/Cosmetic/BikeHorn/BikeHorn.prefab
@@ -87,7 +87,7 @@ MeshFilter:
   m_Mesh: {fileID: 5709868560514540240, guid: b7735b41af47b164f841a513161d8f07, type: 3}
 --- !u!95 &7807247313645579261
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -104,7 +104,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &3401307552301717060
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -287,7 +288,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1
@@ -338,7 +339,7 @@ MeshCollider:
   m_Mesh: {fileID: 5709868560514540240, guid: b7735b41af47b164f841a513161d8f07, type: 3}
 --- !u!95 &6183259094829508424
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -355,7 +356,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &-1808419688812875912
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/WorldObjects/Items/Doodad.prefab
+++ b/Assets/Content/WorldObjects/Items/Doodad.prefab
@@ -176,7 +176,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Generic/Boombox.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Generic/Boombox.prefab
@@ -254,7 +254,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Generic/FloorTile.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Generic/FloorTile.prefab
@@ -146,7 +146,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Generic/Identification/PDA.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Generic/Identification/PDA.prefab
@@ -302,7 +302,7 @@ MonoBehaviour:
   _startFilter: {fileID: 11400000, guid: 092a6d8cb786ce94fb359f11b0da6f29, type: 2}
 --- !u!95 &8953388663960336043
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -319,7 +319,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &8691169782362177299
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/WorldObjects/Items/Functional/Generic/Identification/SecurityPDA.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Generic/Identification/SecurityPDA.prefab
@@ -302,7 +302,7 @@ MonoBehaviour:
   _startFilter: {fileID: 11400000, guid: 092a6d8cb786ce94fb359f11b0da6f29, type: 2}
 --- !u!95 &8953388663960336043
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -319,7 +319,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &8691169782362177299
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/WorldObjects/Items/Functional/Generic/Poster.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Generic/Poster.prefab
@@ -177,7 +177,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Generic/Tanks/OxygenTank.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Generic/Tanks/OxygenTank.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Generic/Tanks/PlasmaTank.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Generic/Tanks/PlasmaTank.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/ElectricalCable.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/ElectricalCable.prefab
@@ -178,7 +178,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/ElectricalWire.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/ElectricalWire.prefab
@@ -178,7 +178,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/GlassReinforcedSheet.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/GlassReinforcedSheet.prefab
@@ -280,7 +280,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/GlassShard.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/GlassShard.prefab
@@ -179,7 +179,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/GlassSheet.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/GlassSheet.prefab
@@ -280,7 +280,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/SteelReinforcedSheet.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/SteelReinforcedSheet.prefab
@@ -278,7 +278,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/SteelRod.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/SteelRod.prefab
@@ -179,7 +179,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/SteelSheet.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/SteelSheet.prefab
@@ -277,7 +277,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1
@@ -377,6 +377,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 49d37ab5b82ded9419a6e3ab3d05af02, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _componentIndexCache: 255
+  _addedNetworkObject: {fileID: 1773710978803455870}
+  _networkObjectCache: {fileID: 0}
 --- !u!1 &7393894785072713980
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/WoodLog.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/WoodLog.prefab
@@ -178,7 +178,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/WoodPlank.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/WoodPlank.prefab
@@ -178,7 +178,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Parts/MachineParts/MatterBin.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Parts/MachineParts/MatterBin.prefab
@@ -112,7 +112,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Parts/MachineParts/MicroLaser.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Parts/MachineParts/MicroLaser.prefab
@@ -112,7 +112,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Parts/PowerCells/PowerCell.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Parts/PowerCells/PowerCell.prefab
@@ -205,7 +205,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Storage/Objects/Medkits/Medkit.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Storage/Objects/Medkits/Medkit.prefab
@@ -398,7 +398,7 @@ MonoBehaviour:
   _container: {fileID: 0}
 --- !u!95 &5206759755089209485
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -415,7 +415,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &3298710121668139635
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -442,7 +443,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Storage/Objects/ToolBoxes/ToolboxBlue.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Storage/Objects/ToolBoxes/ToolboxBlue.prefab
@@ -444,7 +444,7 @@ MonoBehaviour:
   _container: {fileID: 0}
 --- !u!95 &5206759755089209485
 Animator:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -461,7 +461,8 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &3298710121668139635
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -488,7 +489,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Botany/Hatchet.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Botany/Hatchet.prefab
@@ -177,7 +177,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Command/NuclearAuthenticationDisk.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Command/NuclearAuthenticationDisk.prefab
@@ -250,7 +250,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Crowbar.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Crowbar.prefab
@@ -148,7 +148,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Multitool.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Multitool.prefab
@@ -178,7 +178,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/ScrewdriverBlue.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/ScrewdriverBlue.prefab
@@ -177,7 +177,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Welder.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Welder.prefab
@@ -165,7 +165,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Wirecutters.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Wirecutters.prefab
@@ -177,7 +177,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Wrench.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Engineering/Wrench.prefab
@@ -177,7 +177,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Generic/FlashlightBlue.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Generic/FlashlightBlue.prefab
@@ -95,7 +95,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Kitchen/KitchenKnife.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Kitchen/KitchenKnife.prefab
@@ -178,7 +178,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1

--- a/Assets/Content/WorldObjects/Items/Functional/Tools/Medical/HealthScanner.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Tools/Medical/HealthScanner.prefab
@@ -179,7 +179,7 @@ MonoBehaviour:
   _enableTeleport: 0
   _teleportThreshold: 1
   _scaleThreshold: 1
-  _clientAuthoritative: 1
+  _clientAuthoritative: 0
   _sendToOwner: 1
   _enableNetworkLod: 1
   _interval: 1


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary
The problem was that the item GloveInsulated prefab had the NetworkTransform component's "ClientAuthoritative" property set as true, but the code allows only the server to set the Rigidbody component's "IsKinematic" property to be set to false upon releasing the object from the inventory slot. When happening on the host, this interaction behaves properly because the host is the owner client for the object, but when a client owns the object, even though the server side object falls to the ground, the client, being the owner of the object, doesn't let the object fall to the ground at its end.
<!-- Provide a general summary of your change here. -->

<!-- Follow with a more concise explanation of your change here. -->

<!-- What features does this change include/not include? -->

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [ ] No unrelated changes are present. 
A few prefabs have changes that are related to previous changes. (e.g., clothType property was removed in a previous PR, but the prefbas weren't updated)
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [x] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.

<!-- optional. -->
# Pictures/Videos)
<img width="1783" height="1089" alt="image" src="https://github.com/user-attachments/assets/fa486857-b6eb-4df1-b57c-8455eeb5bc17" />
Before

<img width="1781" height="1079" alt="image" src="https://github.com/user-attachments/assets/1d8a8656-508b-4201-b51d-f4c8151f50e5" />
After
<!-- Include photos or videos if possible to help reviewers. -->
<!-- It may also be used in our monthly devblog. -->

# Testing

<!-- Explain how can a reviewer test this PR. -->

<!-- The networking checklist is optional if your feature doesn't require that. You can remove this list if unused. -->
#### Networking checklist
<!-- (ex. The host can open a door.) -->
- [x] Works from host in host mode.
<!-- (ex. The server can open a door, even if not interacting directly.) -->
- [x] Works from server in server mode.
<!-- (ex. The client tries to open a door, and the server opens it. The client and the server have to see the same thing. This would fail if only the client sees this interaction.). -->
- [x] Works on server in client mode.
<!-- (ex. The client tries to open a door, the server opens it, and another client sees that interaction.). -->
- [x] Works and is syncronized across different clients.
<!-- (ex. The client opens a door, the server opens it. The client closes the game, reopens it, and rejoins the server. The client sees the door open.). -->
- [x] Is persistent.

<!-- optional, but encouraged to give technical context. -->
<!-- changes to files, technical notes and known issues. -->
# Changes
Changed all the 87 item prefabs' NetworkTransform component's "Client Authoritative" property to false.
<!-- List any major asset/script/scene changes and why/how they were changed. -->

<!-- Provide a more technical description of your changes to help save the reviewers some time. -->

<!-- List ANYTHING not working correctly, either part of your new change, or another part of the game. -->

<!-- Any known bugs will likely require sorting out before the PR is merged. -->

<!-- optional -->
# Related issues/PRs 
Items dragged out of slot freeze mid air on client #1360
<!-- List any issues or other PRs connected to this one. -->

<!-- If this PR CLOSES any issues/PRs, add "Closes" before the number (e.g. "Closes #123"). -->
