### PR TITLE
Reassign ckey in Network Settings

### DIFF
--- a/Assets/Settings/NetworkSettings.asset
+++ b/Assets/Settings/NetworkSettings.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _preload: 1
   _type: 2
   NetworkType: 2
-  _ckey: unknown
+  _ckey: hostingUser
   ServerAddress: 127.0.0.1
   ServerPort: 8616
   EnableNetworkBandwidthUsageStats: 1


### PR DESCRIPTION
# Summary

At some point of time, ckey for Unity Editor became "unknown", despite being "hostingUser" before.
Currently the game writes down the ckey as a host, so it doesn't cause issues on the second run. Still annoying tho.

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->

# Changes
Reassigned the ckey in Project Settings>Network Settings.
