### PR TITLE
Change the workflow to make it use secret var UNITY_LICENSE for Unity Tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           buildName: RESS3D-${{ steps.tag_name.outputs.SOURCE_TAG }}
           targetPlatform: ${{ matrix.targetPlatform }}
+      - name: Run Unity Tests
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Create new release from tag
         uses: actions/create-release@v1
         id: create_release


### PR DESCRIPTION
# Summary
Currently the workflow doesn't recognise/doesn't want to recognise secret var UNITY_LICENSE. This change will probably allow to run tests with Unity 2021.3.45f2.


# Related issues/PRs 
#1484 
