### PR TITLE
Add UNITY_EMAIL and UNITY_PASSWORD to tests

### DIFF
--- a/.github/workflows/editmodetestrunner.yml
+++ b/.github/workflows/editmodetestrunner.yml
@@ -21,19 +21,14 @@ jobs:
       - run: npm install @actions/github
       - run: npm install jsdom
       - run: npm install fs
-      - name: Debug Secret Visibility
-        run: |
-          if [ -z "${{ secrets.UNITY_LICENSE }}" ]; then
-            echo "SECRET IS EMPTY"
-          else
-            echo "SECRET IS DEFINED"
-          fi
       - name: Run tests
         uses: game-ci/unity-test-runner@v4
         with:
           testMode: editmode
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       - name: Produce summary output
         uses: ./.github/actions/interpret-test-results
         if: always()

--- a/.github/workflows/editmodetestrunner.yml
+++ b/.github/workflows/editmodetestrunner.yml
@@ -21,6 +21,13 @@ jobs:
       - run: npm install @actions/github
       - run: npm install jsdom
       - run: npm install fs
+      - name: Debug Secret Visibility
+        run: |
+          if [ -z "${{ secrets.UNITY_LICENSE }}" ]; then
+            echo "SECRET IS EMPTY"
+          else
+            echo "SECRET IS DEFINED"
+          fi
       - name: Run tests
         uses: game-ci/unity-test-runner@v4
         with:

--- a/.github/workflows/editmodetestrunner.yml
+++ b/.github/workflows/editmodetestrunner.yml
@@ -28,6 +28,15 @@ jobs:
           else
             echo "SECRET IS DEFINED"
           fi
+      - name: Debug license/email/password lengths
+         run: |
+          echo "UNITY_LICENSE length: ${#UNITY_LICENSE}"
+          echo "UNITY_EMAIL length: ${#UNITY_EMAIL}"
+          echo "UNITY_PASSWORD length: ${#UNITY_PASSWORD}"
+         env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       - name: Run tests
         uses: game-ci/unity-test-runner@v4
         with:


### PR DESCRIPTION
# Summary
Now we get a new error "Error: No valid license activation strategy could be determined. Make sure to provide UNITY_EMAIL, UNITY_PASSWORD, and either a UNITY_SERIAL or UNITY_LICENSE. Otherwise please use UNITY_LICENSING_SERVER.", which is progress.
Add corresponding secrets to the workflow
