### PR TITLE
Add admin function access controls

### DIFF
--- a/Assets/Content/Systems/UI/Lobby/Canvas/LobbyCanvas.prefab
+++ b/Assets/Content/Systems/UI/Lobby/Canvas/LobbyCanvas.prefab
@@ -7662,6 +7662,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8942214116569629255}
+  - component: {fileID: 6248120931421175401}
   m_Layer: 5
   m_Name: Administrator View
   m_TagString: Untagged
@@ -7691,6 +7692,18 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6248120931421175401
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5397281151860095728}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b6af73a682645fba4cf9199f63693e1, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1 &7135706429151112205
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SS3D/Permissions/PermissionSubSystem.cs
+++ b/Assets/Scripts/SS3D/Permissions/PermissionSubSystem.cs
@@ -1,4 +1,5 @@
-﻿using FishNet.Object;
+﻿using FishNet.Connection;
+using FishNet.Object;
 using FishNet.Object.Synchronizing;
 using SS3D.Core.Behaviours;
 using SS3D.Data;
@@ -28,6 +29,11 @@ namespace SS3D.Permissions
         /// </summary>
         [SyncVar]
         public bool HasLoadedPermissions;
+
+        [SyncVar(OnChange = nameof(SyncAdminFunctionsEnabledForAll))]
+        private bool _adminFunctionsEnabledForAll;
+
+        public bool AdminFunctionsEnabledForAll => _adminFunctionsEnabledForAll;
 
         /// <summary>
         /// File name to the permissions file.
@@ -197,6 +203,51 @@ namespace SS3D.Permissions
 
             return userPermission >= permissionLevelCheck;
 
+        }
+
+        public bool CanUseAdminFunctions(string ckey)
+        {
+            if (_adminFunctionsEnabledForAll)
+            {
+                return true;
+            }
+
+            return IsAtLeast(ckey, ServerRoleTypes.Administrator);
+        }
+
+        [Server]
+        public void SetAdminFunctionsEnabledForAll(bool enabled)
+        {
+            if (_adminFunctionsEnabledForAll == enabled)
+            {
+                return;
+            }
+
+            Log.Information(this, "Setting admin functions for all users to {enabled}", Logs.ServerOnly, enabled);
+            _adminFunctionsEnabledForAll = enabled;
+            SyncUserPermissions();
+        }
+
+        [ServerRpc(RequireOwnership = false)]
+        public void CmdSetAdminFunctionsEnabledForAll(bool enabled, NetworkConnection conn = null)
+        {
+            if (conn == null || !conn.IsHost)
+            {
+                Log.Warning(this, "Rejected admin functions toggle request from non-host connection", Logs.ServerOnly);
+                return;
+            }
+
+            SetAdminFunctionsEnabledForAll(enabled);
+        }
+
+        private void SyncAdminFunctionsEnabledForAll(bool oldValue, bool newValue, bool asServer)
+        {
+            if (!asServer && IsHost)
+            {
+                return;
+            }
+
+            SyncUserPermissions();
         }
     }
 }

--- a/Assets/Scripts/SS3D/Systems/Furniture/LockLockerInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/LockLockerInteraction.cs
@@ -6,6 +6,7 @@ using SS3D.Interactions.Interfaces;
 using SS3D.Logging;
 using SS3D.Systems.Furniture;
 using SS3D.Systems.Inventory.Containers;
+using System;
 using UnityEngine;
 
 namespace SS3D.Systems.Inventory.Interactions

--- a/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/Commands/AdminFunctionsCommand.cs
+++ b/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/Commands/AdminFunctionsCommand.cs
@@ -1,0 +1,90 @@
+﻿using FishNet.Connection;
+using SS3D.Core;
+using SS3D.Permissions;
+
+namespace SS3D.Systems.IngameConsoleSystem.Commands
+{
+    public class AdminFunctionsCommand : Command
+    {
+        public override string ShortDescription => "View or toggle admin functions for all users";
+        public override string Usage => "[on/off]";
+        public override ServerRoleTypes AccessLevel => ServerRoleTypes.ServerOwner;
+        public override CommandType Type => CommandType.Server;
+
+        private record CalculatedValues(bool ShouldSet, bool Enabled) : ICalculatedValues;
+
+        public override string Perform(string[] args, NetworkConnection conn = null)
+        {
+            if (!ReceiveCheckResponse(args, out CheckArgsResponse response, out CalculatedValues values))
+            {
+                return response.InvalidArgs;
+            }
+
+            PermissionSubSystem permissionSystem = SubSystems.Get<PermissionSubSystem>();
+
+            if (!values.ShouldSet)
+            {
+                return $"Admin functions for all users: {FormatState(permissionSystem.AdminFunctionsEnabledForAll)}";
+            }
+
+            if (conn != null && !conn.IsHost)
+            {
+                return "Only the host can toggle admin functions for all users";
+            }
+
+            permissionSystem.SetAdminFunctionsEnabledForAll(values.Enabled);
+            return $"Admin functions for all users: {FormatState(values.Enabled)}";
+        }
+
+        protected override CheckArgsResponse CheckArgs(string[] args)
+        {
+            CheckArgsResponse response = new();
+
+            if (args.Length == 0)
+            {
+                return response.MakeValid(new CalculatedValues(false, false));
+            }
+
+            if (args.Length != 1)
+            {
+                return response.MakeInvalid("Invalid number of arguments");
+            }
+
+            if (!TryParseState(args[0], out bool enabled))
+            {
+                return response.MakeInvalid("Use on/off, true/false, or 1/0");
+            }
+
+            return response.MakeValid(new CalculatedValues(true, enabled));
+        }
+
+        private static bool TryParseState(string value, out bool enabled)
+        {
+            switch (value.ToLowerInvariant())
+            {
+                case "on":
+                case "true":
+                case "1":
+                case "enable":
+                case "enabled":
+                    enabled = true;
+                    return true;
+                case "off":
+                case "false":
+                case "0":
+                case "disable":
+                case "disabled":
+                    enabled = false;
+                    return true;
+                default:
+                    enabled = false;
+                    return false;
+            }
+        }
+
+        private static string FormatState(bool enabled)
+        {
+            return enabled ? "enabled" : "disabled";
+        }
+    }
+}

--- a/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/Commands/AdminFunctionsCommand.cs.meta
+++ b/Assets/Scripts/SS3D/Systems/IngameConsoleSystem/Commands/AdminFunctionsCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1db3f18197ee4ef6a8ee13ff4a3f2855
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SS3D/Systems/Lobby/UI/AdminFunctionsToggleView.cs
+++ b/Assets/Scripts/SS3D/Systems/Lobby/UI/AdminFunctionsToggleView.cs
@@ -1,0 +1,129 @@
+﻿using Coimbra.Services.Events;
+using FishNet;
+using SS3D.Core;
+using SS3D.Core.Behaviours;
+using SS3D.Core.Settings;
+using SS3D.Logging;
+using SS3D.Permissions;
+using SS3D.Permissions.Events;
+using SS3D.UI.Buttons;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace SS3D.Systems.Lobby.UI
+{
+    /// <summary>
+    /// Adds the host-only server setting that lets every player use admin functions.
+    /// </summary>
+    public class AdminFunctionsToggleView : Actor
+    {
+        private const string NormalText = "<sprite name=\"deny\"> admin funcs: admins";
+        private const string PressedText = "<sprite name=\"approve\"> admin funcs: all";
+
+        private ToggleLabelButton _toggleButton;
+
+        protected override void OnStart()
+        {
+            base.OnStart();
+
+            CreateToggleButton();
+            AddHandle(UserPermissionsChangedEvent.AddListener(HandleUserPermissionsUpdated));
+            RefreshToggleButton();
+        }
+
+        protected override void OnDestroyed()
+        {
+            base.OnDestroyed();
+
+            if (_toggleButton != null)
+            {
+                _toggleButton.OnPressedDown -= HandleToggleButtonPressed;
+            }
+        }
+
+        private void CreateToggleButton()
+        {
+            ToggleLabelButton templateButton = GetComponentsInChildren<ToggleLabelButton>(true)
+                .FirstOrDefault(button => button.gameObject.name == "Start Round");
+
+            if (templateButton == null)
+            {
+                Log.Warning(this, "Could not find a button template for the admin functions toggle", Logs.UI);
+                return;
+            }
+
+            _toggleButton = Instantiate(templateButton, templateButton.transform.parent);
+            _toggleButton.gameObject.name = "Admin Functions For All";
+            _toggleButton.NormalText(NormalText);
+            _toggleButton.PressedText(PressedText);
+            _toggleButton.OnPressedDown += HandleToggleButtonPressed;
+
+            if (_toggleButton.transform is RectTransform rectTransform)
+            {
+                rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 190f);
+            }
+
+            if (_toggleButton.transform.parent.TryGetComponent(out HorizontalOrVerticalLayoutGroup layoutGroup))
+            {
+                layoutGroup.padding.right = 0;
+                layoutGroup.spacing = Mathf.Max(layoutGroup.spacing, 5f);
+            }
+
+            DisableCopiedLocalizers(_toggleButton.gameObject);
+        }
+
+        private void HandleUserPermissionsUpdated(ref EventContext context, in UserPermissionsChangedEvent e)
+        {
+            RefreshToggleButton();
+        }
+
+        private void HandleToggleButtonPressed(bool enabled)
+        {
+            PermissionSubSystem permissionSystem = SubSystems.Get<PermissionSubSystem>();
+
+            if (!CanToggleAdminFunctions(permissionSystem))
+            {
+                RefreshToggleButton();
+                return;
+            }
+
+            permissionSystem.CmdSetAdminFunctionsEnabledForAll(enabled);
+        }
+
+        private void RefreshToggleButton()
+        {
+            if (_toggleButton == null)
+            {
+                return;
+            }
+
+            PermissionSubSystem permissionSystem = SubSystems.Get<PermissionSubSystem>();
+
+            _toggleButton.Pressed = permissionSystem != null && permissionSystem.AdminFunctionsEnabledForAll;
+            _toggleButton.Disabled = !CanToggleAdminFunctions(permissionSystem);
+            _toggleButton.RefreshVisuals();
+        }
+
+        private static bool CanToggleAdminFunctions(PermissionSubSystem permissionSystem)
+        {
+            if (permissionSystem == null || !permissionSystem.HasLoadedPermissions)
+            {
+                return false;
+            }
+
+            return InstanceFinder.IsHost && permissionSystem.IsAtLeast(LocalPlayer.Ckey, ServerRoleTypes.ServerOwner);
+        }
+
+        private static void DisableCopiedLocalizers(GameObject root)
+        {
+            foreach (MonoBehaviour behaviour in root.GetComponentsInChildren<MonoBehaviour>(true))
+            {
+                if (behaviour != null && behaviour.GetType().Name == "LocalizeStringEvent")
+                {
+                    behaviour.enabled = false;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/SS3D/Systems/Lobby/UI/AdminFunctionsToggleView.cs.meta
+++ b/Assets/Scripts/SS3D/Systems/Lobby/UI/AdminFunctionsToggleView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b6af73a682645fba4cf9199f63693e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/ConstructionHologramManager.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/ConstructionHologramManager.cs
@@ -7,7 +7,9 @@ using SS3D.Core.Behaviours;
 using SS3D.Data;
 using SS3D.Data.AssetDatabases;
 using SS3D.Logging;
+using SS3D.Permissions;
 using SS3D.Systems.Inputs;
+using SS3D.Systems.PlayerControl;
 using SS3D.Utils;
 using System;
 using System.Collections.Generic;
@@ -366,6 +368,15 @@ namespace SS3D.Systems.Tile.TileMapCreator
         [ServerRpc(RequireOwnership = false)]
         private void RpcSendCanBuild(string tileObjectSoName, Vector3 placePosition, Direction dir, bool replaceExisting, NetworkConnection conn)
         {
+            if (!CanConnectionUseTileMapEditor(conn))
+            {
+                if (conn != null)
+                {
+                    RpcReceiveCanBuild(conn, placePosition, false);
+                }
+
+                return;
+            }
 
             TileSubSystem tileSystem = SubSystems.Get<TileSubSystem>();
 
@@ -400,6 +411,26 @@ namespace SS3D.Systems.Tile.TileMapCreator
                 }
                 return;
             }
+        }
+
+        [Server]
+        private bool CanConnectionUseTileMapEditor(NetworkConnection conn)
+        {
+            if (conn == null)
+            {
+                Log.Warning(this, "Rejected tilemap build check without a connection", Logs.ServerOnly);
+                return false;
+            }
+
+            string ckey = SubSystems.Get<PlayerSubSystem>().GetCkey(conn);
+            bool canUseTileMapEditor = SubSystems.Get<PermissionSubSystem>().CanUseAdminFunctions(ckey);
+
+            if (!canUseTileMapEditor)
+            {
+                Log.Warning(this, "Rejected tilemap build check from {ckey}", Logs.ServerOnly, ckey);
+            }
+
+            return canUseTileMapEditor;
         }
 
         /// <summary>

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapMenuSubSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapMenuSubSystem.cs
@@ -1,8 +1,12 @@
 ﻿using Coimbra;
+using Coimbra.Services.Events;
 using DynamicPanels;
 using FishNet.Object;
 using SS3D.Core;
 using SS3D.Core.Behaviours;
+using SS3D.Logging;
+using SS3D.Permissions;
+using SS3D.Permissions.Events;
 using SS3D.Data.Management;
 using SS3D.Systems.Inputs;
 using TMPro;
@@ -119,8 +123,9 @@ namespace SS3D.Systems.Tile.TileMapCreator
             ShowUI(false);
             _inputSystem = SubSystems.Get<InputSubSystem>();
             _controls = _inputSystem.Inputs.TileCreator;
-            _inputSystem.ToggleAction(_controls.ToggleMenu, true);
             _controls.ToggleMenu.performed += HandleToggleMenu;
+            AddHandle(UserPermissionsChangedEvent.AddListener(HandleUserPermissionsUpdated));
+            UpdateTileMapMenuActionAvailability();
         }
 
         /// <summary>
@@ -128,22 +133,63 @@ namespace SS3D.Systems.Tile.TileMapCreator
         /// </summary>
         private void HandleToggleMenu(InputAction.CallbackContext context)
         {
-            if (_enabled)
+            if (!_enabled && !CanUseTileMapEditor())
             {
-                _inputSystem.ToggleActionMap(_controls, false, new[] { _controls.ToggleMenu });
-                _inputSystem.ToggleCollisions(_controls, true);
+                Log.Warning(this, "Local player cannot open the tilemap editor", Logs.UI);
+                return;
             }
-            else
+
+            SetMenuEnabled(!_enabled);
+
+            if (!_enabled)
             {
-                _inputSystem.ToggleActionMap(_controls, true, new[] { _controls.ToggleMenu });
-                _inputSystem.ToggleCollisions(_controls, false);
+                return;
             }
-            _enabled = !_enabled;
-            ShowUI(_enabled);
 
             _currentTab = TileMapMenuTab.Build;
             ClearAllTab();
             _tileMapBuildTab.Display();
+        }
+
+        private void HandleUserPermissionsUpdated(ref EventContext context, in UserPermissionsChangedEvent e)
+        {
+            UpdateTileMapMenuActionAvailability();
+        }
+
+        private void UpdateTileMapMenuActionAvailability()
+        {
+            if (_inputSystem == null)
+            {
+                return;
+            }
+
+            bool canUseTileMapEditor = CanUseTileMapEditor();
+            _inputSystem.ToggleAction(_controls.ToggleMenu, canUseTileMapEditor);
+
+            if (_enabled && !canUseTileMapEditor)
+            {
+                SetMenuEnabled(false);
+            }
+        }
+
+        private bool CanUseTileMapEditor()
+        {
+            PermissionSubSystem permissionSystem = SubSystems.Get<PermissionSubSystem>();
+
+            if (permissionSystem == null || !permissionSystem.HasLoadedPermissions)
+            {
+                return false;
+            }
+
+            return permissionSystem.CanUseAdminFunctions(SS3D.Core.Settings.LocalPlayer.Ckey);
+        }
+
+        private void SetMenuEnabled(bool enabled)
+        {
+            _inputSystem.ToggleActionMap(_controls, enabled, new[] { _controls.ToggleMenu });
+            _inputSystem.ToggleCollisions(_controls, !enabled);
+            _enabled = enabled;
+            ShowUI(_enabled);
         }
        
         /// <summary>

--- a/Assets/Scripts/SS3D/Systems/Tile/TileSubSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileSubSystem.cs
@@ -1,9 +1,12 @@
 ﻿using Cysharp.Threading.Tasks;
+using FishNet.Connection;
 using FishNet.Object;
 using SS3D.Core.Behaviours;
 using SS3D.Data.AssetDatabases;
 using SS3D.Data.Management;
 using SS3D.Logging;
+using SS3D.Permissions;
+using SS3D.Systems.PlayerControl;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -103,8 +106,13 @@ namespace SS3D.Systems.Tile
         // No ownership required since clients are allowed to place/remove objects. Should be removed when construction is in.
         [Client]
         [ServerRpc(RequireOwnership = false)]
-        public void RpcPlaceObject(string genericObjectSoName, Vector3 placePosition, Direction dir, bool replaceExisting)
+        public void RpcPlaceObject(string genericObjectSoName, Vector3 placePosition, Direction dir, bool replaceExisting, NetworkConnection conn = null)
         {
+            if (!CanConnectionUseTileMapEditor(conn))
+            {
+                return;
+            }
+
             GenericObjectSo tileObjectSo = GetAsset(genericObjectSoName);
             PlaceObject(tileObjectSo, placePosition, dir, replaceExisting);
         }
@@ -112,8 +120,13 @@ namespace SS3D.Systems.Tile
         // No ownership required since clients are allowed to place/remove objects. Should be removed when construction is in.
         [Client]
         [ServerRpc(RequireOwnership = false)]
-        public void RpcClearTileObject(string tileObjectSoName, Vector3 placePosition, Direction dir)
+        public void RpcClearTileObject(string tileObjectSoName, Vector3 placePosition, Direction dir, NetworkConnection conn = null)
         {
+            if (!CanConnectionUseTileMapEditor(conn))
+            {
+                return;
+            }
+
             GenericObjectSo tileObjectSo = GetAsset(tileObjectSoName);
             _currentMap.ClearTileObject(placePosition, ((TileObjectSo)tileObjectSo).layer, dir);
         }
@@ -121,10 +134,35 @@ namespace SS3D.Systems.Tile
         // No ownership required since clients are allowed to place/remove objects. Should be removed when construction is in.
         [Client]
         [ServerRpc(RequireOwnership = false)]
-        public void RpcClearItemObject(string itemObjectSoName, Vector3 placePosition)
+        public void RpcClearItemObject(string itemObjectSoName, Vector3 placePosition, NetworkConnection conn = null)
         {
+            if (!CanConnectionUseTileMapEditor(conn))
+            {
+                return;
+            }
+
             ItemObjectSo itemObjectSo = (ItemObjectSo)GetAsset(itemObjectSoName);
             _currentMap.ClearItemObject(placePosition, itemObjectSo);
+        }
+
+        [Server]
+        private bool CanConnectionUseTileMapEditor(NetworkConnection conn)
+        {
+            if (conn == null)
+            {
+                Log.Warning(this, "Rejected tilemap editor request without a connection", Logs.ServerOnly);
+                return false;
+            }
+
+            string ckey = SubSystems.Get<PlayerSubSystem>().GetCkey(conn);
+            bool canUseTileMapEditor = SubSystems.Get<PermissionSubSystem>().CanUseAdminFunctions(ckey);
+
+            if (!canUseTileMapEditor)
+            {
+                Log.Warning(this, "Rejected tilemap editor request from {ckey}", Logs.ServerOnly, ckey);
+            }
+
+            return canUseTileMapEditor;
         }
 
         [Server]


### PR DESCRIPTION
Closes #1280

## Summary
- add a synced host-only toggle for allowing admin functions for all users
- add an admin settings UI toggle and adminfunctions console command
- gate the tilemap editor client-side and server-side as the first admin-only function

## Testing
- git diff --check
- Not run: Unity editor/PlayMode tests are not available in this environment