### PR TITLE
Feature/item stacking

### DIFF
--- a/Assets/Content/Systems/UI/Systems/Containers/Inventory/InventorySlots/SingleItemSlot.prefab
+++ b/Assets/Content/Systems/UI/Systems/Containers/Inventory/InventorySlots/SingleItemSlot.prefab
@@ -1,5 +1,140 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7395690832822900500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6588747601474455005}
+  - component: {fileID: 2083145909509970836}
+  - component: {fileID: 5446539457635037957}
+  m_Layer: 0
+  m_Name: CountLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6588747601474455005
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7395690832822900500}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9053896636040410416}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -4, y: -4}
+  m_Pivot: {x: 1, y: 0}
+--- !u!222 &2083145909509970836
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7395690832822900500}
+  m_CullTransparentMesh: 1
+--- !u!114 &5446539457635037957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7395690832822900500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text:
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ffc81b96d71d7544580ef63e2d508f02, type: 2}
+  m_sharedMaterial: {fileID: 8572051279392437555, guid: ffc81b96d71d7544580ef63e2d508f02, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &8857005525053829139
 GameObject:
   m_ObjectHideFlags: 0
@@ -30,7 +165,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 0}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 6588747601474455005}
   m_Father: {fileID: 4603278309003134918}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -57,8 +193,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
@@ -87,9 +223,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f2b2e863b1d33f1408d51dfcf60dcfcb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ItemImage: {fileID: 1643315341115440644}
+  _countLabel: {fileID: 5446539457635037957}
   _item: {fileID: 0}
 --- !u!1001 &2541968410778507077
 PrefabInstance:
@@ -188,7 +325,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3393983965762327756, guid: 1fd282cd3862b2848a83fe40030cf431, type: 3}
       propertyPath: ItemDisplay
-      value: 
+      value:
       objectReference: {fileID: 4932109889070309484}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1fd282cd3862b2848a83fe40030cf431, type: 3}
@@ -212,8 +349,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -255,5 +392,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Content/Systems/UI/Systems/Containers/Inventory/ItemDisplay.prefab
+++ b/Assets/Content/Systems/UI/Systems/Containers/Inventory/ItemDisplay.prefab
@@ -56,8 +56,8 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.40392157, g: 0.5529412, b: 0.72156864, a: 1}
   m_RaycastTarget: 0
@@ -169,8 +169,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.29411766}
   m_RaycastTarget: 1
@@ -245,8 +245,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
@@ -314,8 +314,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -355,6 +355,141 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &6334649772191767841
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3850845667392149591}
+  - component: {fileID: 5126964459055183890}
+  - component: {fileID: 5500761304066541822}
+  m_Layer: 0
+  m_Name: CountLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &3850845667392149591
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6334649772191767841}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 92785356748847295}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -4, y: -4}
+  m_Pivot: {x: 1, y: 0}
+--- !u!222 &5126964459055183890
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6334649772191767841}
+  m_CullTransparentMesh: 1
+--- !u!114 &5500761304066541822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6334649772191767841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text:
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ffc81b96d71d7544580ef63e2d508f02, type: 2}
+  m_sharedMaterial: {fileID: 8572051279392437555, guid: ffc81b96d71d7544580ef63e2d508f02, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &6586082324730229700
 GameObject:
   m_ObjectHideFlags: 0
@@ -411,8 +546,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -443,6 +578,7 @@ GameObject:
   - component: {fileID: 7168428493043215327}
   - component: {fileID: 8760139193141941973}
   - component: {fileID: 6891701966897057378}
+  - component: {fileID: 6027007272079817649}
   m_Layer: 5
   m_Name: ItemDisplay
   m_TagString: Untagged
@@ -465,6 +601,7 @@ RectTransform:
   - {fileID: 152830575182696564}
   - {fileID: 597445950441956786}
   - {fileID: 2178722248321337718}
+  - {fileID: 3850845667392149591}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -491,8 +628,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.79607844}
   m_RaycastTarget: 1
@@ -521,8 +658,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 0
     m_WrapAround: 0
@@ -556,7 +693,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: 
+        m_TargetAssemblyTypeName:
         m_MethodName: Press
         m_Mode: 1
         m_Arguments:
@@ -564,6 +701,21 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument:
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &6027007272079817649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6875637879080599341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c6a5b67335142b1a1a58f3f2130588f, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  ItemImage: {fileID: 1236023188648638431}
+  _countLabel: {fileID: 5500761304066541822}
+  _item: {fileID: 0}

--- a/Assets/Content/Systems/UI/Systems/Containers/Inventory/ItemGridItem.prefab
+++ b/Assets/Content/Systems/UI/Systems/Containers/Inventory/ItemGridItem.prefab
@@ -1,5 +1,140 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &859462700497103684
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2159471916070152491}
+  - component: {fileID: 5413577247828650040}
+  - component: {fileID: 3945543867636487868}
+  m_Layer: 0
+  m_Name: CountLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2159471916070152491
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 859462700497103684}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2088895497220639249}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -4, y: -4}
+  m_Pivot: {x: 1, y: 0}
+--- !u!222 &5413577247828650040
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 859462700497103684}
+  m_CullTransparentMesh: 1
+--- !u!114 &3945543867636487868
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 859462700497103684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text:
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ffc81b96d71d7544580ef63e2d508f02, type: 2}
+  m_sharedMaterial: {fileID: 8572051279392437555, guid: ffc81b96d71d7544580ef63e2d508f02, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7823076622193320381
 GameObject:
   m_ObjectHideFlags: 0
@@ -13,7 +148,7 @@ GameObject:
   - component: {fileID: 4925832067615311047}
   - component: {fileID: 2956964429035123954}
   m_Layer: 5
-  m_Name: Item Grid Item
+  m_Name: ItemGridItem
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -29,8 +164,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5108135920989335516}
+  - {fileID: 2159471916070152491}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -57,11 +194,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -86,10 +224,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6c6a5b67335142b1a1a58f3f2130588f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ItemImage: {fileID: 7428052278835698613}
-  item: {fileID: 0}
+  _countLabel: {fileID: 3945543867636487868}
+  _item: {fileID: 0}
 --- !u!1 &8243702456906174611
 GameObject:
   m_ObjectHideFlags: 0
@@ -118,6 +257,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2088895497220639249}
   m_RootOrder: 0
@@ -145,11 +285,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:

--- a/Assets/Content/WorldObjects/Items/Functional/Materials/SteelSheet.prefab
+++ b/Assets/Content/WorldObjects/Items/Functional/Materials/SteelSheet.prefab
@@ -49,7 +49,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2998748595629600617}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -93,7 +93,7 @@ BoxCollider:
   m_GameObject: {fileID: 2998748595629600617}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Size: {x: 0.56320024, y: 0.052940927, z: 0.8080486}
   m_Center: {x: 0, y: 0.000000010244548, z: 0}
@@ -194,6 +194,75 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.56320024, y: 0.052940927, z: 0.8080486}
   m_Center: {x: 0, y: 0.000000010244548, z: 0}
+--- !u!1 &7066774158076645046
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2782603207321740056}
+  - component: {fileID: 4065242854770538835}
+  m_Layer: 0
+  m_Name: StackContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2782603207321740056
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7066774158076645046}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6104867219766065872}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4065242854770538835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7066774158076645046}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25696236470760b41b375e9b6939444c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  _componentIndexCache: 4
+  _addedNetworkObject: {fileID: 1773710978803455870}
+  _networkObjectCache: {fileID: 1773710978803455870}
+  _automaticContainerSetUp: 0
+  ContainerInteractive: {fileID: 0}
+  ContainerItemDisplay: {fileID: 0}
+  ContainerUi: {fileID: 0}
+  _attachmentOffset: {x: 0, y: 0, z: 0}
+  _onlyStoreWhenOpen: 0
+  _openWhenContainerViewed: 0
+  _attachItems: 1
+  _initialized: 0
+  _maxDistance: 5
+  _isOpenable: 0
+  _isInteractive: 0
+  _hasUi: 0
+  _hasCustomInteraction: 0
+  _hasCustomDisplay: 0
+  _displays: []
+  _numberDisplay: 0
+  _displayAsSlotInUI: 0
+  _size: {x: 2, y: 1}
+  _hideItems: 1
+  _type: 0
+  _startFilter: {fileID: 0}
 --- !u!1 &7125681683583715523
 GameObject:
   m_ObjectHideFlags: 0
@@ -209,6 +278,7 @@ GameObject:
   - component: {fileID: 5296084984690686628}
   - component: {fileID: 1034747657592807112}
   - component: {fileID: 326915721417618478}
+  - component: {fileID: 3069378332302435215}
   m_Layer: 10
   m_Name: SteelSheet
   m_TagString: Untagged
@@ -232,6 +302,7 @@ Transform:
   - {fileID: 8776331283961773675}
   - {fileID: 7890132554308283268}
   - {fileID: 8950997782536062791}
+  - {fileID: 2782603207321740056}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -261,8 +332,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a2836e36774ca1c4bbbee976e17b649c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   _componentIndexCache: 0
   _addedNetworkObject: {fileID: 1773710978803455870}
   _networkObjectCache: {fileID: 1773710978803455870}
@@ -306,14 +377,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 26b716c41e9b56b4baafaf13a523ba2e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   <IsNested>k__BackingField: 0
   <ComponentIndex>k__BackingField: 0
   <PredictedSpawn>k__BackingField: {fileID: 0}
   _networkBehaviours:
   - {fileID: 2568864249795578972}
   - {fileID: 5296084984690686628}
+  - {fileID: 326915721417618478}
+  - {fileID: 3069378332302435215}
+  - {fileID: 4065242854770538835}
   <ParentNetworkObject>k__BackingField: {fileID: 0}
   <ChildNetworkObjects>k__BackingField: []
   SerializedTransformProperties:
@@ -325,7 +399,7 @@ MonoBehaviour:
   _initializeOrder: 0
   _defaultDespawnType: 0
   NetworkObserver: {fileID: 0}
-  <PrefabId>k__BackingField: 43
+  <PrefabId>k__BackingField: 46
   <SpawnableCollectionId>k__BackingField: 0
   _scenePathHash: 0
   <SceneId>k__BackingField: 0
@@ -340,8 +414,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cf76e303c1b57ae4ebbf08dab5bbddc2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   _componentIndexCache: 1
   _addedNetworkObject: {fileID: 1773710978803455870}
   _networkObjectCache: {fileID: 1773710978803455870}
@@ -363,8 +437,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e00534faac6488c47893490f2bf4c5a2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &326915721417618478
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -375,11 +449,31 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 49d37ab5b82ded9419a6e3ab3d05af02, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _componentIndexCache: 255
+  m_Name:
+  m_EditorClassIdentifier:
+  _componentIndexCache: 2
   _addedNetworkObject: {fileID: 1773710978803455870}
-  _networkObjectCache: {fileID: 0}
+  _networkObjectCache: {fileID: 1773710978803455870}
+--- !u!114 &3069378332302435215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7125681683583715523}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ef42ef955e1886545b613d9a520b1691, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  _componentIndexCache: 3
+  _addedNetworkObject: {fileID: 1773710978803455870}
+  _networkObjectCache: {fileID: 1773710978803455870}
+  _maxStack: 3
+  _stackContainer: {fileID: 4065242854770538835}
+  _visualCopies:
+  - {fileID: 2998748595629600617}
+  - {fileID: 7393894785072713980}
 --- !u!1 &7393894785072713980
 GameObject:
   m_ObjectHideFlags: 0
@@ -429,7 +523,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7393894785072713980}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -473,7 +567,7 @@ BoxCollider:
   m_GameObject: {fileID: 7393894785072713980}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Size: {x: 0.56320024, y: 0.052940927, z: 0.8080486}
   m_Center: {x: 0, y: 0.000000010244548, z: 0}

--- a/Assets/Scripts/SS3D/Systems/Furniture/LockLockerInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/LockLockerInteraction.cs
@@ -28,7 +28,7 @@ namespace SS3D.Systems.Inventory.Interactions
             return "Lock Locker";
         }
 
-        public string GetGenericName() => throw new NotImplementedException();
+        public string GetGenericName() => throw new System.NotImplementedException();
 
         public Sprite GetIcon(InteractionEvent interactionEvent)
         {

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/AttachedContainer.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/AttachedContainer.cs
@@ -361,6 +361,11 @@ namespace SS3D.Systems.Inventory.Containers
 		/// <returns>If the item was added</returns>
 		public bool AddItem(Item item)
 		{
+            if (TryMergeItemIntoAnyStack(item))
+            {
+                return true;
+            }
+
 			// TODO: Use a more efficient algorithm
 			for (int y = 0; y < Size.y; y++)
 			{
@@ -381,9 +386,93 @@ namespace SS3D.Systems.Inventory.Containers
         /// </summary>
         public bool TransferItemToOther(Item item, Vector2Int position, AttachedContainer other)
         {
-            if (!FindItem(item, out int index)) return false;
-            if(!RemoveStoredItem(index)) return false;
-            return other.AddStoredItem(new StoredItem(item, position));
+            if (other == null || !FindItem(item, out int index))
+            {
+                return false;
+            }
+
+            if (other.TryMergeItemIntoPosition(item, position, out bool handled))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(other, this))
+            {
+                return MoveItemWithinContainer(item, index, position);
+            }
+
+            if (handled || !other.CanAddItemToEmptyPosition(item, position))
+            {
+                return false;
+            }
+
+            StoredItem originalItem = _storedItems[index];
+            if (!RemoveStoredItem(index))
+            {
+                return false;
+            }
+
+            if (other.AddStoredItem(new StoredItem(item, position)))
+            {
+                return true;
+            }
+
+            AddStoredItem(originalItem);
+            return false;
+        }
+
+        private bool MoveItemWithinContainer(Item item, int index, Vector2Int position)
+        {
+            if (!AreSlotCoordinatesInGrid(position))
+            {
+                return false;
+            }
+
+            Item targetItem = ItemAt(position);
+            if (targetItem != null)
+            {
+                return targetItem == item;
+            }
+
+            if (!CanRemoveItem(item))
+            {
+                return false;
+            }
+
+            ReplaceStoredItem(new StoredItem(item, position), index);
+            return true;
+        }
+
+        /// <summary>
+        /// Transfer an item to the first compatible stack or empty slot in another container.
+        /// </summary>
+        public bool TransferItemToOther(Item item, AttachedContainer other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            foreach (Vector2Int occupiedPosition in other.OccupiedPositions())
+            {
+                if (TransferItemToOther(item, occupiedPosition, other))
+                {
+                    return true;
+                }
+            }
+
+            for (int y = 0; y < other.Size.y; y++)
+            {
+                for (int x = 0; x < other.Size.x; x++)
+                {
+                    if (TransferItemToOther(item, new Vector2Int(x, y), other))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
 		/// <summary>
@@ -449,6 +538,127 @@ namespace SS3D.Systems.Inventory.Containers
             newItem.Item.SetContainer(this);
             return true;
 		}
+
+        private bool CanAddItemToEmptyPosition(Item item, Vector2Int position)
+        {
+            return AreSlotCoordinatesInGrid(position)
+                   && ItemAt(position) == null
+                   && CanContainItem(item)
+                   && !ReferenceEquals(item.Container, this);
+        }
+
+        public bool CanAcceptItem(Item item)
+        {
+            if (item == null)
+            {
+                return false;
+            }
+
+            if (CanContainItem(item))
+            {
+                return true;
+            }
+
+            return CanMergeItemIntoAnyStack(item);
+        }
+
+        private bool TryMergeItemIntoPosition(Item item, Vector2Int position, out bool handled)
+        {
+            handled = false;
+
+            if (ContainerType == ContainerType.Hand)
+            {
+                return false;
+            }
+
+            if (!AreSlotCoordinatesInGrid(position))
+            {
+                return false;
+            }
+
+            Item targetItem = ItemAt(position);
+            if (targetItem == null)
+            {
+                return false;
+            }
+
+            handled = true;
+
+            if (!targetItem.TryGetStackable(out Stackable targetStack)
+                || !item.TryGetStackable(out Stackable sourceStack)
+                || !targetStack.CanMergeFrom(sourceStack))
+            {
+                return false;
+            }
+
+            if (!CanStoreItem(item)
+                || item.GetComponentsInChildren<AttachedContainer>().AsEnumerable().Contains(this)
+                || (bool)GetComponents<IStorageCondition>()?.Any(x => !x.CanStore(this, item)))
+            {
+                return false;
+            }
+
+            if (item.Container != null && !item.Container.CanRemoveItem(item))
+            {
+                return false;
+            }
+
+            if (targetStack.MergeFrom(sourceStack) <= 0)
+            {
+                return false;
+            }
+
+            InvokeOnContentChanged(targetItem, targetItem, ContainerChangeType.Move);
+            return true;
+        }
+
+        private bool TryMergeItemIntoAnyStack(Item item)
+        {
+            foreach (Vector2Int position in OccupiedPositions())
+            {
+                if (TryMergeItemIntoPosition(item, position, out _))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool CanMergeItemIntoAnyStack(Item item)
+        {
+            if (ContainerType == ContainerType.Hand)
+            {
+                return false;
+            }
+
+            if (item == null)
+            {
+                return false;
+            }
+
+            foreach (Vector2Int position in OccupiedPositions())
+            {
+                Item targetItem = ItemAt(position);
+                if (targetItem != null
+                    && targetItem.TryGetStackable(out Stackable targetStack)
+                    && item.TryGetStackable(out Stackable sourceStack)
+                    && targetStack.CanMergeFrom(sourceStack))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private IEnumerable<Vector2Int> OccupiedPositions()
+        {
+            foreach (StoredItem storedItem in _storedItems)
+            {
+                yield return storedItem.Position;
+            }
+        }
 
 		/// <summary>
 		/// Correctly set a storeItem in the container at the given index. All replacing should use this method, never do it directly.

--- a/Assets/Scripts/SS3D/Systems/Inventory/Containers/HumanInventory.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Containers/HumanInventory.cs
@@ -371,13 +371,20 @@ namespace SS3D.Systems.Inventory.Containers
             {
                 if (item != null)
                 {
-                    ClientTransferItem(item, Vector2Int.zero, Hands.SelectedHand.Container);
+                    if (item.TryGetStackable(out Stackable stackable) && stackable.Amount > 1)
+                    {
+                        ClientTakeOneFromStack(item);
+                    }
+                    else
+                    {
+                        ClientTransferItem(item, Vector2Int.zero, Hands.SelectedHand.Container);
+                    }
                 }
             }
             // If selected hand has an item and there's no item on the slot in the container, transfer it to container slot.
             else
             {
-                if (item == null)
+                if (item == null || item.TryGetStackable(out Stackable stackable) && stackable.CanStackWith(Hands.SelectedHand.ItemInHand))
                 {
                     ClientTransferItem(Hands.SelectedHand.ItemInHand, position, container);
                 }
@@ -399,6 +406,44 @@ namespace SS3D.Systems.Inventory.Containers
                 return false;
             }
             return id.HasPermission(permission);
+        }
+
+        public void ClientTakeOneFromStack(Item stackItem)
+        {
+            CmdTakeOneFromStack(stackItem.gameObject);
+        }
+
+        [ServerRpc]
+        private void CmdTakeOneFromStack(GameObject stackObject)
+        {
+            Item stackItem = stackObject.GetComponent<Item>();
+            if (stackItem == null || !stackItem.TryGetStackable(out Stackable stackable) || stackable.Amount <= 1)
+            {
+                return;
+            }
+
+            AttachedContainer sourceContainer = stackItem.Container;
+            if (sourceContainer == null || !containerViewer.CanModifyContainer(sourceContainer))
+            {
+                return;
+            }
+
+            if (!sourceContainer.CanRemoveItem(stackItem))
+            {
+                return;
+            }
+
+            Hands hands = GetComponent<Hands>();
+            if (hands == null || !hands.SelectedHand.IsEmpty() || !hands.SelectedHand.CanInteract(sourceContainer.gameObject))
+            {
+                return;
+            }
+
+            Item splitItem = stackable.TakeOne();
+            if (splitItem != null)
+            {
+                hands.SelectedHand.Pickup(splitItem);
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/SS3D/Systems/Inventory/Interactions/StoreInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Interactions/StoreInteraction.cs
@@ -65,7 +65,7 @@ namespace SS3D.Systems.Inventory.Interactions
 
         private bool CanStore(Item item, AttachedContainer target)
         {
-            return target.CanContainItem(item);
+            return target.CanAcceptItem(item);
         }
 
         public bool Start(InteractionEvent interactionEvent, InteractionReference reference)
@@ -77,8 +77,7 @@ namespace SS3D.Systems.Inventory.Interactions
                 Hands hands = sourceGameObjectProvider.GameObject.GetComponentInParent<Hands>();
                 Item item = hands.SelectedHand.ItemInHand;
 
-                hands.SelectedHand.Container.Dump();
-                _attachedContainer.AddItem(item);
+                hands.SelectedHand.Container.TransferItemToOther(item, _attachedContainer);
             }
 
             return false;

--- a/Assets/Scripts/SS3D/Systems/Inventory/Interactions/TakeOneFromStackInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Interactions/TakeOneFromStackInteraction.cs
@@ -1,0 +1,64 @@
+using SS3D.Data;
+using SS3D.Data.Generated;
+using SS3D.Interactions;
+using SS3D.Interactions.Extensions;
+using SS3D.Interactions.Interfaces;
+using SS3D.Systems.Inventory.Containers;
+using SS3D.Systems.Inventory.Items;
+using UnityEngine;
+
+namespace SS3D.Systems.Inventory.Interactions
+{
+    public sealed class TakeOneFromStackInteraction : IInteraction, IClientInteractionSource
+    {
+        private readonly Stackable _stackable;
+
+        public TakeOneFromStackInteraction(Stackable stackable)
+        {
+            _stackable = stackable;
+        }
+
+        public string GetName(InteractionEvent interactionEvent)
+        {
+            return "Take one";
+        }
+
+        public string GetGenericName() => "Take one";
+
+        public Sprite GetIcon(InteractionEvent interactionEvent)
+        {
+            return Assets.Get<Sprite>(AssetDatabases.InteractionIcons, InteractionIcons.Take);
+        }
+
+        public bool CanInteract(InteractionEvent interactionEvent)
+        {
+            if (_stackable == null || _stackable.Amount <= 1)
+            {
+                return false;
+            }
+
+            if (!InteractionExtensions.RangeCheck(interactionEvent))
+            {
+                return false;
+            }
+
+            return interactionEvent.Source is Hand hand && hand.IsEmpty();
+        }
+
+        public bool Start(InteractionEvent interactionEvent, InteractionReference reference)
+        {
+            if (interactionEvent.Source is not Hand hand || !hand.IsEmpty())
+            {
+                return false;
+            }
+
+            Item item = _stackable.TakeOne();
+            if (item != null)
+            {
+                hand.Pickup(item);
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/SS3D/Systems/Inventory/Interactions/TakeOneFromStackInteraction.cs.meta
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Interactions/TakeOneFromStackInteraction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6dfb0067fd26e54983ee3f428b63991
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Item.cs
@@ -86,6 +86,8 @@ namespace SS3D.Systems.Inventory.Items
         public AttachedContainer Container => _container;
 
         private bool _initialised = false;
+
+        private bool _visible = true;
         
         /// <summary>
         /// All colliders, related to the item, except of colliders, related to stored items
@@ -121,6 +123,13 @@ namespace SS3D.Systems.Inventory.Items
         }
 
         public Item Prefab => Asset ? Assets.Get<Item>(Asset) : null;
+
+        public bool IsStackable => TryGetStackable(out _);
+
+        public bool TryGetStackable(out Stackable stackable)
+        {
+            return TryGetComponent(out stackable);
+        }
 
         /// <summary>
         /// Initialise this item fields. Can only be called once.
@@ -178,6 +187,13 @@ namespace SS3D.Systems.Inventory.Items
                 collidersToExcept.AddRange(item.GetComponentsInChildren<Collider>());
             }
             return GetComponentsInChildren<Collider>().Except(collidersToExcept).ToArray();
+        }
+
+        private Renderer[] GetNativeRenderers()
+        {
+            return GetComponentsInChildren<Renderer>(true)
+                .Where(renderer => renderer.GetComponentInParent<Item>() == this)
+                .ToArray();
         }
 
         public override void OnStartServer()
@@ -255,9 +271,8 @@ namespace SS3D.Systems.Inventory.Items
         [ServerOrClient]
         public void SetVisibility(bool visible)
         {
-            // TODO: Make this handle multiple renderers, with different states
-            Renderer[] renderers = GetComponentsInChildren<Renderer>();
-            foreach (Renderer childRenderer in renderers)
+            _visible = visible;
+            foreach (Renderer childRenderer in GetNativeRenderers())
             {
                 childRenderer.enabled = visible;
             }
@@ -265,13 +280,16 @@ namespace SS3D.Systems.Inventory.Items
 
         public bool IsVisible()
         {
-            // TODO: Make this handle multiple renderers
-            Renderer component = GetComponent<Renderer>();
-            return component != null && component.enabled;
+            return _visible;
         }
 
         public virtual IInteraction[] CreateTargetInteractions(InteractionEvent interactionEvent)
         {
+            if (TryGetStackable(out Stackable stackable) && stackable.Amount > 1)
+            {
+                return new IInteraction[] { new PickupInteraction { Icon = null }, new TakeOneFromStackInteraction(stackable) };
+            }
+
             return new IInteraction[] { new PickupInteraction { Icon = null } };
         }
 

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/ItemSubSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/ItemSubSystem.cs
@@ -59,6 +59,12 @@ namespace SS3D.Systems.Inventory.Items
             SpawnItemInContainer(id.Name, attachedContainer);
         }
 
+        [ServerRpc(RequireOwnership = false)]
+        public void CmdSpawnItemInContainerById(string id, AttachedContainer attachedContainer)
+        {
+            SpawnItemInContainer(id, attachedContainer);
+        }
+
         /// <summary>
         /// Spawns an Item inside a container.
         ///

--- a/Assets/Scripts/SS3D/Systems/Inventory/Items/Stackable.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/Items/Stackable.cs
@@ -1,52 +1,314 @@
-﻿namespace SS3D.Systems.Inventory.Items
+using System;
+using System.Linq;
+using FishNet.Object;
+using FishNet.Object.Synchronizing;
+using SS3D.Systems.Inventory.Containers;
+using UnityEngine;
+
+namespace SS3D.Systems.Inventory.Items
 {
-  //   [RequireComponent(typeof(Item))]
-  //   public class Stackable : SpessBehaviour, IExaminable
-  //   {
-  //       public int maxStack;
-  //       public int amountInStack;
-        // private IExamineRequirement requirements;
-  //
-        // protected override void OnStart()
-        // {
-        //     base.OnStart();
-  //
-        //     PopulateRequirements();
-        // }
-  //
-        // private void PopulateRequirements()
-        // {
-        //     // Populate requirements for this item to be examined.
-        //     requirements = new ReqPermitExamine(gameObject);
-        //     requirements = new ReqMaxRange(requirements, 2.0f);  // Amount in stack only visible from 2 metres.
-        //     requirements = new ReqObstacleCheck(requirements);
-        // }
-  //
-        // private void OnValidate()
-  //       {
-  //           if (maxStack < 2)
-  //           {
-  //               maxStack = 2;
-  //           }
-  //
-  //           if (amountInStack < 1)
-  //           {
-  //               amountInStack = 1;
-  //           }
-  //           else if (amountInStack > maxStack)
-  //           {
-  //               amountInStack = maxStack;
-  //           }
-  //       }
-  //
-        // public IExamineData GetData()
-        // {
-        //     return new DataNameDescription("", $"{amountInStack} in stack");
-        // }
-        //
-        // public IExamineRequirement GetRequirements()
-        // {
-        //     return requirements;
-        // }
-  //   }
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Item))]
+    public class Stackable : NetworkBehaviour
+    {
+        [SerializeField, Min(2)]
+        private int _maxStack = 2;
+
+        [SerializeField, HideInInspector]
+        private AttachedContainer _stackContainer;
+
+        [SerializeField]
+        private GameObject[] _visualCopies = Array.Empty<GameObject>();
+
+        [SyncVar(OnChange = nameof(SyncAmount))]
+        private int _amount = 1;
+
+        private Item _item;
+
+        public int MaxStack => Mathf.Max(2, _maxStack);
+
+        public AttachedContainer StackContainer => _stackContainer;
+
+        public GameObject[] VisualCopies => _visualCopies;
+
+        // Use the local container count until the replicated amount catches up.
+        public int Amount => Math.Max(_amount, LocalAmount);
+
+        public int AvailableSpace => Mathf.Max(0, MaxStack - Amount);
+
+        public bool IsFull => AvailableSpace == 0;
+
+        public Item Item => _item != null ? _item : _item = GetComponent<Item>();
+
+        public event Action<Stackable> OnAmountChanged;
+
+        private int LocalAmount => 1 + (_stackContainer != null ? _stackContainer.ItemCount : 0);
+
+        private void Awake()
+        {
+            _item = GetComponent<Item>();
+            _amount = LocalAmount;
+            SubscribeToContainer();
+            UpdateVisualCopies();
+        }
+
+        private void OnEnable()
+        {
+            SubscribeToContainer();
+        }
+
+        private void OnDisable()
+        {
+            if (_stackContainer != null)
+            {
+                _stackContainer.OnContentsChanged -= HandleStackContainerChanged;
+            }
+        }
+
+        private void OnValidate()
+        {
+            _maxStack = Mathf.Max(2, _maxStack);
+            UpdateVisualCopies();
+        }
+
+        public void Init(int maxStack, AttachedContainer stackContainer = null)
+        {
+            Init(maxStack, stackContainer, _visualCopies);
+        }
+
+        public void Init(int maxStack, AttachedContainer stackContainer, GameObject[] visualCopies)
+        {
+            _maxStack = Mathf.Max(2, maxStack);
+            _stackContainer = stackContainer;
+            _visualCopies = visualCopies ?? Array.Empty<GameObject>();
+            SubscribeToContainer();
+            UpdateVisualCopies();
+        }
+
+        public bool CanStackWith(Item other)
+        {
+            return other != null
+                   && other.TryGetStackable(out Stackable otherStackable)
+                   && CanStackWith(otherStackable);
+        }
+
+        public bool CanStackWith(Stackable other)
+        {
+            if (other == null || other == this)
+            {
+                return false;
+            }
+
+            Item thisItem = Item;
+            Item otherItem = other.Item;
+
+            if (thisItem.Asset != null || otherItem.Asset != null)
+            {
+                return thisItem.Asset != null
+                       && otherItem.Asset != null
+                       && thisItem.Asset.Equals(otherItem.Asset);
+            }
+
+            return thisItem.Name == otherItem.Name;
+        }
+
+        [Server]
+        public int MergeFrom(Stackable source)
+        {
+            if (!CanMergeFrom(source))
+            {
+                return 0;
+            }
+
+            int amountToMove = Math.Min(AvailableSpace, source.Amount);
+            int moved = MoveContainedItems(source, amountToMove);
+
+            if (moved < amountToMove)
+            {
+                moved += MoveVisibleItem(source);
+            }
+
+            NotifyAmountChanged();
+            source.NotifyAmountChanged();
+            return moved;
+        }
+
+        [Server]
+        public Item TakeOne()
+        {
+            return Split(1).FirstOrDefault();
+        }
+
+        [Server]
+        public Item[] Split(int amount)
+        {
+            if (amount <= 0 || Amount <= 1 || _stackContainer == null)
+            {
+                return Array.Empty<Item>();
+            }
+
+            int amountToTake = Math.Min(amount, Amount - 1);
+            Item[] items = _stackContainer.Items.Reverse().Take(amountToTake).ToArray();
+
+            foreach (Item item in items)
+            {
+                _stackContainer.RemoveItem(item);
+            }
+
+            NotifyAmountChanged();
+            return items;
+        }
+
+        public bool CanMergeFrom(Stackable source)
+        {
+            return source != null
+                   && CanStackWith(source)
+                   && AvailableSpace > 0
+                   && _stackContainer != null;
+        }
+
+        private int MoveContainedItems(Stackable source, int amountToMove)
+        {
+            if (source._stackContainer == null)
+            {
+                return 0;
+            }
+
+            int moved = 0;
+            foreach (Item containedItem in source._stackContainer.Items.ToArray())
+            {
+                if (moved >= amountToMove)
+                {
+                    break;
+                }
+
+                if (source._stackContainer.TransferItemToOther(containedItem, NextStackPosition(), _stackContainer))
+                {
+                    moved++;
+                }
+            }
+
+            return moved;
+        }
+
+        private int MoveVisibleItem(Stackable source)
+        {
+            Item sourceItem = source.Item;
+            AttachedContainer sourceContainer = sourceItem.Container;
+
+            if (sourceContainer == null)
+            {
+                return _stackContainer.AddItemPosition(sourceItem, NextStackPosition()) ? 1 : 0;
+            }
+
+            return sourceContainer.TransferItemToOther(sourceItem, NextStackPosition(), _stackContainer) ? 1 : 0;
+        }
+
+        private Vector2Int NextStackPosition()
+        {
+            if (_stackContainer == null)
+            {
+                return Vector2Int.zero;
+            }
+
+            for (int y = 0; y < _stackContainer.Size.y; y++)
+            {
+                for (int x = 0; x < _stackContainer.Size.x; x++)
+                {
+                    Vector2Int position = new(x, y);
+                    if (_stackContainer.ItemAt(position) == null)
+                    {
+                        return position;
+                    }
+                }
+            }
+
+            return Vector2Int.zero;
+        }
+
+        private void SubscribeToContainer()
+        {
+            if (_stackContainer == null)
+            {
+                return;
+            }
+
+            _stackContainer.OnContentsChanged -= HandleStackContainerChanged;
+            _stackContainer.OnContentsChanged += HandleStackContainerChanged;
+        }
+
+        private void HandleStackContainerChanged(AttachedContainer container, Item oldItem, Item newItem, ContainerChangeType type)
+        {
+            NotifyAmountChanged();
+        }
+
+        private void NotifyAmountChanged()
+        {
+            _amount = LocalAmount;
+            bool isServer = HasNetworkObject() && IsServer;
+            bool isSpawned = HasNetworkObject() && IsSpawned;
+            ApplyAmountChanged();
+
+            if (isServer && isSpawned)
+            {
+                RpcSyncAmount(_amount);
+            }
+        }
+
+        private void SyncAmount(int oldAmount, int newAmount, bool asServer)
+        {
+            ApplyAmountChanged();
+        }
+
+        [ObserversRpc(BufferLast = true, RunLocally = true)]
+        private void RpcSyncAmount(int amount)
+        {
+            _amount = amount;
+            ApplyAmountChanged();
+        }
+
+        private void ApplyAmountChanged()
+        {
+            UpdateVisualCopies();
+            OnAmountChanged?.Invoke(this);
+        }
+
+        private bool HasNetworkObject()
+        {
+            try
+            {
+                return NetworkObject != null;
+            }
+            catch (NullReferenceException)
+            {
+                return false;
+            }
+        }
+
+        private void UpdateVisualCopies()
+        {
+            if (_visualCopies == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < _visualCopies.Length; i++)
+            {
+                if (_visualCopies[i] != null)
+                {
+                    bool active = i < Amount - 1;
+                    _visualCopies[i].SetActive(active);
+                    foreach (Renderer renderer in _visualCopies[i].GetComponentsInChildren<Renderer>(true))
+                    {
+                        renderer.enabled = active && Item.IsVisible();
+                    }
+
+                    foreach (Collider collider in _visualCopies[i].GetComponentsInChildren<Collider>(true))
+                    {
+                        collider.enabled = false;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Assets/Scripts/SS3D/Systems/Inventory/UI/ItemDisplay.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/UI/ItemDisplay.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using UnityEngine.InputSystem;
+using TMPro;
 
 namespace SS3D.Systems.Inventory.UI
 {
@@ -14,6 +15,7 @@ namespace SS3D.Systems.Inventory.UI
     public class ItemDisplay : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler, IPointerDownHandler, IPointerClickHandler
     {
         public Image ItemImage;
+        [SerializeField] private TMP_Text _countLabel;
         [NonSerialized] public bool ShouldDrop;
         [NonSerialized] public Vector3 OldPosition;
 
@@ -33,13 +35,16 @@ namespace SS3D.Systems.Inventory.UI
             get => _item;
             set
             {
+                UnsubscribeFromStack();
                 _item = value;
+                SubscribeToStack();
                 UpdateDisplay();
             }
         }
 
         public void Start()
         {
+            EnsureDisplayReferences();
             _slotImage = GetComponent<Image>();
             if (!_outlineInner)
             {
@@ -55,11 +60,21 @@ namespace SS3D.Systems.Inventory.UI
             }
             if (_item != null)
             {
+                SubscribeToStack();
                 UpdateDisplay();
             }
         }
 
-        public virtual void OnDropAccepted() { }
+        private void OnDestroy()
+        {
+            UnsubscribeFromStack();
+        }
+
+        public virtual void OnDropAccepted()
+        {
+            RestoreDragOrigin();
+            MakeVisible(true);
+        }
 
         public void OnPointerDown(PointerEventData eventData)
         {
@@ -114,14 +129,13 @@ namespace SS3D.Systems.Inventory.UI
 
             _slotImage.raycastTarget = true;
 
-            transform.SetParent(_oldParent, false);
-            GetComponent<RectTransform>().localPosition = OldPosition;
-
             if (ShouldDrop)
             {
                 OnDropAccepted();
                 return;
             }
+
+            RestoreDragOrigin();
 
             // If the raycast did not hit any element from the UI, drop the item out of the inventory.
             GameObject o = eventData.pointerCurrentRaycast.gameObject;
@@ -133,8 +147,10 @@ namespace SS3D.Systems.Inventory.UI
 
         private void UpdateDisplay()
         {
+            EnsureDisplayReferences();
             if(ItemImage == null)
             {
+                UpdateCountLabel();
                 return;
             }
             ItemImage.sprite = Item != null ? Item.ItemSprite : null;
@@ -142,6 +158,85 @@ namespace SS3D.Systems.Inventory.UI
             Color imageColor = ItemImage.color;
             imageColor.a = ItemImage.sprite != null ? 255 : 0;
             ItemImage.color = imageColor;
+            UpdateCountLabel();
+        }
+
+        public void RefreshStackCount()
+        {
+            UpdateCountLabel();
+        }
+
+        private void EnsureDisplayReferences()
+        {
+            if (ItemImage == null)
+            {
+                Transform itemImageTransform = transform.Find("ItemImage");
+                if (itemImageTransform != null)
+                {
+                    ItemImage = itemImageTransform.GetComponent<Image>();
+                }
+                else
+                {
+                    ItemImage = GetComponent<Image>();
+                }
+            }
+
+            if (_countLabel == null)
+            {
+                _countLabel = GetComponentInChildren<TMP_Text>(true);
+            }
+        }
+
+        private void RestoreDragOrigin()
+        {
+            if (_oldParent == null)
+            {
+                return;
+            }
+
+            transform.SetParent(_oldParent, false);
+            GetComponent<RectTransform>().localPosition = OldPosition;
+        }
+
+        private void SubscribeToStack()
+        {
+            if (_item != null && _item.TryGetStackable(out Stackable stackable))
+            {
+                stackable.OnAmountChanged -= HandleStackAmountChanged;
+                stackable.OnAmountChanged += HandleStackAmountChanged;
+            }
+        }
+
+        private void UnsubscribeFromStack()
+        {
+            if (_item != null && _item.TryGetStackable(out Stackable stackable))
+            {
+                stackable.OnAmountChanged -= HandleStackAmountChanged;
+            }
+        }
+
+        private void HandleStackAmountChanged(Stackable stackable)
+        {
+            UpdateCountLabel();
+        }
+
+        private void UpdateCountLabel()
+        {
+            EnsureDisplayReferences();
+            if (_countLabel == null)
+            {
+                return;
+            }
+
+            if (_item != null && _item.TryGetStackable(out Stackable stackable) && stackable.Amount > 1)
+            {
+                _countLabel.gameObject.SetActive(true);
+                _countLabel.text = stackable.Amount.ToString();
+                return;
+            }
+
+            _countLabel.text = string.Empty;
+            _countLabel.gameObject.SetActive(false);
         }
 
 		public void MakeVisible(bool visible)

--- a/Assets/Scripts/SS3D/Systems/Inventory/UI/ItemGrid.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/UI/ItemGrid.cs
@@ -119,6 +119,8 @@ namespace SS3D.Systems.Inventory.UI
                         if (gridItem.Item == newItem)
                         {
                             position = container.PositionOf(newItem);
+                            gridItem.Item = newItem;
+                            gridItem.RefreshStackCount();
                             MoveToSlot(gridItem, position);
                             break;
                         }
@@ -209,7 +211,7 @@ namespace SS3D.Systems.Inventory.UI
 
             Vector2Int slot = new(Mathf.RoundToInt(position.x - 1 / 2f), Mathf.RoundToInt(position.y - 1 / 2f));
 
-			if (!AttachedContainer.CanContainItemAtPosition(item, slot))
+			if (!CanDropItemAtSlot(item, slot))
 			{
 				return;
 			}
@@ -222,6 +224,19 @@ namespace SS3D.Systems.Inventory.UI
 			display.MakeVisible(false);
 			display.ShouldDrop = true;
             Inventory.ClientTransferItem(item, slot, AttachedContainer);
+        }
+
+        private bool CanDropItemAtSlot(Item item, Vector2Int slot)
+        {
+            Item targetItem = AttachedContainer.ItemAt(slot);
+            if (targetItem == null)
+            {
+                return AttachedContainer.CanContainItemAtPosition(item, slot);
+            }
+
+            return targetItem.TryGetStackable(out Stackable targetStack)
+                   && item.TryGetStackable(out Stackable sourceStack)
+                   && targetStack.CanMergeFrom(sourceStack);
         }
 
 		/// <summary>

--- a/Assets/Scripts/SS3D/Systems/Inventory/UI/ItemGridItem.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/UI/ItemGridItem.cs
@@ -4,10 +4,5 @@ namespace SS3D.Systems.Inventory.UI
 {
     public class ItemGridItem : ItemDisplay
     {
-        public override void OnDropAccepted()
-        {
-            base.OnDropAccepted();
-			MakeVisible(false);
-        }
     }
 }

--- a/Assets/Scripts/SS3D/Systems/Inventory/UI/SingleItemContainerSlot.cs
+++ b/Assets/Scripts/SS3D/Systems/Inventory/UI/SingleItemContainerSlot.cs
@@ -58,7 +58,7 @@ namespace SS3D.Systems.Inventory.UI
         {
             Item item = display.Item;
 
-            if (!_container.CanContainItem(display.Item))
+            if (!CanDropItem(display.Item))
             {
                 return;
             }
@@ -70,6 +70,19 @@ namespace SS3D.Systems.Inventory.UI
             display.ShouldDrop = true;
 			display.MakeVisible(false);
             Inventory.ClientTransferItem(display.Item, Vector2Int.zero, Container);
+        }
+
+        private bool CanDropItem(Item item)
+        {
+            Item targetItem = _container.ItemAt(Vector2Int.zero);
+            if (targetItem == null)
+            {
+                return _container.CanContainItem(item);
+            }
+
+            return targetItem.TryGetStackable(out Stackable targetStack)
+                   && item.TryGetStackable(out Stackable sourceStack)
+                   && targetStack.CanMergeFrom(sourceStack);
         }
 
         /// <summary>
@@ -105,7 +118,7 @@ namespace SS3D.Systems.Inventory.UI
 
         private void ContainerContentsChanged(AttachedContainer _, Item oldItem, Item newItem, ContainerChangeType type)
         {
-            if (type != ContainerChangeType.Move)
+            if (type != ContainerChangeType.Move || oldItem == newItem)
             {
                 UpdateDisplay();
             }

--- a/Assets/Scripts/Tests/EditMode/ContainerTests.cs
+++ b/Assets/Scripts/Tests/EditMode/ContainerTests.cs
@@ -5,11 +5,34 @@ using SS3D.Systems;
 using SS3D.Systems.Inventory.Containers;
 using System.Linq;
 using SS3D.Systems.Inventory.Items;
+using UnityEngine.SceneManagement;
 
 namespace EditorTests
 {
     public class ContainerTests
     {
+        private HashSet<GameObject> _sceneRootsBeforeTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _sceneRootsBeforeTest = SceneManager.GetActiveScene()
+                .GetRootGameObjects()
+                .ToHashSet();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (GameObject gameObject in SceneManager.GetActiveScene().GetRootGameObjects())
+            {
+                if (!_sceneRootsBeforeTest.Contains(gameObject))
+                {
+                    Object.DestroyImmediate(gameObject);
+                }
+            }
+        }
+
         #region Tests
         /// <summary>
         /// Test to confirm containers can have items stored in them
@@ -126,6 +149,125 @@ namespace EditorTests
             Assert.False(container.Items.Contains(neutralItem), "should only accept items with Accepted Traits");
             Assert.False(container.Items.Contains(deniedItem), "should never accept items with Denied Traits");
         }
+
+        [Test]
+        public void OccupiedSlotsRejectNormalNonStackableMoves()
+        {
+            AttachedContainer source = CreateContainer(new Vector2Int(1, 1), null);
+            AttachedContainer destination = CreateContainer(new Vector2Int(1, 1), null);
+            Item sourceItem = createItem("Source");
+            Item destinationItem = createItem("Destination");
+            source.AddItem(sourceItem);
+            destination.AddItem(destinationItem);
+
+            bool transferred = source.TransferItemToOther(sourceItem, Vector2Int.zero, destination);
+
+            Assert.False(transferred);
+            Assert.True(source.Items.Contains(sourceItem));
+            Assert.True(destination.Items.Contains(destinationItem));
+        }
+
+        [Test]
+        public void OccupiedSlotsAcceptCompatibleStackMerges()
+        {
+            AttachedContainer source = CreateContainer(new Vector2Int(1, 1), null);
+            AttachedContainer destination = CreateContainer(new Vector2Int(1, 1), null);
+            Stackable sourceStack = StackableTests.CreateStackableItem("Cable", 5);
+            Stackable destinationStack = StackableTests.CreateStackableItem("Cable", 5);
+            source.AddItem(sourceStack.Item);
+            destination.AddItem(destinationStack.Item);
+
+            bool transferred = source.TransferItemToOther(sourceStack.Item, Vector2Int.zero, destination);
+
+            Assert.True(transferred);
+            Assert.False(source.Items.Contains(sourceStack.Item));
+            Assert.True(destination.Items.Contains(destinationStack.Item));
+            Assert.AreEqual(2, destinationStack.Amount);
+        }
+
+        [Test]
+        public void TransferToContainerMergesWithCompatibleStackWhenNoSlotIsSpecified()
+        {
+            AttachedContainer source = CreateContainer(new Vector2Int(1, 1), null);
+            AttachedContainer destination = CreateContainer(new Vector2Int(1, 1), null);
+            Stackable sourceStack = StackableTests.CreateStackableItem("Cable", 5);
+            Stackable destinationStack = StackableTests.CreateStackableItem("Cable", 5);
+            source.AddItem(sourceStack.Item);
+            destination.AddItem(destinationStack.Item);
+
+            bool transferred = source.TransferItemToOther(sourceStack.Item, destination);
+
+            Assert.True(transferred);
+            Assert.False(source.Items.Contains(sourceStack.Item));
+            Assert.AreEqual(2, destinationStack.Amount);
+        }
+
+        [Test]
+        public void SpawnedStackItemMergesIntoFullContainerStack()
+        {
+            AttachedContainer destination = CreateContainer(new Vector2Int(1, 1), null);
+            Stackable destinationStack = StackableTests.CreateStackableItem("Cable", 5);
+            Stackable spawnedStack = StackableTests.CreateStackableItem("Cable", 5);
+            destination.AddItem(destinationStack.Item);
+
+            bool added = destination.AddItem(spawnedStack.Item);
+
+            Assert.True(added);
+            Assert.AreEqual(2, destinationStack.Amount);
+            Assert.False(destination.Items.Contains(spawnedStack.Item));
+            Assert.True(destinationStack.StackContainer.Items.Contains(spawnedStack.Item));
+            Assert.AreEqual(destinationStack.StackContainer, spawnedStack.Item.Container);
+        }
+
+        [Test]
+        public void StackMergeHonorsSourceRemovalConditions()
+        {
+            AttachedContainer source = CreateContainer(new Vector2Int(1, 1), null);
+            source.gameObject.AddComponent<DenyRemoveStorageCondition>();
+            AttachedContainer destination = CreateContainer(new Vector2Int(1, 1), null);
+            Stackable sourceStack = StackableTests.CreateStackableItem("Cable", 5, 2);
+            Stackable destinationStack = StackableTests.CreateStackableItem("Cable", 5);
+            source.AddItem(sourceStack.Item);
+            destination.AddItem(destinationStack.Item);
+
+            bool transferred = source.TransferItemToOther(sourceStack.Item, Vector2Int.zero, destination);
+
+            Assert.False(transferred);
+            Assert.True(source.Items.Contains(sourceStack.Item));
+            Assert.AreEqual(2, sourceStack.Amount);
+            Assert.AreEqual(1, destinationStack.Amount);
+        }
+
+        [Test]
+        public void TransferWithinSameContainerMovesItemToEmptySlot()
+        {
+            AttachedContainer container = CreateContainer(new Vector2Int(2, 1), null);
+            Item item = createItem("Source");
+            container.AddItemPosition(item, Vector2Int.zero);
+
+            bool transferred = container.TransferItemToOther(item, new Vector2Int(1, 0), container);
+
+            Assert.True(transferred);
+            Assert.AreEqual(new Vector2Int(1, 0), container.PositionOf(item));
+            Assert.AreEqual(container, item.Container);
+        }
+
+        [Test]
+        public void FailedTransferLeavesSourceContainerUnchanged()
+        {
+            AttachedContainer source = CreateContainer(new Vector2Int(1, 1), null);
+            AttachedContainer destination = CreateContainer(new Vector2Int(1, 1), null);
+            Item sourceItem = createItem("Source");
+            Item destinationItem = createItem("Destination");
+            source.AddItem(sourceItem);
+            destination.AddItem(destinationItem);
+
+            bool transferred = source.TransferItemToOther(sourceItem, Vector2Int.zero, destination);
+
+            Assert.False(transferred);
+            Assert.AreEqual(source, sourceItem.Container);
+            Assert.True(source.Items.Contains(sourceItem));
+        }
         #endregion
 
         #region Helper functions
@@ -167,6 +309,19 @@ namespace EditorTests
             var item = go.AddComponent<Item>();
             item.Init(name, weight, new List<Trait>());
             return item;
+        }
+
+        private sealed class DenyRemoveStorageCondition : MonoBehaviour, IStorageCondition
+        {
+            public bool CanStore(AttachedContainer container, Item item)
+            {
+                return true;
+            }
+
+            public bool CanRemove(AttachedContainer container, Item item)
+            {
+                return false;
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Tests/EditMode/ItemDisplayTests.cs
+++ b/Assets/Scripts/Tests/EditMode/ItemDisplayTests.cs
@@ -1,0 +1,210 @@
+using System.Reflection;
+using NUnit.Framework;
+using SS3D.Systems.Inventory.UI;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using SS3D.Systems.Inventory.Containers;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace EditorTests
+{
+    public class ItemDisplayTests
+    {
+        private HashSet<GameObject> _sceneRootsBeforeTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _sceneRootsBeforeTest = SceneManager.GetActiveScene()
+                .GetRootGameObjects()
+                .ToHashSet();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (GameObject gameObject in SceneManager.GetActiveScene().GetRootGameObjects())
+            {
+                if (!_sceneRootsBeforeTest.Contains(gameObject))
+                {
+                    UnityEngine.Object.DestroyImmediate(gameObject);
+                }
+            }
+        }
+
+        [Test]
+        public void CountLabelShowsOnlyForStackAmountsAboveOne()
+        {
+            GameObject displayObject = new("ItemDisplay");
+            ItemDisplay display = displayObject.AddComponent<ItemDisplay>();
+            display.ItemImage = new GameObject("ItemImage").AddComponent<Image>();
+            display.ItemImage.transform.SetParent(displayObject.transform);
+
+            Type tmpType = Type.GetType("TMPro.TextMeshProUGUI, Unity.TextMeshPro");
+            Assert.NotNull(tmpType);
+
+            Component countLabel = new GameObject("CountLabel").AddComponent(tmpType);
+            countLabel.transform.SetParent(displayObject.transform);
+            typeof(ItemDisplay)
+                .GetField("_countLabel", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.SetValue(display, countLabel);
+
+            display.Item = StackableTests.CreateStackableItem("Cable", 5).Item;
+
+            Assert.False(countLabel.gameObject.activeSelf);
+
+            display.Item = StackableTests.CreateStackableItem("Cable", 5, 3).Item;
+
+            Assert.True(countLabel.gameObject.activeSelf);
+            string text = (string)tmpType.GetProperty("text")?.GetValue(countLabel);
+            Assert.AreEqual("3", text);
+        }
+
+        [Test]
+        public void GridItemDropAcceptedRestoresVisibility()
+        {
+            GameObject displayObject = new("ItemGridItem");
+            displayObject.AddComponent<RectTransform>();
+            ItemGridItem display = displayObject.AddComponent<ItemGridItem>();
+            Image image = new GameObject("ItemImage").AddComponent<Image>();
+            image.transform.SetParent(displayObject.transform);
+
+            display.MakeVisible(false);
+            Assert.False(image.enabled);
+
+            display.OnDropAccepted();
+
+            Assert.True(image.enabled);
+        }
+
+        [Test]
+        public void DropAcceptedReturnsDisplayToOriginalSlot()
+        {
+            GameObject slotObject = new("Slot");
+            GameObject displayObject = new("ItemDisplay");
+            RectTransform rectTransform = displayObject.AddComponent<RectTransform>();
+            ItemDisplay display = displayObject.AddComponent<ItemDisplay>();
+
+            Image image = new GameObject("ItemImage").AddComponent<Image>();
+            image.transform.SetParent(displayObject.transform);
+
+            displayObject.transform.SetParent(new GameObject("DragRoot").transform);
+            display.OldPosition = new Vector3(12f, 8f, 0f);
+            display.MakeVisible(false);
+            typeof(ItemDisplay)
+                .GetField("_oldParent", ReflectionFlags)
+                ?.SetValue(display, slotObject.transform);
+
+            display.OnDropAccepted();
+
+            Assert.AreSame(slotObject.transform, displayObject.transform.parent);
+            Assert.AreEqual(display.OldPosition, rectTransform.localPosition);
+            Assert.True(image.enabled);
+        }
+
+        [UnityTest]
+        public IEnumerator CountLabelUpdatesWhenContainerStackMergeRefreshesExistingGridItem()
+        {
+            AttachedContainer source = StackableTests.CreateContainer(new Vector2Int(1, 1));
+            AttachedContainer destination = StackableTests.CreateContainer(new Vector2Int(1, 1));
+            var sourceStack = StackableTests.CreateStackableItem("Cable", 5);
+            var destinationStack = StackableTests.CreateStackableItem("Cable", 5);
+            source.AddItem(sourceStack.Item);
+            destination.AddItem(destinationStack.Item);
+
+            GameObject gridObject = new("ItemGrid");
+            ItemGrid grid = gridObject.AddComponent<ItemGrid>();
+            grid.AttachedContainer = destination;
+            grid.ItemDisplayPrefab = CreateDisplayPrefab();
+            grid.ItemSlotPrefab = CreateSlotPrefab();
+
+            GameObject gridLayoutObject = new("Grid");
+            gridLayoutObject.transform.SetParent(gridObject.transform);
+            GridLayoutGroup layout = gridLayoutObject.AddComponent<GridLayoutGroup>();
+            layout.cellSize = new Vector2(32, 32);
+            UnityEngine.Object.Instantiate(grid.ItemSlotPrefab, gridLayoutObject.transform);
+
+            typeof(ItemGrid)
+                .GetField("_gridLayout", ReflectionFlags)
+                ?.SetValue(grid, layout);
+
+            typeof(ItemGrid)
+                .GetMethod("CreateItemDisplay", ReflectionFlags)
+                ?.Invoke(grid, new object[] { destinationStack.Item, Vector2Int.zero, false });
+
+            Assert.True(source.TransferItemToOther(sourceStack.Item, Vector2Int.zero, destination));
+            yield return null;
+
+            TMP_TextLike label = FindCountLabel(gridObject);
+            Assert.NotNull(label.Component);
+            Assert.True(label.Component.gameObject.activeSelf);
+            Assert.AreEqual("2", label.Text);
+        }
+
+        private const BindingFlags ReflectionFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+
+        private static GameObject CreateDisplayPrefab()
+        {
+            GameObject displayObject = new("ItemDisplayPrefab");
+            displayObject.AddComponent<RectTransform>();
+            displayObject.AddComponent<Image>();
+            ItemGridItem display = displayObject.AddComponent<ItemGridItem>();
+
+            GameObject itemImageObject = new("ItemImage");
+            itemImageObject.transform.SetParent(displayObject.transform);
+            display.ItemImage = itemImageObject.AddComponent<Image>();
+
+            Type tmpType = Type.GetType("TMPro.TextMeshProUGUI, Unity.TextMeshPro");
+            Assert.NotNull(tmpType);
+            Component countLabel = new GameObject("CountLabel").AddComponent(tmpType);
+            countLabel.transform.SetParent(displayObject.transform);
+            typeof(ItemDisplay)
+                .GetField("_countLabel", ReflectionFlags)
+                ?.SetValue(display, countLabel);
+
+            return displayObject;
+        }
+
+        private static GameObject CreateSlotPrefab()
+        {
+            GameObject slotObject = new("Slot");
+            slotObject.AddComponent<RectTransform>();
+            return slotObject;
+        }
+
+        private static TMP_TextLike FindCountLabel(GameObject root)
+        {
+            Type tmpType = Type.GetType("TMPro.TextMeshProUGUI, Unity.TextMeshPro");
+            Assert.NotNull(tmpType);
+            foreach (Component component in root.GetComponentsInChildren(tmpType, true))
+            {
+                if (component.name == "CountLabel")
+                {
+                    return new TMP_TextLike(component, tmpType);
+                }
+            }
+
+            return new TMP_TextLike(null, tmpType);
+        }
+
+        private readonly struct TMP_TextLike
+        {
+            private readonly Type _type;
+
+            public TMP_TextLike(Component component, Type type)
+            {
+                Component = component;
+                _type = type;
+            }
+
+            public Component Component { get; }
+
+            public string Text => (string)_type.GetProperty("text")?.GetValue(Component);
+        }
+    }
+}

--- a/Assets/Scripts/Tests/EditMode/ItemDisplayTests.cs.meta
+++ b/Assets/Scripts/Tests/EditMode/ItemDisplayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbd499a186db11e46a9ba21fcca5a1dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/EditMode/StackableTests.cs
+++ b/Assets/Scripts/Tests/EditMode/StackableTests.cs
@@ -1,0 +1,218 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using SS3D.Systems;
+using SS3D.Systems.Inventory.Containers;
+using SS3D.Systems.Inventory.Items;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace EditorTests
+{
+    public class StackableTests
+    {
+        private HashSet<GameObject> _sceneRootsBeforeTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _sceneRootsBeforeTest = SceneManager.GetActiveScene()
+                .GetRootGameObjects()
+                .ToHashSet();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (GameObject gameObject in SceneManager.GetActiveScene().GetRootGameObjects())
+            {
+                if (!_sceneRootsBeforeTest.Contains(gameObject))
+                {
+                    Object.DestroyImmediate(gameObject);
+                }
+            }
+        }
+
+        [Test]
+        public void CompatibleItemsMerge()
+        {
+            Stackable destination = CreateStackableItem("Cable", 5);
+            Stackable source = CreateStackableItem("Cable", 5);
+            AttachedContainer sourceContainer = CreateContainer(new Vector2Int(1, 1));
+            sourceContainer.AddItem(source.Item);
+
+            int moved = destination.MergeFrom(source);
+
+            Assert.AreEqual(1, moved);
+            Assert.AreEqual(2, destination.Amount);
+            Assert.True(destination.StackContainer.Items.Contains(source.Item));
+        }
+
+        [Test]
+        public void IncompatibleItemsDoNotMerge()
+        {
+            Stackable destination = CreateStackableItem("Cable", 5);
+            Stackable source = CreateStackableItem("Glass", 5);
+            AttachedContainer sourceContainer = CreateContainer(new Vector2Int(1, 1));
+            sourceContainer.AddItem(source.Item);
+
+            int moved = destination.MergeFrom(source);
+
+            Assert.AreEqual(0, moved);
+            Assert.AreEqual(1, destination.Amount);
+            Assert.True(sourceContainer.Items.Contains(source.Item));
+        }
+
+        [Test]
+        public void MergeCapsAtMaxStack()
+        {
+            Stackable destination = CreateStackableItem("Cable", 3);
+            Stackable source = CreateStackableItem("Cable", 5, 3);
+            AttachedContainer sourceContainer = CreateContainer(new Vector2Int(1, 1));
+            sourceContainer.AddItem(source.Item);
+
+            int moved = destination.MergeFrom(source);
+
+            Assert.AreEqual(2, moved);
+            Assert.AreEqual(3, destination.Amount);
+            Assert.True(destination.IsFull);
+        }
+
+        [Test]
+        public void PartialMergeLeavesLeftoversInSource()
+        {
+            Stackable destination = CreateStackableItem("Cable", 4, 3);
+            Stackable source = CreateStackableItem("Cable", 5, 3);
+            AttachedContainer sourceContainer = CreateContainer(new Vector2Int(1, 1));
+            sourceContainer.AddItem(source.Item);
+
+            int moved = destination.MergeFrom(source);
+
+            Assert.AreEqual(1, moved);
+            Assert.AreEqual(4, destination.Amount);
+            Assert.AreEqual(2, source.Amount);
+            Assert.True(sourceContainer.Items.Contains(source.Item));
+        }
+
+        [Test]
+        public void FullMergeRemovesSourceVisibleItemFromOriginalContainer()
+        {
+            Stackable destination = CreateStackableItem("Cable", 5);
+            Stackable source = CreateStackableItem("Cable", 5, 2);
+            AttachedContainer sourceContainer = CreateContainer(new Vector2Int(1, 1));
+            sourceContainer.AddItem(source.Item);
+
+            int moved = destination.MergeFrom(source);
+
+            Assert.AreEqual(2, moved);
+            Assert.False(sourceContainer.Items.Contains(source.Item));
+            Assert.True(destination.StackContainer.Items.Contains(source.Item));
+        }
+
+        [Test]
+        public void TakeOneReducesStackAmountByOne()
+        {
+            Stackable stackable = CreateStackableItem("Cable", 5, 3);
+
+            Item taken = stackable.TakeOne();
+
+            Assert.NotNull(taken);
+            Assert.AreEqual(2, stackable.Amount);
+            Assert.False(stackable.StackContainer.Items.Contains(taken));
+        }
+
+        [Test]
+        public void SplitRemovesRequestedAmountFromStack()
+        {
+            Stackable stackable = CreateStackableItem("Cable", 5, 4);
+
+            Item[] splitItems = stackable.Split(2);
+
+            Assert.AreEqual(2, splitItems.Length);
+            Assert.AreEqual(2, stackable.Amount);
+            Assert.False(stackable.StackContainer.Items.Contains(splitItems[0]));
+            Assert.False(stackable.StackContainer.Items.Contains(splitItems[1]));
+        }
+
+        [Test]
+        public void VisualCopiesStayHiddenWhenStackItemIsHidden()
+        {
+            Stackable stackable = CreateStackableItem("Cable", 3);
+            GameObject visualCopy = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            visualCopy.transform.SetParent(stackable.transform);
+            visualCopy.SetActive(false);
+            stackable.Item.SetVisibility(false);
+
+            stackable.StackContainer.AddItem(CreateItem("Cable"));
+            stackable.Init(3, stackable.StackContainer, new[] { visualCopy });
+
+            Assert.True(visualCopy.activeSelf);
+            Assert.False(visualCopy.GetComponent<Renderer>().enabled);
+            Assert.False(visualCopy.GetComponent<Collider>().enabled);
+        }
+
+        [Test]
+        public void StoredItemsStayHiddenWhenStackItemIsShown()
+        {
+            Stackable stackable = CreateStackableItem("Cable", 3);
+            Item storedItem = CreateRenderedItem("Cable");
+            Renderer storedRenderer = storedItem.GetComponent<Renderer>();
+            stackable.StackContainer.AddItem(storedItem);
+            storedItem.SetVisibility(false);
+
+            stackable.Item.SetVisibility(false);
+            stackable.Item.SetVisibility(true);
+
+            Assert.True(stackable.Item.IsVisible());
+            Assert.False(storedRenderer.enabled);
+        }
+
+        public static Stackable CreateStackableItem(string itemName, int maxStack, int amount = 1)
+        {
+            GameObject go = new(itemName);
+            Item item = go.AddComponent<Item>();
+            item.Init(itemName, 1f, new List<Trait>());
+
+            Stackable stackable = go.AddComponent<Stackable>();
+
+            GameObject containerObject = new($"{itemName} Stack Container");
+            containerObject.transform.SetParent(go.transform);
+            AttachedContainer stackContainer = containerObject.AddComponent<AttachedContainer>();
+            stackContainer.Init(new Vector2Int(maxStack - 1, 1), null);
+            stackable.Init(maxStack, stackContainer);
+
+            for (int i = 1; i < amount; i++)
+            {
+                Item contained = CreateItem(itemName);
+                stackContainer.AddItem(contained);
+            }
+
+            return stackable;
+        }
+
+        public static AttachedContainer CreateContainer(Vector2Int size)
+        {
+            GameObject go = new();
+            AttachedContainer container = go.AddComponent<AttachedContainer>();
+            container.Init(size, null);
+            return container;
+        }
+
+        public static Item CreateItem(string itemName)
+        {
+            GameObject go = new(itemName);
+            Item item = go.AddComponent<Item>();
+            item.Init(itemName, 1f, new List<Trait>());
+            return item;
+        }
+
+        private static Item CreateRenderedItem(string itemName)
+        {
+            GameObject go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            go.name = itemName;
+            Item item = go.AddComponent<Item>();
+            item.Init(itemName, 1f, new List<Trait>());
+            return item;
+        }
+    }
+}

--- a/Assets/Scripts/Tests/EditMode/StackableTests.cs.meta
+++ b/Assets/Scripts/Tests/EditMode/StackableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 433d1f3a12b3f4a46b1b02d4451f61c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/PlayMode/Framework/AbstractTests/PlayModeTest.cs
+++ b/Assets/Scripts/Tests/PlayMode/Framework/AbstractTests/PlayModeTest.cs
@@ -28,7 +28,7 @@ namespace SS3D.Tests
     [TestFixture]
     public abstract class PlayModeTest : InputTestFixture
     {
-        protected const string ExecutableName = "SS3D";
+        protected internal const string ExecutableName = "SS3D";
         protected const string CancelButton = "Cancel";
         protected const string ReadyButtonName = "Ready";
         protected const string ServerSettingsTabName = "Server Settings";
@@ -153,6 +153,11 @@ namespace SS3D.Tests
             NetworkSettings newSettings = UnityEngine.Object.Instantiate(originalSettings);
             newSettings.NetworkType = type;
             newSettings.Ckey = "john";
+            if (type is NetworkType.Client)
+            {
+                newSettings.ServerAddress = LoadFileHelpers.IpAddress;
+                newSettings.ServerPort = ushort.Parse(LoadFileHelpers.Port);
+            }
 
             // Apply the new settings
             ScriptableSettings.SetOrOverwrite<NetworkSettings>(newSettings);
@@ -189,11 +194,26 @@ namespace SS3D.Tests
             SceneManager.LoadScene("Boot", LoadSceneMode.Single);
         }
 
-        protected void KillAllBuiltExecutables()
+        protected static void KillAllBuiltExecutables()
         {
             foreach (var process in Process.GetProcessesByName(ExecutableName))
             {
-                process.Kill();
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill();
+                        process.WaitForExit(5000);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    UnityEngine.Debug.LogWarning($"Failed to stop {ExecutableName} process {process.Id}: {exception.Message}");
+                }
+                finally
+                {
+                    process.Dispose();
+                }
             }
         }
 

--- a/Assets/Scripts/Tests/PlayMode/Framework/Helpers/TestHelpers.cs
+++ b/Assets/Scripts/Tests/PlayMode/Framework/Helpers/TestHelpers.cs
@@ -192,9 +192,7 @@ namespace SS3D.Tests
 
             foreach (Hand hand in inventory.Hands.PlayerHands.Where(hand => hand.Container.Empty))
             {
-                Item itemToSpawn = Assets.Get<GameObject>(AssetDatabases.Items, item)?.GetComponent<Item>();
-
-                itemSystem.CmdSpawnItemInContainer(itemToSpawn, hand.Container);
+                itemSystem.CmdSpawnItemInContainerById(item, hand.Container);
 
                 return hand.Container;
             }

--- a/Assets/Scripts/Tests/PlayMode/Framework/PlayModeTestRunGuard.cs
+++ b/Assets/Scripts/Tests/PlayMode/Framework/PlayModeTestRunGuard.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using NUnit.Framework.Interfaces;
+using UnityEngine;
+using UnityEngine.TestRunner;
+
+[assembly: TestRunCallback(typeof(SS3D.Tests.PlayModeTestRunGuard))]
+
+namespace SS3D.Tests
+{
+    public sealed class PlayModeTestRunGuard : ITestRunCallback
+    {
+        public void RunStarted(ITest testsToRun)
+        {
+            ConfigureEditorForPlayModeTests();
+            KillBuiltExecutables();
+        }
+
+        public void RunFinished(ITestResult testResults)
+        {
+            KillBuiltExecutables();
+        }
+
+        public void TestStarted(ITest test)
+        {
+        }
+
+        public void TestFinished(ITestResult result)
+        {
+        }
+
+        internal static void ConfigureEditorForPlayModeTests()
+        {
+#if UNITY_EDITOR
+            DisableFastScriptReloadHotReload();
+#endif
+        }
+
+        internal static void KillBuiltExecutables()
+        {
+            foreach (Process process in Process.GetProcessesByName(PlayModeTest.ExecutableName))
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill();
+                        process.WaitForExit(5000);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    UnityEngine.Debug.LogWarning($"Failed to stop {PlayModeTest.ExecutableName} process {process.Id}: {exception.Message}");
+                }
+                finally
+                {
+                    process.Dispose();
+                }
+            }
+        }
+
+#if UNITY_EDITOR
+        private static void DisableFastScriptReloadHotReload()
+        {
+            Type preferenceType = FindType("FastScriptReload.Editor.FastScriptReloadPreference");
+            if (preferenceType == null)
+            {
+                return;
+            }
+
+            SetFastScriptReloadPreference(preferenceType, "EnableAutoReloadForChangedFiles", false);
+            SetFastScriptReloadPreference(preferenceType, "EnableOnDemandReload", false);
+            SetFastScriptReloadPreference(preferenceType, "EnableExperimentalEditorHotReloadSupport", false);
+        }
+
+        private static void SetFastScriptReloadPreference(Type preferenceType, string fieldName, bool value)
+        {
+            FieldInfo field = preferenceType.GetField(fieldName, BindingFlags.Public | BindingFlags.Static);
+            object preference = field?.GetValue(null);
+            if (preference == null)
+            {
+                return;
+            }
+
+            MethodInfo setter = preference.GetType().GetMethod("SetEditorPersistedValue", BindingFlags.Public | BindingFlags.Instance);
+            setter?.Invoke(preference, new object[] { value });
+        }
+
+        private static Type FindType(string fullName)
+        {
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type type = assembly.GetType(fullName);
+                if (type != null)
+                {
+                    return type;
+                }
+            }
+
+            return null;
+        }
+#endif
+    }
+
+}

--- a/Assets/Scripts/Tests/PlayMode/Framework/PlayModeTestRunGuard.cs.meta
+++ b/Assets/Scripts/Tests/PlayMode/Framework/PlayModeTestRunGuard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 356cd7fb30742564d904056e4835c107
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/PlayMode/Framework/TemplateTests/PlaymodeTestRepository.cs
+++ b/Assets/Scripts/Tests/PlayMode/Framework/TemplateTests/PlaymodeTestRepository.cs
@@ -3,6 +3,7 @@ using SS3D.Core;
 using SS3D.Data.Generated;
 using SS3D.Systems.Entities;
 using SS3D.Systems.Entities.Humanoid;
+using SS3D.Systems.Inventory.Containers;
 using SS3D.Systems.Rounds;
 using SS3D.Systems.Screens;
 using SS3D.UI.Buttons;
@@ -119,7 +120,7 @@ namespace SS3D.Tests
             var hand = TestHelpers.LocalPlayerSpawnItemInFirstHandAvailable(Items.PDA);
             var playerPosition = TestHelpers.GetLocalPlayerPosition();
 
-            yield return new WaitForSeconds(0.2f);
+            yield return WaitUntilHandEmptyState(hand, false, "PDA did not appear in the local player's hand after spawning.");
 
             // Drop item at a close position from local player
             var itemPosition = playerPosition;
@@ -130,18 +131,25 @@ namespace SS3D.Tests
             fixture.Set(fixture.Mouse.position, target2D);
 
             // Check that player can drop and pick up item again.
-            Assert.That(!hand.Empty);
-            yield return new WaitForSeconds(0.2f);
             Debug.Log("pressing left button " + target2D);
             fixture.PressAndRelease(fixture.Mouse.leftButton);
-            yield return new WaitForSeconds(0.2f);
-            Assert.That(hand.Empty);
+            yield return WaitUntilHandEmptyState(hand, true, "PDA was not dropped from the local player's hand.");
             yield return new WaitForSeconds(0.2f);
             fixture.PressAndRelease(fixture.Mouse.leftButton);
-            yield return new WaitForSeconds(0.1f);
-            Assert.That(!hand.Empty);
+            yield return WaitUntilHandEmptyState(hand, false, "PDA was not picked back up into the local player's hand.");
 
             yield return new WaitForSeconds(1f);
+        }
+
+        private static IEnumerator WaitUntilHandEmptyState(AttachedContainer hand, bool expectedEmpty, string failureMessage, float timeout = 3f)
+        {
+            float startTime = Time.time;
+            while (hand.Empty != expectedEmpty && Time.time < startTime + timeout)
+            {
+                yield return null;
+            }
+
+            Assert.That(hand.Empty, Is.EqualTo(expectedEmpty), failureMessage);
         }
 
         /// <summary>

--- a/Assets/Scripts/Tests/PlayMode/GeneralTests/Client/ClientStackingActions.cs
+++ b/Assets/Scripts/Tests/PlayMode/GeneralTests/Client/ClientStackingActions.cs
@@ -1,0 +1,125 @@
+using System.Collections;
+using System.Linq;
+using FishNet;
+using NUnit.Framework;
+using SS3D.Core;
+using SS3D.Data.Generated;
+using SS3D.Networking;
+using SS3D.Systems.Entities;
+using SS3D.Systems.Interactions;
+using SS3D.Systems.Inventory.Containers;
+using SS3D.Systems.Inventory.Items;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace SS3D.Tests
+{
+    public class ClientStackingActions : PlayModeTest
+    {
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            LogAssert.ignoreFailingMessages = true;
+            yield return LoadAndSetInGame(NetworkType.Client);
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            LogAssert.ignoreFailingMessages = true;
+            yield return TestHelpers.FinishAndExitRound();
+            KillAllBuiltExecutables();
+        }
+
+        [UnityTest]
+        public IEnumerator ClientCanStackSteelSheetsInsideToolbox()
+        {
+            HumanInventory inventory = GetLocalInventory();
+            Assert.That(inventory.Hands.HandContainers.Count, Is.GreaterThanOrEqualTo(2));
+
+            AttachedContainer toolboxHand = inventory.Hands.HandContainers[0];
+            AttachedContainer sourceHand = inventory.Hands.HandContainers[1];
+            InteractionController interactionController = inventory.GetComponent<InteractionController>();
+
+            ItemSubSystem itemSystem = SubSystems.Get<ItemSubSystem>();
+            itemSystem.CmdSpawnItemInContainerById(Items.ToolboxBlue, toolboxHand);
+            itemSystem.CmdSpawnItemInContainerById(Items.SteelSheet, sourceHand);
+
+            yield return WaitUntilContainerItemCount(toolboxHand, 1, "Toolbox did not appear.");
+            yield return WaitUntilContainerItemCount(sourceHand, 1, "Source steel sheet did not appear.");
+
+            Item toolboxItem = toolboxHand.Items.First();
+            AttachedContainer toolboxContainer = toolboxItem.GetComponentsInChildren<AttachedContainer>(true)
+                .First(container => container != toolboxHand && container.Size.x > 1);
+            Hand sourceHandObject = inventory.Hands.PlayerHands.First(hand => hand.Container == sourceHand);
+
+            inventory.Hands.CmdSetActiveHand(sourceHand);
+            yield return WaitUntilSelectedHand(inventory.Hands, sourceHand);
+            interactionController.InteractInHand(toolboxContainer.ContainerInteractive.gameObject, sourceHandObject.gameObject);
+            yield return new WaitForSeconds(0.5f);
+            inventory.ClientInteractWithContainerSlot(toolboxContainer, Vector2Int.zero);
+
+            yield return WaitUntilContainerItemCount(sourceHand, 0, "Source hand still held the first steel sheet.");
+            yield return WaitUntilContainerItemCount(toolboxContainer, 1, "First steel sheet did not move into toolbox.");
+
+            Item destinationItem = toolboxContainer.Items.First();
+            Assert.That(destinationItem.TryGetStackable(out Stackable destinationStack), Is.True);
+
+            itemSystem.CmdSpawnItemInContainerById(Items.SteelSheet, sourceHand);
+            yield return WaitUntilContainerItemCount(sourceHand, 1, "Second source steel sheet did not appear.");
+
+            Item secondSourceItem = sourceHand.Items.First();
+            Assert.That(secondSourceItem.TryGetStackable(out _), Is.True);
+            inventory.ClientInteractWithContainerSlot(toolboxContainer, Vector2Int.zero);
+
+            yield return WaitUntilContainerItemCount(sourceHand, 0, "Source hand still held the transferred second steel sheet.");
+            yield return WaitUntilStackAmount(destinationStack, 2, "Destination steel sheet stack did not reach amount 2.");
+        }
+
+        protected override bool UseMockUpInputs()
+        {
+            return true;
+        }
+
+        private static HumanInventory GetLocalInventory()
+        {
+            EntitySubSystem entitySystem = SubSystems.Get<EntitySubSystem>();
+            entitySystem.TryGetOwnedEntity(InstanceFinder.ClientManager.Connection, out Entity entity);
+            return entity.GetComponent<HumanInventory>();
+        }
+
+        private static IEnumerator WaitUntilSelectedHand(Hands hands, AttachedContainer expectedContainer, float timeout = 5f)
+        {
+            float startTime = Time.time;
+            while (hands.SelectedHand.Container != expectedContainer && Time.time < startTime + timeout)
+            {
+                yield return null;
+            }
+
+            Assert.That(hands.SelectedHand.Container, Is.EqualTo(expectedContainer));
+        }
+
+        private static IEnumerator WaitUntilContainerItemCount(AttachedContainer container, int expectedCount, string failureMessage, float timeout = 5f)
+        {
+            float startTime = Time.time;
+            while (container.ItemCount != expectedCount && Time.time < startTime + timeout)
+            {
+                yield return null;
+            }
+
+            Assert.That(container.ItemCount, Is.EqualTo(expectedCount), failureMessage);
+        }
+
+        private static IEnumerator WaitUntilStackAmount(Stackable stackable, int expectedAmount, string failureMessage, float timeout = 5f)
+        {
+            float startTime = Time.time;
+            while (stackable.Amount != expectedAmount && Time.time < startTime + timeout)
+            {
+                yield return null;
+            }
+
+            Assert.That(stackable.Amount, Is.EqualTo(expectedAmount), failureMessage);
+        }
+
+    }
+}

--- a/Assets/Scripts/Tests/PlayMode/GeneralTests/Client/ClientStackingActions.cs.meta
+++ b/Assets/Scripts/Tests/PlayMode/GeneralTests/Client/ClientStackingActions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70a186374984c7a45bd7dfe7ced7d8c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/PlayMode/GeneralTests/Host/HostStackingActions.cs
+++ b/Assets/Scripts/Tests/PlayMode/GeneralTests/Host/HostStackingActions.cs
@@ -1,0 +1,207 @@
+using System.Collections;
+using System.Linq;
+using FishNet;
+using NUnit.Framework;
+using SS3D.Core;
+using SS3D.Data.Generated;
+using SS3D.Networking;
+using SS3D.Systems.Entities;
+using SS3D.Systems.Interactions;
+using SS3D.Systems.Inventory.Containers;
+using SS3D.Systems.Inventory.Items;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace SS3D.Tests
+{
+    public class HostStackingActions : PlayModeTest
+    {
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            LogAssert.ignoreFailingMessages = true;
+            yield return LoadAndSetInGame(NetworkType.Host, 8f);
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            LogAssert.ignoreFailingMessages = true;
+            yield return TestHelpers.FinishAndExitRound();
+        }
+
+        [UnityTest]
+        public IEnumerator HostCanStackSteelSheetsInsideToolbox()
+        {
+            HumanInventory inventory = null;
+            yield return WaitUntilLocalInventoryReady(readyInventory => inventory = readyInventory);
+            Assert.That(inventory.Hands.HandContainers.Count, Is.GreaterThanOrEqualTo(2));
+            ClearHandContainers(inventory);
+
+            AttachedContainer toolboxHand = inventory.Hands.HandContainers[0];
+            AttachedContainer sourceHand = inventory.Hands.HandContainers[1];
+            InteractionController interactionController = inventory.GetComponent<InteractionController>();
+
+            ItemSubSystem itemSystem = SubSystems.Get<ItemSubSystem>();
+            itemSystem.SpawnItemInContainer(Items.ToolboxBlue, toolboxHand);
+            itemSystem.SpawnItemInContainer(Items.SteelSheet, sourceHand);
+
+            Item toolboxItem = null;
+            yield return WaitUntilContainerHasItem(
+                toolboxHand,
+                item => item.GetComponentsInChildren<AttachedContainer>(true)
+                    .Any(container => container != toolboxHand && container.Size.x > 1),
+                item => toolboxItem = item,
+                "Toolbox did not appear.");
+            yield return WaitUntilContainerHasItem(
+                sourceHand,
+                item => item.TryGetStackable(out _),
+                _ => { },
+                "Source steel sheet did not appear.");
+
+            AttachedContainer toolboxContainer = null;
+            yield return WaitUntilToolboxContainerAvailable(toolboxItem, toolboxHand, container => toolboxContainer = container);
+            Hand sourceHandObject = inventory.Hands.PlayerHands.First(hand => hand.Container == sourceHand);
+
+            inventory.Hands.CmdSetActiveHand(sourceHand);
+            yield return WaitUntilSelectedHand(inventory.Hands, sourceHand);
+            interactionController.InteractInHand(toolboxContainer.ContainerInteractive.gameObject, sourceHandObject.gameObject);
+            yield return new WaitForSeconds(0.5f);
+            inventory.ClientInteractWithContainerSlot(toolboxContainer, Vector2Int.zero);
+
+            yield return WaitUntilContainerItemCount(sourceHand, 0, "Source hand still held the first steel sheet.");
+            yield return WaitUntilContainerItemCount(toolboxContainer, 1, "First steel sheet did not move into toolbox.");
+
+            Item destinationItem = toolboxContainer.Items.First();
+            Assert.That(destinationItem.TryGetStackable(out Stackable destinationStack), Is.True);
+
+            itemSystem.SpawnItemInContainer(Items.SteelSheet, sourceHand);
+            yield return WaitUntilContainerItemCount(sourceHand, 1, "Second source steel sheet did not appear.");
+
+            Item secondSourceItem = sourceHand.Items.First();
+            Assert.That(secondSourceItem.TryGetStackable(out _), Is.True);
+            inventory.ClientInteractWithContainerSlot(toolboxContainer, Vector2Int.zero);
+
+            yield return WaitUntilContainerItemCount(sourceHand, 0, "Source hand still held the transferred second steel sheet.");
+            yield return WaitUntilStackAmount(destinationStack, 2, "Destination steel sheet stack did not reach amount 2.");
+        }
+
+        protected override bool UseMockUpInputs()
+        {
+            return true;
+        }
+
+        private static IEnumerator WaitUntilLocalInventoryReady(System.Action<HumanInventory> setInventory, float timeout = 15f)
+        {
+            EntitySubSystem entitySystem = SubSystems.Get<EntitySubSystem>();
+            float startTime = Time.time;
+            HumanInventory inventory = null;
+            while (inventory == null && Time.time < startTime + timeout)
+            {
+                Entity entity = null;
+                if (InstanceFinder.IsHost && entitySystem.LastSpawned != null)
+                {
+                    entity = entitySystem.LastSpawned;
+                }
+                else
+                {
+                    entitySystem.TryGetOwnedEntity(InstanceFinder.ClientManager.Connection, out entity);
+                }
+
+                inventory = entity != null ? entity.GetComponent<HumanInventory>() : null;
+                if (inventory != null && inventory.Hands.HandContainers.Count >= 2)
+                {
+                    break;
+                }
+
+                inventory = null;
+                yield return null;
+            }
+
+            Assert.That(inventory, Is.Not.Null, "Local host inventory did not become ready.");
+            setInventory(inventory);
+        }
+
+        private static void ClearHandContainers(HumanInventory inventory)
+        {
+            foreach (AttachedContainer handContainer in inventory.Hands.HandContainers)
+            {
+                foreach (Item item in handContainer.Items.ToList())
+                {
+                    handContainer.RemoveItem(item);
+                }
+            }
+        }
+
+        private static IEnumerator WaitUntilSelectedHand(Hands hands, AttachedContainer expectedContainer, float timeout = 5f)
+        {
+            float startTime = Time.time;
+            while (hands.SelectedHand.Container != expectedContainer && Time.time < startTime + timeout)
+            {
+                yield return null;
+            }
+
+            Assert.That(hands.SelectedHand.Container, Is.EqualTo(expectedContainer));
+        }
+
+        private static IEnumerator WaitUntilToolboxContainerAvailable(
+            Item toolboxItem,
+            AttachedContainer handContainer,
+            System.Action<AttachedContainer> setContainer,
+            float timeout = 5f)
+        {
+            float startTime = Time.time;
+            AttachedContainer toolboxContainer = null;
+            while (toolboxContainer == null && Time.time < startTime + timeout)
+            {
+                toolboxContainer = toolboxItem.GetComponentsInChildren<AttachedContainer>(true)
+                    .FirstOrDefault(container => container != handContainer && container.Size.x > 1);
+                yield return null;
+            }
+
+            Assert.That(toolboxContainer, Is.Not.Null, "Toolbox container did not appear.");
+            setContainer(toolboxContainer);
+        }
+
+        private static IEnumerator WaitUntilContainerItemCount(AttachedContainer container, int expectedCount, string failureMessage, float timeout = 5f)
+        {
+            float startTime = Time.time;
+            while (container.ItemCount != expectedCount && Time.time < startTime + timeout)
+            {
+                yield return null;
+            }
+
+            Assert.That(container.ItemCount, Is.EqualTo(expectedCount), failureMessage);
+        }
+
+        private static IEnumerator WaitUntilContainerHasItem(
+            AttachedContainer container,
+            System.Func<Item, bool> predicate,
+            System.Action<Item> setItem,
+            string failureMessage,
+            float timeout = 5f)
+        {
+            float startTime = Time.time;
+            Item item = null;
+            while (item == null && Time.time < startTime + timeout)
+            {
+                item = container.Items.FirstOrDefault(predicate);
+                yield return null;
+            }
+
+            Assert.That(item, Is.Not.Null, failureMessage);
+            setItem(item);
+        }
+
+        private static IEnumerator WaitUntilStackAmount(Stackable stackable, int expectedAmount, string failureMessage, float timeout = 5f)
+        {
+            float startTime = Time.time;
+            while (stackable.Amount != expectedAmount && Time.time < startTime + timeout)
+            {
+                yield return null;
+            }
+
+            Assert.That(stackable.Amount, Is.EqualTo(expectedAmount), failureMessage);
+        }
+    }
+}

--- a/Assets/Scripts/Tests/PlayMode/GeneralTests/Host/HostStackingActions.cs.meta
+++ b/Assets/Scripts/Tests/PlayMode/GeneralTests/Host/HostStackingActions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6e1b2a73e514ef4abbe0a1d2dfcc515
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/PlayMode/SS3D.Tests.PlayMode.asmdef
+++ b/Assets/Scripts/Tests/PlayMode/SS3D.Tests.PlayMode.asmdef
@@ -15,7 +15,8 @@
         "Unity.InputSystem.TestFramework",
         "SS3D.Data",
         "SS3D.Networking",
-        "SS3D.CommandLine"
+        "SS3D.CommandLine",
+        "SS3D.Interactions"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
 # Summary

  Adds stackable inventory items for containers, addressing #1258.

  Each stackable item type can define its own per-slot stack limit. Stacked items keep their hidden
  item instances in an internal stack container, support adding/removing items from the bundle, merge
  when dropped onto matching stacks, and show stack counts in container UI.

  This PR includes:
  - Stackable item logic with merge, split, and take-one support.
  - Container transfer support for stacking into compatible occupied slots.
  - Inventory UI stack count labels.
  - Toolbox/container stacking behavior for steel sheets.
  - A “Take one” interaction for stacks.
  - Tests for stack logic, container transfers, UI count updates, and multiplayer client stacking.

  This PR does not broadly convert every stackable candidate item. Steel sheets are the initial
  configured stackable item.

  #### PR checklist
  - [x] The game builds properly without errors.
  - [x] No unrelated changes are present.
  - [x] No "trash" files are committed.
  - [x] Relevant code is documented.
  - [ ] Update the related GitBook document, or create a new one if needed.

  # Pictures/Videos
[stacking.webm](https://github.com/user-attachments/assets/16ae150d-0eb9-44aa-9489-85e4bbf83c21)

  # Testing

  Automated tests run:

  - Focused EditMode stacking suite passed:
    - `EditorTests.StackableTests`
    - `EditorTests.ContainerTests`
    - `EditorTests.ItemDisplayTests`

  - Multiplayer PlayMode test passed:
    - `SS3D.Tests.ClientStackingActions.ClientCanStackSteelSheetsInsideToolbox`

  Manual/expected behavior to test:
  - Put a steel sheet into a toolbox.
  - Add another steel sheet to the same toolbox slot.
  - The toolbox UI should show stack count `2`.
  - A hand should still only hold one item and should not become a stack.
  - Empty-hand click on a stack should take one item.
  - Dragging a matching steel sheet onto another steel sheet should stack.
  - Dragging an item to an empty slot should still move normally.
  - Reopen the toolbox and verify the UI still matches the container state.

  #### Networking checklist
  - [x] Works from host in host mode.
  - [x] Works from server in server mode.
  - [x] Works on server in client mode.
  - [x] Works and is syncronized across different clients.
  - [ ] Is persistent.

  # Changes

  Major changes:
  - Added `Stackable` support for item stacks using a hidden internal stack container.
  - Added per-item stack limits through the `Stackable` component.
  - Updated container transfer logic to merge compatible stackable items into occupied slots.
  - Prevented stacks from forming in hand containers.
  - Added take-one behavior for splitting one item from a stack.
  - Added stack count display support to inventory UI slots/grid items.
  - Configured `SteelSheet.prefab` as the first stackable item.
  - Added regression handling for:
    - source container removal restrictions during stack merge/take-one
    - newly spawned stack items merging into a full container with stack space
    - hidden items stored inside stacks staying hidden when the outer stack item is shown
    - rejected drag/drop restoring item display visibility/state

  Test/support changes:
  - Added EditMode tests for stack merge/split behavior, container stacking transfers, and UI count
  labels.
  - Added a PlayMode multiplayer test for stacking steel sheets inside a toolbox.
  - Hardened PlayMode test cleanup so built test executables are cleaned up during test runs only.

  Known notes:
  - Steel sheets are the only item configured as stackable in this PR.
  - Broader stackable item rollout should be handled separately.

  # Related issues/PRs

  Closes #1258