### PR TITLE
Show detailed examine text while holding Shift

### DIFF
--- a/Assets/Scripts/SS3D/Systems/Examine/ExamineUI.cs
+++ b/Assets/Scripts/SS3D/Systems/Examine/ExamineUI.cs
@@ -1,7 +1,5 @@
 using SS3D.Core;
 using SS3D.Core.Behaviours;
-using System.Collections;
-using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Localization.Tables;
@@ -52,18 +50,18 @@ namespace SS3D.Systems.Examine
 
         private string GetHoverText(IExaminable examinable, bool showDetailedText)
         {
-            if (examinable?.GetData() == null)
-            {
-                return string.Empty;
-            }
-
-            ExamineData data = examinable.GetData();
-            if (data.LocalizationTable == null)
+            ExamineData data = examinable?.GetData();
+            if (data == null || data.LocalizationTable == null)
             {
                 return string.Empty;
             }
 
             _currentStringTable = data.LocalizationTable.GetTable();
+            if (_currentStringTable == null)
+            {
+                return string.Empty;
+            }
+
             string name = GetLocalizedValue(data.NameKey);
 
             if (!showDetailedText)

--- a/Assets/Scripts/SS3D/Systems/Examine/ExamineUI.cs
+++ b/Assets/Scripts/SS3D/Systems/Examine/ExamineUI.cs
@@ -1,4 +1,4 @@
-﻿using SS3D.Core;
+using SS3D.Core;
 using SS3D.Core.Behaviours;
 using System.Collections;
 using System.Collections.Generic;
@@ -11,8 +11,11 @@ namespace SS3D.Systems.Examine
     public class ExamineUI : Actor
     {
         [SerializeField] private TMP_Text HoverName;
+        [SerializeField] private KeyCode DetailedExamineKey = KeyCode.LeftShift;
 
         private StringTable _currentStringTable;
+        private IExaminable _currentExaminable;
+        private bool _wasDetailedExamineHeld;
 
         protected override void OnEnabled()
         {
@@ -22,8 +25,18 @@ namespace SS3D.Systems.Examine
 
         protected override void OnDisabled()
         {
-            base.OnEnabled();
+            base.OnDisabled();
             SubSystems.Get<ExamineSubSystem>().OnExaminableChanged -= UpdateHoverText;
+        }
+
+        private void Update()
+        {
+            bool isDetailedExamineHeld = IsDetailedExamineHeld();
+            if (isDetailedExamineHeld != _wasDetailedExamineHeld)
+            {
+                _wasDetailedExamineHeld = isDetailedExamineHeld;
+                UpdateHoverText(_currentExaminable);
+            }
         }
 
         /// <summary>
@@ -32,27 +45,64 @@ namespace SS3D.Systems.Examine
         /// <param name="examinable">The object that is being examined</param>
         private void UpdateHoverText(IExaminable examinable)
         {
-            string hoverTextToDisplay = string.Empty;
+            _currentExaminable = examinable;
+            _wasDetailedExamineHeld = IsDetailedExamineHeld();
+            HoverName.text = GetHoverText(examinable, _wasDetailedExamineHeld);
+        }
 
-            if (examinable?.GetData())
+        private string GetHoverText(IExaminable examinable, bool showDetailedText)
+        {
+            if (examinable?.GetData() == null)
             {
-                ExamineData data = examinable.GetData();
-
-                if (data.LocalizationTable != null)
-                {
-                    _currentStringTable = data.LocalizationTable?.GetTable();
-                    if (_currentStringTable[data.NameKey]?.LocalizedValue is null)
-                    {
-                        hoverTextToDisplay = data.NameKey + " *[to be localized]*";
-                    }
-                    else
-                    {
-                        hoverTextToDisplay = _currentStringTable[data.NameKey]?.LocalizedValue;
-                    }
-                }
+                return string.Empty;
             }
 
-            HoverName.text = hoverTextToDisplay;
+            ExamineData data = examinable.GetData();
+            if (data.LocalizationTable == null)
+            {
+                return string.Empty;
+            }
+
+            _currentStringTable = data.LocalizationTable.GetTable();
+            string name = GetLocalizedValue(data.NameKey);
+
+            if (!showDetailedText)
+            {
+                return name;
+            }
+
+            string description = GetLocalizedValue(data.DescriptionKey);
+            if (string.IsNullOrEmpty(description))
+            {
+                return name;
+            }
+
+            if (string.IsNullOrEmpty(name))
+            {
+                return description;
+            }
+
+            return $"{name}\n{description}";
+        }
+
+        private string GetLocalizedValue(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return string.Empty;
+            }
+
+            if (_currentStringTable[key]?.LocalizedValue is null)
+            {
+                return key + " *[to be localized]*";
+            }
+
+            return _currentStringTable[key]?.LocalizedValue;
+        }
+
+        private bool IsDetailedExamineHeld()
+        {
+            return Input.GetKey(DetailedExamineKey) || Input.GetKey(KeyCode.RightShift);
         }
     }
 }


### PR DESCRIPTION
# Summary

This PR re-adds the basic detailed examine interaction from #1394.

When the player hovers an examinable object, the UI keeps the current behavior by showing only the localized object name. While either Shift key is held, the same hover label updates immediately to show the localized name plus the localized description on a second line. Releasing Shift switches the label back to the short name.

#### PR checklist
- [ ] The game builds properly without errors. Not verified locally; I do not have a Unity editor/runtime available in this Codex environment.
- [x] No unrelated changes are present.
- [x] No "trash" files are committed.
- [x] Relevant code is documented where useful.
- [x] GitBook update is not needed for this small UI behavior restoration; the existing design page for detailed examine is still the relevant reference.

# Pictures/Videos

I cannot attach an in-game screenshot from this environment because Unity is not available here.

Expected in-game result for review:
- Hover an examinable object without Shift: the hover text shows only the localized object name.
- Hold Left Shift or Right Shift while still hovering: the hover text updates to the object name on the first line and the detailed description on the second line.
- Release Shift: the hover text returns to the name-only display.

# Testing

Suggested in-game check:
1. Open a scene with an object that has examine data with both `NameKey` and `DescriptionKey` localization entries.
2. Hover the object without holding Shift.
3. Confirm the label shows only the localized name.
4. Hold Left Shift or Right Shift while still hovering the object.
5. Confirm the label immediately expands to name plus description.
6. Release Shift and confirm it returns to the name-only label.
7. Move away from the object and confirm the label clears as before.

Static verification done:
- Reviewed the diff and kept it limited to `ExamineUI.cs`.
- Preserved the existing missing-localization fallback text.
- Fixed the existing lifecycle typo where `OnDisabled()` called `base.OnEnabled()` instead of `base.OnDisabled()`.

# Changes

- Stores the currently hovered `IExaminable` so the UI can refresh when the Shift key state changes.
- Adds a serialized `DetailedExamineKey` defaulting to `LeftShift`, while also accepting `RightShift`.
- Extracts hover text construction and localization lookup into small helpers.
- Displays name-only text by default and name plus description while detailed examine is held.

# Related issues/PRs

Closes #1394.
