### PR TITLE
Fix: crafting null reference when hand is empty

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Crafting/CraftingSubSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Crafting/CraftingSubSystem.cs
@@ -78,7 +78,7 @@ namespace SS3D.Systems.Crafting
                     Log.Error(this, "Crafting recipe database contains object which is not recipe");
                     continue;
                 }
-                
+
                 _recipeOrganiser.TryAdd(recipe.Target.Id, new());
                 _recipeOrganiser[recipe.Target.Id].Add(recipe);
             }
@@ -90,7 +90,7 @@ namespace SS3D.Systems.Crafting
         private bool TryGetRecipeLinks(CraftingInteractionType interactionType, GameObject target, out List<TaggedEdge<RecipeStep, RecipeStepLink>> links)
         {
             links = new();
-            
+
             if (!target.TryGetComponent(out IWorldObjectAsset targetAssetReference)) return false;
 
             if (targetAssetReference.Asset is null)
@@ -99,18 +99,20 @@ namespace SS3D.Systems.Crafting
 
                 return false;
             }
-            
+
             if (!_recipeOrganiser.TryGetValue(targetAssetReference.Asset.Id, out List<CraftingRecipe> recipes))
             {
                 Log.Information(this, $"no recipes with target's name {targetAssetReference.Asset.Id}");
                 return false;
             }
-            
+
             string currentStepName = CurrentStepName(target);
-            links = (from potentialRecipe in recipes from link in potentialRecipe.GetLinksFromStep(currentStepName) 
-                where interactionType == link.Tag?.CraftingInteractionType select link).ToList();
-            
-            if (links.Count == 0) 
+            links = (from potentialRecipe in recipes
+                     from link in potentialRecipe.GetLinksFromStep(currentStepName)
+                     where interactionType == link.Tag?.CraftingInteractionType
+                     select link).ToList();
+
+            if (links.Count == 0)
             {
                 Log.Information(this, $"no recipe links matching interaction type {interactionType}, from recipe step {currentStepName} ");
             }
@@ -137,7 +139,7 @@ namespace SS3D.Systems.Crafting
         public void Craft(CraftingInteraction interaction, InteractionEvent interactionEvent)
         {
             TaggedEdge<RecipeStep, RecipeStepLink> link = interaction.ChosenLink;
-            if (!CanCraftRecipeLink(interactionEvent, link))  return;
+            if (!CanCraftRecipeLink(interactionEvent, link)) return;
             List<IRecipeIngredient> ingredients = GetIngredientsToConsume(interactionEvent, link);
             IRecipeIngredient recipeTarget = interactionEvent.Target.GetGameObject().GetComponent<IRecipeIngredient>();
 
@@ -153,7 +155,7 @@ namespace SS3D.Systems.Crafting
                 Log.Error(this, $"Tag associated to recipe link {link} should not be null");
                 return;
             }
-            
+
             foreach (SecondaryResult secondaryResult in link.Tag.SecondaryResults)
             {
                 for (int i = 0; i < secondaryResult.Amount; i++)
@@ -196,7 +198,7 @@ namespace SS3D.Systems.Crafting
                 Log.Error(this, $"World object reference {result} has no prefab associated");
                 return;
             }
-                
+
             if (link.Target.CustomCraft)
             {
                 resultInstance = result.Prefab.GetComponent<ICraftable>()?.Craft(interaction, interactionEvent);
@@ -205,9 +207,9 @@ namespace SS3D.Systems.Crafting
             {
                 resultInstance = DefaultCraft(interaction, interactionEvent, result.Prefab, link.Target);
             }
-            
+
             if (link.Tag == null || !link.Tag.ModifyResult) return;
-            
+
             if (!resultInstance)
             {
                 Log.Error(this, "could not craft an instance for the recipe result");
@@ -258,7 +260,15 @@ namespace SS3D.Systems.Crafting
         {
             availableLinks = new();
 
-            if (!TryGetRecipeLinks(interactionType, interactionEvent.Target.GetGameObject(),
+            GameObject target = interactionEvent.Target.GetGameObject();
+
+            if (!target)
+            {
+                Log.Warning(this, "AvailableRecipeLinks called with a null interaction target GameObject.");
+                return false;
+            }
+
+            if (!TryGetRecipeLinks(interactionType, target,
                     out List<TaggedEdge<RecipeStep, RecipeStepLink>> potentialLinks))
             {
                 return false;
@@ -270,7 +280,7 @@ namespace SS3D.Systems.Crafting
                 availableLinks.Add(link);
             }
 
-            return availableLinks.Count > 0; 
+            return availableLinks.Count > 0;
         }
 
         /// <summary>
@@ -288,7 +298,7 @@ namespace SS3D.Systems.Crafting
 
             List<IRecipeIngredient> ingredients = GetIngredientsToConsume(interactionEvent, link);
             Dictionary<string, int> potentialRecipeElements = ItemListToDictionnaryOfRecipeElements(ingredients);
-            
+
             return CheckEnoughCloseItemsForRecipe(potentialRecipeElements, link.Tag);
         }
 
@@ -300,7 +310,7 @@ namespace SS3D.Systems.Crafting
         private List<IRecipeIngredient> BuildListOfItemToConsume([NotNull] List<IRecipeIngredient> closeItemsFromTarget,
             [NotNull] RecipeStepLink recipeStep)
         {
-            List<IRecipeIngredient>  itemsToConsume = new();
+            List<IRecipeIngredient> itemsToConsume = new();
             Dictionary<string, int> recipeElements = new(recipeStep.Elements);
 
             foreach (IRecipeIngredient item in closeItemsFromTarget)
@@ -385,9 +395,9 @@ namespace SS3D.Systems.Crafting
         {
             List<TweenerCore<Vector3, Vector3, VectorOptions>> coroutines = new();
             Vector3 targetPosition = interactionEvent.Target.GetGameObject().transform.position;
-            List<GameObject> ingredientsToConsume = 
+            List<GameObject> ingredientsToConsume =
                 GetIngredientsToConsume(interactionEvent, interaction.ChosenLink).Select(x => x.GameObject).ToList();
-            
+
             foreach (GameObject go in ingredientsToConsume)
             {
                 coroutines.Add(go.transform.DOMove(targetPosition, 0.75f));
@@ -404,7 +414,7 @@ namespace SS3D.Systems.Crafting
         public void CancelMoveAllObjectsToCraftPoint(InteractionReference reference)
         {
             // TODO: Remove checks for null
-            _coroutinesOrganiser[reference].Where(x => x!= null).ToList().ForEach(x => x.Kill());
+            _coroutinesOrganiser[reference].Where(x => x != null).ToList().ForEach(x => x.Kill());
             CancelCraftingSmoke(reference.Id);
         }
 
@@ -459,7 +469,7 @@ namespace SS3D.Systems.Crafting
                 }
                 foreach (Item item in itemsInHand)
                 {
-                    if(item.GameObject.TryGetComponent(out IRecipeIngredient recipeIngredient))
+                    if (item.GameObject.TryGetComponent(out IRecipeIngredient recipeIngredient))
                         ingredients.Add(recipeIngredient);
                 }
             }
@@ -638,14 +648,14 @@ namespace SS3D.Systems.Crafting
         public List<CraftingInteraction> CreateInteractions(InteractionEvent interactionEvent, CraftingInteractionType craftingInteractionType)
         {
             List<CraftingInteraction> craftingInteractions = new();
-            if (!AvailableRecipeLinks(craftingInteractionType, interactionEvent, 
+            if (!AvailableRecipeLinks(craftingInteractionType, interactionEvent,
                 out List<TaggedEdge<RecipeStep, RecipeStepLink>> availableRecipes)) return craftingInteractions;
 
             foreach (TaggedEdge<RecipeStep, RecipeStepLink> recipeLink in availableRecipes)
             {
                 CraftingInteraction interaction = new(recipeLink.Tag.ExecutionTime,
                     interactionEvent.Source.GameObject.GetComponentInParent<HumanoidController>().transform, craftingInteractionType, recipeLink);
-                
+
                 craftingInteractions.Add(interaction);
             }
 

--- a/Assets/Scripts/SS3D/Systems/Crafting/OpenCraftingMenuInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Crafting/OpenCraftingMenuInteraction.cs
@@ -1,7 +1,9 @@
 ﻿using QuikGraph;
 using SS3D.Core;
 using SS3D.Interactions;
+using SS3D.Interactions.Extensions;
 using SS3D.Interactions.Interfaces;
+using SS3D.Logging;
 using SS3D.Systems.Crafting;
 using System.Collections.Generic;
 using System.Linq;
@@ -46,8 +48,16 @@ public class OpenCraftingMenuInteraction : IInteraction, IClientInteractionSourc
     /// <returns>If the interaction can be executed</returns>
     public bool CanInteract(InteractionEvent interactionEvent)
     {
-        if (!SubSystems.TryGet(out CraftingSubSystem craftingSystem))
+        if (interactionEvent?.Target == null || !interactionEvent.Target.GetGameObject())
+        {
             return false;
+        }
+
+        if (!SubSystems.TryGet(out CraftingSubSystem craftingSystem))
+        {
+            Log.Warning(this, "OpenCraftingMenuInteraction.CanInteract could not find CraftingSubSystem.");
+            return false;
+        }
 
         bool recipesAvailable = true;
         recipesAvailable &= craftingSystem.AvailableRecipeLinks(_craftingInteractionType, interactionEvent, out List<TaggedEdge<RecipeStep, RecipeStepLink>> _);

--- a/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
+++ b/Assets/Scripts/SS3D/Systems/Interactions/InteractionController.cs
@@ -5,6 +5,7 @@ using FishNet.Object;
 using SS3D.Core;
 using SS3D.Core.Behaviours;
 using SS3D.Interactions;
+using SS3D.Interactions.Extensions;
 using SS3D.Interactions.Interfaces;
 using SS3D.Logging;
 using SS3D.Systems.Inputs;
@@ -33,7 +34,7 @@ namespace SS3D.Systems.Interactions
         private Controls.InteractionsActions _controls;
         private Controls.HotkeysActions _hotkeysControls;
         private InputSubSystem _inputSystem;
-        
+
         private Camera _camera;
         private RadialInteractionSubSystem _radialView;
 
@@ -54,10 +55,10 @@ namespace SS3D.Systems.Interactions
         protected override void OnAwake()
         {
             base.OnAwake();
-            
+
             _radialView = SubSystems.Get<RadialInteractionSubSystem>();
             _camera = SubSystems.Get<CameraSubSystem>().PlayerCamera.GetComponent<Camera>();
-            
+
             _inputSystem = SubSystems.Get<InputSubSystem>();
             Controls controls = _inputSystem.Inputs;
             _controls = controls.Interactions;
@@ -106,7 +107,6 @@ namespace SS3D.Systems.Interactions
         [Client]
         public void HandleRunPrimary(InputAction.CallbackContext callbackContext)
         {
-            Debug.Log("run primary : " + Mouse.current.position.ReadValue());
             if (EventSystem.current.IsPointerOverGameObject())
             {
                 return;
@@ -123,6 +123,7 @@ namespace SS3D.Systems.Interactions
             string interactionName = interaction.Interaction.GetName(interactionEvent);
             interactionEvent.Target = interaction.Target;
 
+            Log.Information(this, "Running interaction {interactionName} on target {target}", Logs.Generic, interactionName, interaction.Target);
             CmdRunInteraction(ray, interactionName);
         }
 
@@ -325,7 +326,7 @@ namespace SS3D.Systems.Interactions
             List<IInteractionTarget> targets = new();
 
             // Get all target components which are not disabled and the source can interact with
-            targets.AddRange(targetGameObject.GetComponents<IInteractionTarget>().Where(x =>(x as MonoBehaviour)?.enabled != false && source.CanInteractWithTarget(x)));
+            targets.AddRange(targetGameObject.GetComponents<IInteractionTarget>().Where(x => (x as MonoBehaviour)?.enabled != false && source.CanInteractWithTarget(x)));
             if (targets.Count < 1)
             {
                 targets.Add(new InteractionTargetGameObject(targetGameObject));
@@ -388,7 +389,7 @@ namespace SS3D.Systems.Interactions
         }
 
         [ServerRpc]
-        private void CmdRunInventoryInteraction(GameObject target, GameObject sourceObject,  int index, string interactionName)
+        private void CmdRunInventoryInteraction(GameObject target, GameObject sourceObject, int index, string interactionName)
         {
             IInteractionSource source = sourceObject.GetComponent<IInteractionSource>();
             List<IInteractionTarget> targets = GetTargetsFromGameObject(source, target);


### PR DESCRIPTION
<!-- The notes within these arrows are for you but can be deleted. -->
<!-- Add "[WIP]" to the beginning of your title if you aren't immediately ready for review. -->
<!-- Optional fields should be removed for readability if not used. -->

# Summary

I found a simple bug, a null reference in the crafting system being thrown when interacting with the lockers with an open hand.

I also added some related logging.

Some related formatting issues was also committed.

I found two things that may or may not be worth turning into issues:
- Running an interaction currently ray traces 3 times because the ray trace is used to find the interactions, first to check if you can do the interaction on the client, then the server verifies that the client can do the interaction, then the client needs to find the interaction again one last time. I'd consider sending changing the protocol so the information on the source and target objects are sent to the server so the raycast only happens to find what you're clicking on, not to find out what interactions are available.
- The "GetGameObject()" method on IInteractionTarget is unintuitive, because some targets have game objects, but do not implement the optional IGameObjectProvider, making it unclear what the purpose of it is.

#### PR checklist
- [x] The game builds properly without errors.
<!--  (ex. "Update BikeHorn prefab" changed HumanOrgans.fbx for some reason) -->
- [x] No unrelated changes are present.
<!--  (ex. An auto-generated Unity file that if updated when you open Unity, if necessary, update .gitignore). -->
- [x] No "trash" files are committed.
<!-- optional, if no code -->
- [ ] Relevant code is documented.
<!-- optional, if doc is needed -->
- [ ] Update the related GitBook document, or create a new one if needed.
