### PR TITLE
Gate tilemap editor behind admin permission check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ Assets/Content/Addressables/Windows/addressables_content_state.bin
 Assets/Content/Addressables/Windows/addressables_content_state.bin.meta
 Assets/Content/Addressables/link.xml
 Assets/Content/Addressables/link.xml.meta
+graphify-out/

--- a/Assets/Scripts/SS3D/Permissions/PermissionSettings.cs
+++ b/Assets/Scripts/SS3D/Permissions/PermissionSettings.cs
@@ -12,9 +12,18 @@ namespace SS3D.Permissions
         [SerializeField]
         private bool _addServerOwnerPermissionToServerHost;
 
+        [SerializeField]
+        private bool _adminFunctionsForAll;
+
         /// <summary>
         /// We can define if the host will get the owner permission when he joins the game.
         /// </summary>
         public static bool AddServerOwnerPermissionToServerHost => GetOrFind<PermissionSettings>()._addServerOwnerPermissionToServerHost;
+
+        /// <summary>
+        /// If true, admin-only functions are available to all users.
+        /// Defaults to false, meaning only admins (host by default) can use admin functions.
+        /// </summary>
+        public static bool AdminFunctionsForAll => GetOrFind<PermissionSettings>()._adminFunctionsForAll;
     }
 }

--- a/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapMenuSubSystem.cs
+++ b/Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapMenuSubSystem.cs
@@ -4,6 +4,8 @@ using FishNet.Object;
 using SS3D.Core;
 using SS3D.Core.Behaviours;
 using SS3D.Data.Management;
+using SS3D.Logging;
+using SS3D.Permissions;
 using SS3D.Systems.Inputs;
 using TMPro;
 using UnityEngine;
@@ -128,6 +130,12 @@ namespace SS3D.Systems.Tile.TileMapCreator
         /// </summary>
         private void HandleToggleMenu(InputAction.CallbackContext context)
         {
+            if (!_enabled && !CanAccessTilemapEditor())
+            {
+                Log.Information(this, "Player lacks permission to access the tilemap editor", Logs.ServerOnly);
+                return;
+            }
+
             if (_enabled)
             {
                 _inputSystem.ToggleActionMap(_controls, false, new[] { _controls.ToggleMenu });
@@ -144,6 +152,28 @@ namespace SS3D.Systems.Tile.TileMapCreator
             _currentTab = TileMapMenuTab.Build;
             ClearAllTab();
             _tileMapBuildTab.Display();
+        }
+
+        /// <summary>
+        /// Checks whether the local player is allowed to use the tilemap editor.
+        /// </summary>
+        private bool CanAccessTilemapEditor()
+        {
+            if (PermissionSettings.AdminFunctionsForAll)
+            {
+                return true;
+            }
+
+            string ckey = Core.Settings.LocalPlayer.Ckey;
+            if (string.IsNullOrEmpty(ckey))
+            {
+                return false;
+            }
+
+            PermissionSubSystem permissionSystem = SubSystems.Get<PermissionSubSystem>();
+            return permissionSystem != null
+                   && permissionSystem.HasLoadedPermissions
+                   && permissionSystem.IsAtLeast(ckey, ServerRoleTypes.Administrator);
         }
        
         /// <summary>


### PR DESCRIPTION
Closes #1280

The tilemap editor was accessible to all players regardless of role. This gates it behind the admin permission check so only administrators can open it.

## Changes
- `Assets/Scripts/SS3D/Permissions/PermissionSettings.cs` — added `AdminFunctionsForAll` bool setting that allows hosts to opt-in to letting all players use admin functions
- `Assets/Scripts/SS3D/Systems/Tile/TileMapCreator/TileMapMenuSubSystem.cs` — added `CanAccessTilemapEditor()` permission check preventing non-admin players from opening the tilemap editor

## Verification
- The tilemap editor toggle is blocked for users below Administrator role when `AdminFunctionsForAll` is false
- When `AdminFunctionsForAll` is true, all users can access the tilemap editor
- Admins can always access the tilemap editor regardless of the setting