### PR TITLE
Add adaptive floor tiles beneath airlocks

### DIFF
--- a/Assets/Content/WorldObjects/Structures/Doors/CivillianAirlock.prefab
+++ b/Assets/Content/WorldObjects/Structures/Doors/CivillianAirlock.prefab
@@ -314,6 +314,8 @@ MonoBehaviour:
   _syncedConnections: 0
   wallCapPrefab: {fileID: 3591147544166670882, guid: 9682b163cae64f74a93b6e84ce84ae5b, type: 3}
   doorType: 0
+  airlockFloorPrefab: {fileID: 6767447678079105841, guid: 778e6f90a9ad89d4b856955961745b56, type: 3}
+  transparentFloorMaterial: {fileID: 2100000, guid: 11367021fd2c47deaef924f68d3e7d29, type: 2}
 --- !u!95 &6205019768642409540
 Animator:
   serializedVersion: 4

--- a/Assets/Content/WorldObjects/Structures/Doors/SecurityAirlock.prefab
+++ b/Assets/Content/WorldObjects/Structures/Doors/SecurityAirlock.prefab
@@ -314,6 +314,8 @@ MonoBehaviour:
   _syncedConnections: 0
   wallCapPrefab: {fileID: 3591147544166670882, guid: 9682b163cae64f74a93b6e84ce84ae5b, type: 3}
   doorType: 0
+  airlockFloorPrefab: {fileID: 6767447678079105841, guid: 778e6f90a9ad89d4b856955961745b56, type: 3}
+  transparentFloorMaterial: {fileID: 2100000, guid: 11367021fd2c47deaef924f68d3e7d29, type: 2}
 --- !u!114 &-2593019434011219120
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Content/WorldObjects/Structures/Floors/Tiles/AirlockTransparentFloor.mat
+++ b/Assets/Content/WorldObjects/Structures/Floors/Tiles/AirlockTransparentFloor.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AirlockTransparentFloor
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords:
+  - _ALPHABLEND_ON
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _GlossMapScale: 1
+    - _Glossiness: 0.1
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 3
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 5
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 0}

--- a/Assets/Content/WorldObjects/Structures/Floors/Tiles/AirlockTransparentFloor.mat.meta
+++ b/Assets/Content/WorldObjects/Structures/Floors/Tiles/AirlockTransparentFloor.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11367021fd2c47deaef924f68d3e7d29
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SS3D/Systems/Furniture/LockLockerInteraction.cs
+++ b/Assets/Scripts/SS3D/Systems/Furniture/LockLockerInteraction.cs
@@ -6,6 +6,7 @@ using SS3D.Interactions.Interfaces;
 using SS3D.Logging;
 using SS3D.Systems.Furniture;
 using SS3D.Systems.Inventory.Containers;
+using System;
 using UnityEngine;
 
 namespace SS3D.Systems.Inventory.Interactions

--- a/Assets/Scripts/SS3D/Systems/Tile/Connections/DoorAdjacencyConnector.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/Connections/DoorAdjacencyConnector.cs
@@ -1,14 +1,15 @@
 ﻿
+using System.Collections.Generic;
 using UnityEngine;
 using SS3D.Systems.Tile.Connections.AdjacencyTypes;
 using Coimbra;
 using FishNet.Object;
+using SS3D.Core;
 
 namespace SS3D.Systems.Tile.Connections
 {
     /// <summary>
     /// Connector for doors, handling adding wall caps, creating custom floor tile under the door.
-    /// TODO : add the custom floor.
     /// </summary>
     public class DoorAdjacencyConnector : AbstractHorizontalConnector, IAdjacencyConnector
     {
@@ -32,14 +33,36 @@ namespace SS3D.Systems.Tile.Connections
         [SerializeField]
         private DoorType doorType;
 
+        [SerializeField]
+        private GameObject airlockFloorPrefab = null;
+
+        [SerializeField]
+        private Material transparentFloorMaterial = null;
+
         // WallCap gameobjects, North, East, South, West. Null if not present.
         private GameObject[] wallCaps = new GameObject[4];
+
+        private GameObject _airlockFloor;
+
+        public override void OnStartClient()
+        {
+            base.OnStartClient();
+            RefreshAirlockFloorTiles();
+        }
+
+        private void Start()
+        {
+            RefreshAirlockFloorTiles();
+        }
 
         public override bool UpdateSingleConnection(Direction dir, PlacedTileObject placedObject, bool updateNeighbours)
         {
             bool update = base.UpdateSingleConnection(dir, placedObject, updateNeighbours);
             if (update)
                 UpdateWallCaps();
+
+            RefreshAirlockFloorTiles();
+
             return update;
         }
 
@@ -47,6 +70,61 @@ namespace SS3D.Systems.Tile.Connections
         {
             base.UpdateAllConnections();
             UpdateWallCaps();
+            RefreshAirlockFloorTiles();
+        }
+
+        public void RefreshAirlockFloorTiles()
+        {
+            if (_placedObject == null)
+            {
+                return;
+            }
+
+            if (!TryGetAirlockFloorNeighbours(out List<PlacedTileObject> neighbours))
+            {
+                return;
+            }
+
+            GameObject floorTile = GetOrCreateAirlockFloor();
+            if (floorTile == null)
+            {
+                return;
+            }
+
+            MeshRenderer activeFloorRenderer = GetActiveAirlockFloorRenderer(floorTile);
+            if (activeFloorRenderer == null)
+            {
+                return;
+            }
+
+            _placedObject.HasNeighbourFrontBack(neighbours, out PlacedTileObject frontTile, true);
+            _placedObject.HasNeighbourFrontBack(neighbours, out PlacedTileObject backTile, false);
+
+            SetRendererMaterial(activeFloorRenderer, 0, GetFloorMaterialOrDefault(frontTile, transparentFloorMaterial));
+            SetRendererMaterial(activeFloorRenderer, 1, GetFloorMaterialOrDefault(backTile, transparentFloorMaterial));
+        }
+
+        private bool TryGetAirlockFloorNeighbours(out List<PlacedTileObject> floorNeighbours)
+        {
+            floorNeighbours = new List<PlacedTileObject>();
+            if (!SubSystems.TryGet(out TileSubSystem tileSystem) || tileSystem.CurrentMap == null)
+            {
+                return false;
+            }
+
+            PlacedTileObject[] neighbours = tileSystem.CurrentMap.GetNeighbourPlacedObjects(
+                TileLayer.Turf,
+                _placedObject.gameObject.transform.position);
+
+            foreach (PlacedTileObject neighbour in neighbours)
+            {
+                if (neighbour != null)
+                {
+                    floorNeighbours.Add(neighbour);
+                }
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -104,6 +182,99 @@ namespace SS3D.Systems.Tile.Connections
         {
             return (neighbourObject && neighbourObject.HasAdjacencyConnector &&
                 neighbourObject.GenericType == TileObjectGenericType.Wall);
+        }
+
+        private GameObject GetOrCreateAirlockFloor()
+        {
+            if (_airlockFloor != null)
+            {
+                return _airlockFloor;
+            }
+
+            if (airlockFloorPrefab == null)
+            {
+                return null;
+            }
+
+            _airlockFloor = Instantiate(airlockFloorPrefab, transform);
+            _airlockFloor.name = "AirlockFloorTile";
+            _airlockFloor.transform.localPosition = Vector3.zero;
+            _airlockFloor.transform.localRotation = Quaternion.identity;
+            _airlockFloor.transform.localScale = Vector3.one;
+            RemoveTileRuntimeComponents(_airlockFloor);
+
+            return _airlockFloor;
+        }
+
+        private void RemoveTileRuntimeComponents(GameObject floorTile)
+        {
+            foreach (Collider collider in floorTile.GetComponents<Collider>())
+            {
+                Destroy(collider);
+            }
+
+            foreach (MonoBehaviour component in floorTile.GetComponents<MonoBehaviour>())
+            {
+                Destroy(component);
+            }
+        }
+
+        private MeshRenderer GetActiveAirlockFloorRenderer(GameObject floorTile)
+        {
+            bool doorRunsNorthSouth = IsNorthSouth(_placedObject.Direction);
+            Transform northSouthTile = floorTile.transform.Find("AirlockTileNS");
+            Transform eastWestTile = floorTile.transform.Find("AirlockTileEW");
+
+            if (northSouthTile != null)
+            {
+                northSouthTile.gameObject.SetActive(doorRunsNorthSouth);
+            }
+
+            if (eastWestTile != null)
+            {
+                eastWestTile.gameObject.SetActive(!doorRunsNorthSouth);
+            }
+
+            Transform activeTile = doorRunsNorthSouth ? northSouthTile : eastWestTile;
+            return activeTile != null ? activeTile.GetComponent<MeshRenderer>() : null;
+        }
+
+        public static bool IsNorthSouth(Direction direction)
+        {
+            return direction == Direction.North || direction == Direction.South;
+        }
+
+        public static Material GetFloorMaterialOrDefault(PlacedTileObject tileObject, Material defaultMaterial)
+        {
+            if (tileObject == null || tileObject.GenericType != TileObjectGenericType.Floor)
+            {
+                return defaultMaterial;
+            }
+
+            MeshRenderer floorRenderer = tileObject.GetComponentInChildren<MeshRenderer>();
+            if (floorRenderer == null || floorRenderer.sharedMaterials.Length == 0)
+            {
+                return defaultMaterial;
+            }
+
+            return floorRenderer.sharedMaterials[0] ?? defaultMaterial;
+        }
+
+        public static void SetRendererMaterial(MeshRenderer renderer, int materialIndex, Material material)
+        {
+            if (renderer == null || material == null)
+            {
+                return;
+            }
+
+            Material[] materials = renderer.sharedMaterials;
+            if (materialIndex < 0 || materialIndex >= materials.Length)
+            {
+                return;
+            }
+
+            materials[materialIndex] = material;
+            renderer.sharedMaterials = materials;
         }
 
         /// <summary>

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMap.cs
@@ -228,6 +228,8 @@ namespace SS3D.Systems.Tile
                     placedObject.UpdateAdjacencies();
                 }
 
+                RefreshAirlockFloorTilesNear(tileObjectSo.layer, placePosition);
+
                 placedObjectGo = placedObject.gameObject;
             }
 
@@ -268,6 +270,48 @@ namespace SS3D.Systems.Tile
                 }
 
                 clearLocation.ClearAllPlacedObject();
+            }
+
+            RefreshAirlockFloorTilesNear(layer, placePosition);
+        }
+
+        private void RefreshAirlockFloorTilesNear(TileLayer layer, Vector3 worldPosition)
+        {
+            if (layer != TileLayer.Turf)
+            {
+                return;
+            }
+
+            HashSet<DoorAdjacencyConnector> refreshedConnectors = new();
+            RefreshAirlockFloorTileAt(worldPosition, refreshedConnectors);
+
+            foreach (PlacedTileObject neighbour in GetCardinalNeighbourPlacedObjects(TileLayer.Turf, worldPosition))
+            {
+                if (neighbour != null && neighbour.TryGetComponent(out DoorAdjacencyConnector connector))
+                {
+                    RefreshAirlockFloorTile(connector, refreshedConnectors);
+                }
+            }
+        }
+
+        private void RefreshAirlockFloorTileAt(Vector3 worldPosition, HashSet<DoorAdjacencyConnector> refreshedConnectors)
+        {
+            foreach (PlacedTileObject placedObject in GetTileLocation(TileLayer.Turf, worldPosition).GetAllPlacedObject())
+            {
+                if (placedObject != null && placedObject.TryGetComponent(out DoorAdjacencyConnector connector))
+                {
+                    RefreshAirlockFloorTile(connector, refreshedConnectors);
+                }
+            }
+        }
+
+        private void RefreshAirlockFloorTile(
+            DoorAdjacencyConnector connector,
+            HashSet<DoorAdjacencyConnector> refreshedConnectors)
+        {
+            if (connector != null && refreshedConnectors.Add(connector))
+            {
+                connector.RefreshAirlockFloorTiles();
             }
         }
 

--- a/Assets/Scripts/Tests/EditMode/DoorAdjacencyConnectorTests.cs
+++ b/Assets/Scripts/Tests/EditMode/DoorAdjacencyConnectorTests.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+using SS3D.Systems.Tile;
+using SS3D.Systems.Tile.Connections;
+using UnityEngine;
+
+namespace EditorTests
+{
+    public class DoorAdjacencyConnectorTests
+    {
+        [Test]
+        public void IsNorthSouthReturnsTrueOnlyForNorthAndSouth()
+        {
+            Assert.IsTrue(DoorAdjacencyConnector.IsNorthSouth(Direction.North));
+            Assert.IsTrue(DoorAdjacencyConnector.IsNorthSouth(Direction.South));
+            Assert.IsFalse(DoorAdjacencyConnector.IsNorthSouth(Direction.East));
+            Assert.IsFalse(DoorAdjacencyConnector.IsNorthSouth(Direction.West));
+        }
+
+        [Test]
+        public void SetRendererMaterialOnlyUpdatesRequestedSlot()
+        {
+            GameObject gameObject = new("test renderer");
+            MeshRenderer renderer = gameObject.AddComponent<MeshRenderer>();
+            Material firstMaterial = new(Shader.Find("Standard"));
+            Material secondMaterial = new(Shader.Find("Standard"));
+            Material replacementMaterial = new(Shader.Find("Standard"));
+            renderer.sharedMaterials = new[] { firstMaterial, secondMaterial };
+
+            DoorAdjacencyConnector.SetRendererMaterial(renderer, 1, replacementMaterial);
+
+            Assert.AreSame(firstMaterial, renderer.sharedMaterials[0]);
+            Assert.AreSame(replacementMaterial, renderer.sharedMaterials[1]);
+
+            Object.DestroyImmediate(firstMaterial);
+            Object.DestroyImmediate(secondMaterial);
+            Object.DestroyImmediate(replacementMaterial);
+            Object.DestroyImmediate(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Tests/EditMode/DoorAdjacencyConnectorTests.cs.meta
+++ b/Assets/Scripts/Tests/EditMode/DoorAdjacencyConnectorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ef11ac4ff504fe0965123f5595fe582
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Closes #1299.

## Summary
- Spawns the existing airlock floor tile visual beneath airlocks and selects the north/south or east/west mesh based on the airlock direction.
- Copies the front and back adjacent floor materials onto the matching sides of the airlock floor tile.
- Uses a transparent fallback material when an adjacent floor is missing.
- Refreshes nearby airlocks after turf placement/removal so existing airlocks update when neighboring floors change.

## Tests
- Added edit-mode coverage for airlock floor orientation and material-slot assignment helpers.
- Verified civilian and security airlock prefabs both reference the airlock floor visual and transparent fallback material.