### PR TITLE
Codex/UI color palette

### DIFF
--- a/Assets/Scripts/SS3D/Data/PaletteColors.cs
+++ b/Assets/Scripts/SS3D/Data/PaletteColors.cs
@@ -34,8 +34,11 @@ namespace SS3D.Data
         }
 
         public PaletteColor Key { get; }
+
         public string DisplayName { get; }
+
         public Color Color { get; }
+
         public string Hex => "#" + ColorUtility.ToHtmlStringRGBA(Color);
     }
 

--- a/Assets/Scripts/SS3D/Data/PaletteColors.cs
+++ b/Assets/Scripts/SS3D/Data/PaletteColors.cs
@@ -1,125 +1,26 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace SS3D.Data
 {
-    public enum PaletteColor
-    {
-        White,
-        TextPrimary,
-        TextDisabled,
-        UiOverlay,
-        UiOverlayHighlighted,
-        UiOverlayDisabled,
-        LightGreen,
-        NormalGreen,
-        LightBlue,
-        LightRed,
-        LogBlue,
-        LogGreen,
-        LogRed,
-        LogServer,
-        LogExternal,
-        LogClient,
-        LogPhysics
-    }
-
-    public struct PaletteColorDefinition
-    {
-        public PaletteColorDefinition(PaletteColor key, string displayName, Color color)
-        {
-            Key = key;
-            DisplayName = displayName;
-            Color = color;
-        }
-
-        public PaletteColor Key { get; }
-
-        public string DisplayName { get; }
-
-        public Color Color { get; }
-
-        public string Hex => "#" + ColorUtility.ToHtmlStringRGBA(Color);
-    }
-
+    /// <summary>
+    /// Shared UI colors used by SS3D views and style assets.
+    /// Keep subsystem-specific colors close to their subsystem instead.
+    /// </summary>
     public static class PaletteColors
     {
         public static readonly Color White = Color.white;
         public static readonly Color TextPrimary = White;
+        public static readonly Color TextInverted = Color.black;
         public static readonly Color TextDisabled = new Color(1f, 1f, 1f, 0.23137255f);
 
-        public static readonly Color UiOverlay = new Color(0f, 0f, 0f, 0.34901962f);
-        public static readonly Color UiOverlayHighlighted = new Color(0f, 0f, 0f, 0.7490196f);
-        public static readonly Color UiOverlayDisabled = new Color(0f, 0f, 0f, 0.6f);
+        public static readonly Color ButtonBackground = new Color(0f, 0f, 0f, 0.34901962f);
+        public static readonly Color ButtonBackgroundHighlighted = new Color(0f, 0f, 0f, 0.7490196f);
+        public static readonly Color ButtonBackgroundPressed = White;
+        public static readonly Color ButtonBackgroundDisabled = new Color(0f, 0f, 0f, 0.6f);
 
         public static readonly Color LightGreen = new Color32(42, 193, 50, 255);
         public static readonly Color NormalGreen = new Color32(35, 155, 42, 255);
         public static readonly Color LightBlue = new Color32(80, 115, 216, 255);
         public static readonly Color LightRed = new Color32(155, 31, 31, 255);
-
-        public static readonly Color LogBlue = FromHex("#90C4FE");
-        public static readonly Color LogGreen = FromHex("#88B36B");
-        public static readonly Color LogRed = FromHex("#8D3131");
-        public static readonly Color LogServer = FromHex("#A645A6");
-        public static readonly Color LogExternal = FromHex("#E6DC33");
-        public static readonly Color LogClient = FromHex("#B94949");
-        public static readonly Color LogPhysics = FromHex("#678DB8");
-
-        private static readonly PaletteColorDefinition[] _colors =
-        {
-            new PaletteColorDefinition(PaletteColor.White, "White", White),
-            new PaletteColorDefinition(PaletteColor.TextPrimary, "Text Primary", TextPrimary),
-            new PaletteColorDefinition(PaletteColor.TextDisabled, "Text Disabled", TextDisabled),
-            new PaletteColorDefinition(PaletteColor.UiOverlay, "UI Overlay", UiOverlay),
-            new PaletteColorDefinition(PaletteColor.UiOverlayHighlighted, "UI Overlay Highlighted", UiOverlayHighlighted),
-            new PaletteColorDefinition(PaletteColor.UiOverlayDisabled, "UI Overlay Disabled", UiOverlayDisabled),
-            new PaletteColorDefinition(PaletteColor.LightGreen, "Light Green", LightGreen),
-            new PaletteColorDefinition(PaletteColor.NormalGreen, "Normal Green", NormalGreen),
-            new PaletteColorDefinition(PaletteColor.LightBlue, "Light Blue", LightBlue),
-            new PaletteColorDefinition(PaletteColor.LightRed, "Light Red", LightRed),
-            new PaletteColorDefinition(PaletteColor.LogBlue, "Log Blue", LogBlue),
-            new PaletteColorDefinition(PaletteColor.LogGreen, "Log Green", LogGreen),
-            new PaletteColorDefinition(PaletteColor.LogRed, "Log Red", LogRed),
-            new PaletteColorDefinition(PaletteColor.LogServer, "Log Server", LogServer),
-            new PaletteColorDefinition(PaletteColor.LogExternal, "Log External", LogExternal),
-            new PaletteColorDefinition(PaletteColor.LogClient, "Log Client", LogClient),
-            new PaletteColorDefinition(PaletteColor.LogPhysics, "Log Physics", LogPhysics)
-        };
-
-        private static readonly Dictionary<PaletteColor, Color> _colorLookup = BuildLookup();
-
-        public static IReadOnlyList<PaletteColorDefinition> All => _colors;
-
-        public static Color Get(PaletteColor color)
-        {
-            return _colorLookup.TryGetValue(color, out Color value) ? value : White;
-        }
-
-        public static bool TryGet(PaletteColor color, out Color value)
-        {
-            return _colorLookup.TryGetValue(color, out value);
-        }
-
-        public static string GetHex(PaletteColor color)
-        {
-            return "#" + ColorUtility.ToHtmlStringRGBA(Get(color));
-        }
-
-        private static Dictionary<PaletteColor, Color> BuildLookup()
-        {
-            var lookup = new Dictionary<PaletteColor, Color>();
-
-            foreach (PaletteColorDefinition color in _colors)
-            {
-                lookup[color.Key] = color.Color;
-            }
-
-            return lookup;
-        }
-
-        private static Color FromHex(string hex)
-        {
-            return ColorUtility.TryParseHtmlString(hex, out Color color) ? color : White;
-        }
     }
 }

--- a/Assets/Scripts/SS3D/Data/PaletteColors.cs
+++ b/Assets/Scripts/SS3D/Data/PaletteColors.cs
@@ -1,136 +1,26 @@
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace SS3D.Data
 {
-    /// <summary>
-    /// Semantic keys for shared UI colors used by SS3D views and style assets.
-    /// </summary>
-    public enum PaletteColor
-    {
-        TextPrimary,
-        TextInverted,
-        TextDisabled,
-        ButtonBackground,
-        ButtonBackgroundHighlighted,
-        ButtonBackgroundPressed,
-        ButtonBackgroundDisabled,
-        LightGreen,
-        NormalGreen,
-        LightBlue,
-        LightRed
-    }
-
-    /// <summary>
-    /// Metadata for one shared UI color.
-    /// </summary>
-    public sealed class PaletteColorDefinition
-    {
-        public PaletteColor Key { get; private set; }
-        public string DisplayName { get; private set; }
-        public Color Color { get; private set; }
-        public string Usage { get; private set; }
-
-        public PaletteColorDefinition(PaletteColor key, string displayName, Color color, string usage)
-        {
-            Key = key;
-            DisplayName = displayName;
-            Color = color;
-            Usage = usage;
-        }
-    }
-
     /// <summary>
     /// Shared UI colors used by SS3D views and style assets.
     /// Keep subsystem-specific colors close to their subsystem instead.
     /// </summary>
     public static class PaletteColors
     {
-        public static readonly Color White = Color.white;
-        public static readonly Color TextPrimary = White;
-        public static readonly Color TextInverted = Color.black;
-        public static readonly Color TextDisabled = new Color(1f, 1f, 1f, 0.23137255f);
+        public static Color White = Color.white;
+        public static Color TextPrimary = White;
+        public static Color TextInverted = Color.black;
+        public static Color TextDisabled = new Color(1f, 1f, 1f, 0.23137255f);
 
-        public static readonly Color ButtonBackground = new Color(0f, 0f, 0f, 0.34901962f);
-        public static readonly Color ButtonBackgroundHighlighted = new Color(0f, 0f, 0f, 0.7490196f);
-        public static readonly Color ButtonBackgroundPressed = White;
-        public static readonly Color ButtonBackgroundDisabled = new Color(0f, 0f, 0f, 0.6f);
+        public static Color ButtonBackground = new Color(0f, 0f, 0f, 0.34901962f);
+        public static Color ButtonBackgroundHighlighted = new Color(0f, 0f, 0f, 0.7490196f);
+        public static Color ButtonBackgroundPressed = White;
+        public static Color ButtonBackgroundDisabled = new Color(0f, 0f, 0f, 0.6f);
 
-        public static readonly Color LightGreen = new Color32(42, 193, 50, 255);
-        public static readonly Color NormalGreen = new Color32(35, 155, 42, 255);
-        public static readonly Color LightBlue = new Color32(80, 115, 216, 255);
-        public static readonly Color LightRed = new Color32(155, 31, 31, 255);
-
-        private static readonly PaletteColorDefinition[] Definitions =
-        {
-            new PaletteColorDefinition(PaletteColor.TextPrimary, "Text primary", TextPrimary, "Default text on dark UI backgrounds."),
-            new PaletteColorDefinition(PaletteColor.TextInverted, "Text inverted", TextInverted, "Text displayed on light or pressed UI states."),
-            new PaletteColorDefinition(PaletteColor.TextDisabled, "Text disabled", TextDisabled, "Text for disabled or unavailable controls."),
-            new PaletteColorDefinition(PaletteColor.ButtonBackground, "Button background", ButtonBackground, "Default generic button overlay."),
-            new PaletteColorDefinition(PaletteColor.ButtonBackgroundHighlighted, "Button background highlighted", ButtonBackgroundHighlighted, "Hovered or highlighted generic button overlay."),
-            new PaletteColorDefinition(PaletteColor.ButtonBackgroundPressed, "Button background pressed", ButtonBackgroundPressed, "Pressed generic button background."),
-            new PaletteColorDefinition(PaletteColor.ButtonBackgroundDisabled, "Button background disabled", ButtonBackgroundDisabled, "Disabled generic button overlay."),
-            new PaletteColorDefinition(PaletteColor.LightGreen, "Light green", LightGreen, "Positive or success accent color."),
-            new PaletteColorDefinition(PaletteColor.NormalGreen, "Normal green", NormalGreen, "Standard green accent color."),
-            new PaletteColorDefinition(PaletteColor.LightBlue, "Light blue", LightBlue, "Informational or selected-state accent color."),
-            new PaletteColorDefinition(PaletteColor.LightRed, "Light red", LightRed, "Danger or destructive-state accent color.")
-        };
-
-        private static readonly Dictionary<PaletteColor, PaletteColorDefinition> DefinitionsByKey = BuildDefinitionsByKey();
-
-        /// <summary>
-        /// All shared UI colors, including their semantic key and intended usage.
-        /// </summary>
-        public static IReadOnlyList<PaletteColorDefinition> All
-        {
-            get { return Definitions; }
-        }
-
-        public static Color GetColor(PaletteColor key)
-        {
-            return GetDefinition(key).Color;
-        }
-
-        public static bool TryGetColor(PaletteColor key, out Color color)
-        {
-            PaletteColorDefinition definition;
-            if (DefinitionsByKey.TryGetValue(key, out definition))
-            {
-                color = definition.Color;
-                return true;
-            }
-
-            color = default(Color);
-            return false;
-        }
-
-        public static PaletteColorDefinition GetDefinition(PaletteColor key)
-        {
-            PaletteColorDefinition definition;
-            if (DefinitionsByKey.TryGetValue(key, out definition))
-            {
-                return definition;
-            }
-
-            throw new ArgumentOutOfRangeException(nameof(key), key, "Unknown palette color key.");
-        }
-
-        public static bool TryGetDefinition(PaletteColor key, out PaletteColorDefinition definition)
-        {
-            return DefinitionsByKey.TryGetValue(key, out definition);
-        }
-
-        private static Dictionary<PaletteColor, PaletteColorDefinition> BuildDefinitionsByKey()
-        {
-            Dictionary<PaletteColor, PaletteColorDefinition> definitionsByKey = new Dictionary<PaletteColor, PaletteColorDefinition>();
-
-            foreach (PaletteColorDefinition definition in Definitions)
-            {
-                definitionsByKey.Add(definition.Key, definition);
-            }
-
-            return definitionsByKey;
-        }
+        public static Color LightGreen = new Color32(42, 193, 50, 255);
+        public static Color NormalGreen = new Color32(35, 155, 42, 255);
+        public static Color LightBlue = new Color32(80, 115, 216, 255);
+        public static Color LightRed = new Color32(155, 31, 31, 255);
     }
 }

--- a/Assets/Scripts/SS3D/Data/PaletteColors.cs
+++ b/Assets/Scripts/SS3D/Data/PaletteColors.cs
@@ -1,16 +1,122 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace SS3D.Data
 {
+    public enum PaletteColor
+    {
+        White,
+        TextPrimary,
+        TextDisabled,
+        UiOverlay,
+        UiOverlayHighlighted,
+        UiOverlayDisabled,
+        LightGreen,
+        NormalGreen,
+        LightBlue,
+        LightRed,
+        LogBlue,
+        LogGreen,
+        LogRed,
+        LogServer,
+        LogExternal,
+        LogClient,
+        LogPhysics
+    }
+
+    public struct PaletteColorDefinition
+    {
+        public PaletteColorDefinition(PaletteColor key, string displayName, Color color)
+        {
+            Key = key;
+            DisplayName = displayName;
+            Color = color;
+        }
+
+        public PaletteColor Key { get; }
+        public string DisplayName { get; }
+        public Color Color { get; }
+        public string Hex => "#" + ColorUtility.ToHtmlStringRGBA(Color);
+    }
+
     public static class PaletteColors
     {
-        public static Color White = Color.white;
-        public static Color LightGreen = new Color(42, 193, 50);
-        public static Color NormalGreen = new Color(35, 155, 42);
+        public static readonly Color White = Color.white;
+        public static readonly Color TextPrimary = White;
+        public static readonly Color TextDisabled = new Color(1f, 1f, 1f, 0.23137255f);
 
-        public static Color LightBlue = new Color(80, 115, 216);
+        public static readonly Color UiOverlay = new Color(0f, 0f, 0f, 0.34901962f);
+        public static readonly Color UiOverlayHighlighted = new Color(0f, 0f, 0f, 0.7490196f);
+        public static readonly Color UiOverlayDisabled = new Color(0f, 0f, 0f, 0.6f);
 
-        public static Color LightRed = new Color(155, 31, 31);
+        public static readonly Color LightGreen = new Color32(42, 193, 50, 255);
+        public static readonly Color NormalGreen = new Color32(35, 155, 42, 255);
+        public static readonly Color LightBlue = new Color32(80, 115, 216, 255);
+        public static readonly Color LightRed = new Color32(155, 31, 31, 255);
 
+        public static readonly Color LogBlue = FromHex("#90C4FE");
+        public static readonly Color LogGreen = FromHex("#88B36B");
+        public static readonly Color LogRed = FromHex("#8D3131");
+        public static readonly Color LogServer = FromHex("#A645A6");
+        public static readonly Color LogExternal = FromHex("#E6DC33");
+        public static readonly Color LogClient = FromHex("#B94949");
+        public static readonly Color LogPhysics = FromHex("#678DB8");
+
+        private static readonly PaletteColorDefinition[] _colors =
+        {
+            new PaletteColorDefinition(PaletteColor.White, "White", White),
+            new PaletteColorDefinition(PaletteColor.TextPrimary, "Text Primary", TextPrimary),
+            new PaletteColorDefinition(PaletteColor.TextDisabled, "Text Disabled", TextDisabled),
+            new PaletteColorDefinition(PaletteColor.UiOverlay, "UI Overlay", UiOverlay),
+            new PaletteColorDefinition(PaletteColor.UiOverlayHighlighted, "UI Overlay Highlighted", UiOverlayHighlighted),
+            new PaletteColorDefinition(PaletteColor.UiOverlayDisabled, "UI Overlay Disabled", UiOverlayDisabled),
+            new PaletteColorDefinition(PaletteColor.LightGreen, "Light Green", LightGreen),
+            new PaletteColorDefinition(PaletteColor.NormalGreen, "Normal Green", NormalGreen),
+            new PaletteColorDefinition(PaletteColor.LightBlue, "Light Blue", LightBlue),
+            new PaletteColorDefinition(PaletteColor.LightRed, "Light Red", LightRed),
+            new PaletteColorDefinition(PaletteColor.LogBlue, "Log Blue", LogBlue),
+            new PaletteColorDefinition(PaletteColor.LogGreen, "Log Green", LogGreen),
+            new PaletteColorDefinition(PaletteColor.LogRed, "Log Red", LogRed),
+            new PaletteColorDefinition(PaletteColor.LogServer, "Log Server", LogServer),
+            new PaletteColorDefinition(PaletteColor.LogExternal, "Log External", LogExternal),
+            new PaletteColorDefinition(PaletteColor.LogClient, "Log Client", LogClient),
+            new PaletteColorDefinition(PaletteColor.LogPhysics, "Log Physics", LogPhysics)
+        };
+
+        private static readonly Dictionary<PaletteColor, Color> _colorLookup = BuildLookup();
+
+        public static IReadOnlyList<PaletteColorDefinition> All => _colors;
+
+        public static Color Get(PaletteColor color)
+        {
+            return _colorLookup.TryGetValue(color, out Color value) ? value : White;
+        }
+
+        public static bool TryGet(PaletteColor color, out Color value)
+        {
+            return _colorLookup.TryGetValue(color, out value);
+        }
+
+        public static string GetHex(PaletteColor color)
+        {
+            return "#" + ColorUtility.ToHtmlStringRGBA(Get(color));
+        }
+
+        private static Dictionary<PaletteColor, Color> BuildLookup()
+        {
+            var lookup = new Dictionary<PaletteColor, Color>();
+
+            foreach (PaletteColorDefinition color in _colors)
+            {
+                lookup[color.Key] = color.Color;
+            }
+
+            return lookup;
+        }
+
+        private static Color FromHex(string hex)
+        {
+            return ColorUtility.TryParseHtmlString(hex, out Color color) ? color : White;
+        }
     }
 }

--- a/Assets/Scripts/SS3D/Data/PaletteColors.cs
+++ b/Assets/Scripts/SS3D/Data/PaletteColors.cs
@@ -1,7 +1,46 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace SS3D.Data
 {
+    /// <summary>
+    /// Semantic keys for shared UI colors used by SS3D views and style assets.
+    /// </summary>
+    public enum PaletteColor
+    {
+        TextPrimary,
+        TextInverted,
+        TextDisabled,
+        ButtonBackground,
+        ButtonBackgroundHighlighted,
+        ButtonBackgroundPressed,
+        ButtonBackgroundDisabled,
+        LightGreen,
+        NormalGreen,
+        LightBlue,
+        LightRed
+    }
+
+    /// <summary>
+    /// Metadata for one shared UI color.
+    /// </summary>
+    public sealed class PaletteColorDefinition
+    {
+        public PaletteColor Key { get; private set; }
+        public string DisplayName { get; private set; }
+        public Color Color { get; private set; }
+        public string Usage { get; private set; }
+
+        public PaletteColorDefinition(PaletteColor key, string displayName, Color color, string usage)
+        {
+            Key = key;
+            DisplayName = displayName;
+            Color = color;
+            Usage = usage;
+        }
+    }
+
     /// <summary>
     /// Shared UI colors used by SS3D views and style assets.
     /// Keep subsystem-specific colors close to their subsystem instead.
@@ -22,5 +61,76 @@ namespace SS3D.Data
         public static readonly Color NormalGreen = new Color32(35, 155, 42, 255);
         public static readonly Color LightBlue = new Color32(80, 115, 216, 255);
         public static readonly Color LightRed = new Color32(155, 31, 31, 255);
+
+        private static readonly PaletteColorDefinition[] Definitions =
+        {
+            new PaletteColorDefinition(PaletteColor.TextPrimary, "Text primary", TextPrimary, "Default text on dark UI backgrounds."),
+            new PaletteColorDefinition(PaletteColor.TextInverted, "Text inverted", TextInverted, "Text displayed on light or pressed UI states."),
+            new PaletteColorDefinition(PaletteColor.TextDisabled, "Text disabled", TextDisabled, "Text for disabled or unavailable controls."),
+            new PaletteColorDefinition(PaletteColor.ButtonBackground, "Button background", ButtonBackground, "Default generic button overlay."),
+            new PaletteColorDefinition(PaletteColor.ButtonBackgroundHighlighted, "Button background highlighted", ButtonBackgroundHighlighted, "Hovered or highlighted generic button overlay."),
+            new PaletteColorDefinition(PaletteColor.ButtonBackgroundPressed, "Button background pressed", ButtonBackgroundPressed, "Pressed generic button background."),
+            new PaletteColorDefinition(PaletteColor.ButtonBackgroundDisabled, "Button background disabled", ButtonBackgroundDisabled, "Disabled generic button overlay."),
+            new PaletteColorDefinition(PaletteColor.LightGreen, "Light green", LightGreen, "Positive or success accent color."),
+            new PaletteColorDefinition(PaletteColor.NormalGreen, "Normal green", NormalGreen, "Standard green accent color."),
+            new PaletteColorDefinition(PaletteColor.LightBlue, "Light blue", LightBlue, "Informational or selected-state accent color."),
+            new PaletteColorDefinition(PaletteColor.LightRed, "Light red", LightRed, "Danger or destructive-state accent color.")
+        };
+
+        private static readonly Dictionary<PaletteColor, PaletteColorDefinition> DefinitionsByKey = BuildDefinitionsByKey();
+
+        /// <summary>
+        /// All shared UI colors, including their semantic key and intended usage.
+        /// </summary>
+        public static IReadOnlyList<PaletteColorDefinition> All
+        {
+            get { return Definitions; }
+        }
+
+        public static Color GetColor(PaletteColor key)
+        {
+            return GetDefinition(key).Color;
+        }
+
+        public static bool TryGetColor(PaletteColor key, out Color color)
+        {
+            PaletteColorDefinition definition;
+            if (DefinitionsByKey.TryGetValue(key, out definition))
+            {
+                color = definition.Color;
+                return true;
+            }
+
+            color = default(Color);
+            return false;
+        }
+
+        public static PaletteColorDefinition GetDefinition(PaletteColor key)
+        {
+            PaletteColorDefinition definition;
+            if (DefinitionsByKey.TryGetValue(key, out definition))
+            {
+                return definition;
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(key), key, "Unknown palette color key.");
+        }
+
+        public static bool TryGetDefinition(PaletteColor key, out PaletteColorDefinition definition)
+        {
+            return DefinitionsByKey.TryGetValue(key, out definition);
+        }
+
+        private static Dictionary<PaletteColor, PaletteColorDefinition> BuildDefinitionsByKey()
+        {
+            Dictionary<PaletteColor, PaletteColorDefinition> definitionsByKey = new Dictionary<PaletteColor, PaletteColorDefinition>();
+
+            foreach (PaletteColorDefinition definition in Definitions)
+            {
+                definitionsByKey.Add(definition.Key, definition);
+            }
+
+            return definitionsByKey;
+        }
     }
 }

--- a/Documents/UI_COLOR_PALETTE.md
+++ b/Documents/UI_COLOR_PALETTE.md
@@ -3,10 +3,16 @@
 SS3D keeps shared UI colors in `Assets/Scripts/SS3D/Data/PaletteColors.cs`.
 Use this palette instead of adding a new hard-coded color when the same UI color is reused in more than one place.
 
-## Code usage
+The palette supports two access patterns:
+
+- direct constants, such as `PaletteColors.LightBlue`, for simple UI code;
+- semantic keys, such as `PaletteColor.LightBlue`, for editor tooling, dropdowns, validation, or code that needs to enumerate available colors.
+
+## Direct code usage
 
 ```csharp
 using SS3D.Data;
+using UnityEngine;
 using UnityEngine.UI;
 
 public sealed class ReadyStateView : MonoBehaviour
@@ -22,6 +28,24 @@ public sealed class ReadyStateView : MonoBehaviour
 }
 ```
 
+## Semantic lookup usage
+
+```csharp
+using SS3D.Data;
+using UnityEngine;
+
+public sealed class PalettePreview : MonoBehaviour
+{
+    public Color GetPreviewColor(PaletteColor colorKey)
+    {
+        return PaletteColors.GetColor(colorKey);
+    }
+}
+```
+
+Use `PaletteColors.All` when a tool or inspector needs to list every shared color with display names and usage notes.
+Use `TryGetColor` or `TryGetDefinition` when reading saved or external palette keys that might be invalid.
+
 ## Available shared colors
 
 - `TextPrimary`, `TextInverted`, and `TextDisabled` match the text states already used by shared button styles.
@@ -31,5 +55,11 @@ public sealed class ReadyStateView : MonoBehaviour
 ## Adding colors
 
 Add a color here only when it is genuinely shared by UI code or assets. Colors that belong to one subsystem, such as logging colors, should stay with that subsystem instead of growing the UI palette.
+
+When adding a shared color:
+
+1. Add a semantic key to `PaletteColor`.
+2. Add a direct `PaletteColors` field for existing direct-call usage.
+3. Add a matching `PaletteColorDefinition` entry, including a display name and intended usage.
 
 Prefer `Color32` for byte-based RGB values, for example `new Color32(80, 115, 216, 255)`. Unity's `Color` constructor expects normalized `0f..1f` channel values.

--- a/Documents/UI_COLOR_PALETTE.md
+++ b/Documents/UI_COLOR_PALETTE.md
@@ -1,7 +1,7 @@
 # UI Color Palette
 
 SS3D keeps shared UI colors in `Assets/Scripts/SS3D/Data/PaletteColors.cs`.
-Use this palette instead of hard-coded color literals when a color is shared by more than one UI component.
+Use this palette instead of adding a new hard-coded color when the same UI color is reused in more than one place.
 
 ## Code usage
 
@@ -16,30 +16,20 @@ public sealed class ReadyStateView : MonoBehaviour
     public void SetReady(bool ready)
     {
         _background.color = ready
-            ? PaletteColors.Get(PaletteColor.LightBlue)
-            : PaletteColors.Get(PaletteColor.UiOverlay);
+            ? PaletteColors.LightBlue
+            : PaletteColors.ButtonBackground;
     }
 }
 ```
 
-Existing direct static colors still work:
+## Available shared colors
 
-```csharp
-_label.color = PaletteColors.TextPrimary;
-_button.image.color = PaletteColors.UiOverlayHighlighted;
-```
-
-## Choosing colors
-
-- `TextPrimary` and `TextDisabled` are for text states.
-- `UiOverlay`, `UiOverlayHighlighted`, and `UiOverlayDisabled` match the existing generic button asset.
-- `LightGreen`, `NormalGreen`, `LightBlue`, and `LightRed` are gameplay/UI accent colors.
-- `Log*` colors mirror the existing log color set so UI and logs can share the same semantic colors when needed.
+- `TextPrimary`, `TextInverted`, and `TextDisabled` match the text states already used by shared button styles.
+- `ButtonBackground`, `ButtonBackgroundHighlighted`, `ButtonBackgroundPressed`, and `ButtonBackgroundDisabled` match the existing generic button style values.
+- `LightGreen`, `NormalGreen`, `LightBlue`, and `LightRed` are the existing reusable accent colors.
 
 ## Adding colors
 
-1. Add a new key to the `PaletteColor` enum.
-2. Add a static `Color` value in `PaletteColors`.
-3. Add it to the `_colors` array so editor/debug tools can enumerate it.
+Add a color here only when it is genuinely shared by UI code or assets. Colors that belong to one subsystem, such as logging colors, should stay with that subsystem instead of growing the UI palette.
 
 Prefer `Color32` for byte-based RGB values, for example `new Color32(80, 115, 216, 255)`. Unity's `Color` constructor expects normalized `0f..1f` channel values.

--- a/Documents/UI_COLOR_PALETTE.md
+++ b/Documents/UI_COLOR_PALETTE.md
@@ -3,12 +3,7 @@
 SS3D keeps shared UI colors in `Assets/Scripts/SS3D/Data/PaletteColors.cs`.
 Use this palette instead of adding a new hard-coded color when the same UI color is reused in more than one place.
 
-The palette supports two access patterns:
-
-- direct constants, such as `PaletteColors.LightBlue`, for simple UI code;
-- semantic keys, such as `PaletteColor.LightBlue`, for editor tooling, dropdowns, validation, or code that needs to enumerate available colors.
-
-## Direct code usage
+## Usage
 
 ```csharp
 using SS3D.Data;
@@ -28,38 +23,14 @@ public sealed class ReadyStateView : MonoBehaviour
 }
 ```
 
-## Semantic lookup usage
-
-```csharp
-using SS3D.Data;
-using UnityEngine;
-
-public sealed class PalettePreview : MonoBehaviour
-{
-    public Color GetPreviewColor(PaletteColor colorKey)
-    {
-        return PaletteColors.GetColor(colorKey);
-    }
-}
-```
-
-Use `PaletteColors.All` when a tool or inspector needs to list every shared color with display names and usage notes.
-Use `TryGetColor` or `TryGetDefinition` when reading saved or external palette keys that might be invalid.
-
 ## Available shared colors
 
-- `TextPrimary`, `TextInverted`, and `TextDisabled` match the text states already used by shared button styles.
+- `TextPrimary`, `TextInverted`, and `TextDisabled` match the text states used by shared button styles.
 - `ButtonBackground`, `ButtonBackgroundHighlighted`, `ButtonBackgroundPressed`, and `ButtonBackgroundDisabled` match the existing generic button style values.
 - `LightGreen`, `NormalGreen`, `LightBlue`, and `LightRed` are the existing reusable accent colors.
 
 ## Adding colors
 
-Add a color here only when it is genuinely shared by UI code or assets. Colors that belong to one subsystem, such as logging colors, should stay with that subsystem instead of growing the UI palette.
-
-When adding a shared color:
-
-1. Add a semantic key to `PaletteColor`.
-2. Add a direct `PaletteColors` field for existing direct-call usage.
-3. Add a matching `PaletteColorDefinition` entry, including a display name and intended usage.
+Add a color here only when it is genuinely shared by UI code or assets. Colors that belong to one subsystem, such as logging colors, should stay with that subsystem.
 
 Prefer `Color32` for byte-based RGB values, for example `new Color32(80, 115, 216, 255)`. Unity's `Color` constructor expects normalized `0f..1f` channel values.

--- a/Documents/UI_COLOR_PALETTE.md
+++ b/Documents/UI_COLOR_PALETTE.md
@@ -1,0 +1,45 @@
+# UI Color Palette
+
+SS3D keeps shared UI colors in `Assets/Scripts/SS3D/Data/PaletteColors.cs`.
+Use this palette instead of hard-coded color literals when a color is shared by more than one UI component.
+
+## Code usage
+
+```csharp
+using SS3D.Data;
+using UnityEngine.UI;
+
+public sealed class ReadyStateView : MonoBehaviour
+{
+    [SerializeField] private Image _background;
+
+    public void SetReady(bool ready)
+    {
+        _background.color = ready
+            ? PaletteColors.Get(PaletteColor.LightBlue)
+            : PaletteColors.Get(PaletteColor.UiOverlay);
+    }
+}
+```
+
+Existing direct static colors still work:
+
+```csharp
+_label.color = PaletteColors.TextPrimary;
+_button.image.color = PaletteColors.UiOverlayHighlighted;
+```
+
+## Choosing colors
+
+- `TextPrimary` and `TextDisabled` are for text states.
+- `UiOverlay`, `UiOverlayHighlighted`, and `UiOverlayDisabled` match the existing generic button asset.
+- `LightGreen`, `NormalGreen`, `LightBlue`, and `LightRed` are gameplay/UI accent colors.
+- `Log*` colors mirror the existing log color set so UI and logs can share the same semantic colors when needed.
+
+## Adding colors
+
+1. Add a new key to the `PaletteColor` enum.
+2. Add a static `Color` value in `PaletteColors`.
+3. Add it to the `_colors` array so editor/debug tools can enumerate it.
+
+Prefer `Color32` for byte-based RGB values, for example `new Color32(80, 115, 216, 255)`. Unity's `Color` constructor expects normalized `0f..1f` channel values.


### PR DESCRIPTION
# Summary

Adds a small shared UI color palette for the colors already reused across SS3D interface code.

## Changes

- Keep the existing direct `PaletteColors` access pattern, but centralize the shared UI colors in one place.
- Add the generic button overlay and text colors that were already being reused by hand.
- Use `Color32` for byte-style RGB values so the palette matches Unity's expected channel semantics.
- Add concise documentation for the available colors and how to extend the palette.

## Testing

- Reviewed the touched code and documentation statically.
- Not run locally: this Codex environment does not have a Unity editor/runtime available for a full game build.
- Current GitHub Actions run is failing before PR code is checked out. The workflow is `pull_request_target` and checks out `develop`, where `LockLockerInteraction.cs` currently has an unrelated `NotImplementedException` compile error.

Closes #1377.
